### PR TITLE
docs: bump service count to 31 — add Codex + catch up on fireworks/voyageai/modal (refs aiwatch#294)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Each monthly report includes:
 
 ## Methodology
 
-- **30 services monitored**: 14 LLM APIs, 9 voice & inference, 3 AI apps, 4 coding agents
+- **31 services monitored**: 14 LLM APIs, 9 voice & inference, 3 AI apps, 5 coding agents
 - **Data sources**: Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, AWS Health Dashboard, Azure Status RSS, OnlineOrNot
 - **AIWatch Score**: Weighted composite of uptime (40pts), incident affected days (25pts), recovery time (15pts), and probe-based responsiveness (20pts). Services without probe data use 80→100 score redistribution.
 - **Uptime figures**: Official status page metrics — single primary component basis where available, platform-wide average otherwise

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: AIWatch Reports
-description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 30 AI services
+description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 31 AI services
 baseurl: ""
 url: https://reports.ai-watch.dev
 theme: minima

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "[MON] [YEAR] AI Reliability Report"
-description: "Monthly reliability report for 30 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
+description: "Monthly reliability report for 31 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
 date: [YYYY-MM-DD]
 published: true
 ---
@@ -9,7 +9,7 @@ published: true
 > **Source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
 > **Period**: [MONTH] 1–[LAST_DAY], [YEAR]
 > **Published**: [PUBLISH_MONTH] [YEAR]
-> **Services monitored**: 30 — 23 API services, 4 coding agents, 3 AI apps
+> **Services monitored**: 31 — 23 API services, 5 coding agents, 3 AI apps
 
 ## Summary
 
@@ -174,7 +174,7 @@ Unlike raw uptime %, it incorporates incident frequency (how often things break)
 ## About This Report
 
 * **Data Sources:** Real-time data is aggregated from official status pages via multiple frameworks, including Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, OnlineOrNot, and RSS feeds (Source: [ai-watch.dev](https://ai-watch.dev)).
-* **Monitoring Frequency:** All 30 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
+* **Monitoring Frequency:** All 31 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
 * **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). Services without probe data use 80→100 score redistribution. Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
 * **Confidence Levels:** *High* = official uptime data available; *Medium* = uptime not published (industry average 99.5% assumed) or estimate-based. Confidence reflects uptime data quality. Probe data status (Responsiveness) is shown separately on each service's dashboard.
 * **Incident Counting:** Incident counts reflect all affected components per service. Providers differ in reporting granularity — Anthropic reports per-model incidents (Opus/Sonnet/Haiku each counted separately), while others report at the service level.

--- a/index.md
+++ b/index.md
@@ -1,10 +1,10 @@
 ---
 layout: home
 title: AIWatch Monthly Reports
-description: "Monthly AI service incident reports covering 30 AI services — uptime, incidents, and reliability rankings."
+description: "Monthly AI service incident reports covering 31 AI services — uptime, incidents, and reliability rankings."
 ---
 
-Monthly AI service incident reports covering 30 AI services monitored by [AIWatch](https://ai-watch.dev).
+Monthly AI service incident reports covering 31 AI services monitored by [AIWatch](https://ai-watch.dev).
 
 ## Reports
 

--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -47,13 +47,16 @@ function escapeXml(s) {
 const ID_TO_NAME = {
   claude: 'Claude API', openai: 'OpenAI API', gemini: 'Gemini API',
   mistral: 'Mistral API', cohere: 'Cohere API', groq: 'Groq Cloud',
-  together: 'Together AI', perplexity: 'Perplexity', huggingface: 'Hugging Face',
+  together: 'Together AI', fireworks: 'Fireworks AI',
+  perplexity: 'Perplexity', huggingface: 'Hugging Face',
   replicate: 'Replicate', elevenlabs: 'ElevenLabs', xai: 'xAI (Grok)',
   deepseek: 'DeepSeek API', openrouter: 'OpenRouter', bedrock: 'Amazon Bedrock',
   azureopenai: 'Azure OpenAI', pinecone: 'Pinecone', stability: 'Stability AI',
+  voyageai: 'Voyage AI', modal: 'Modal',
   claudeai: 'claude.ai', chatgpt: 'ChatGPT', characterai: 'Character.AI',
-  claudecode: 'Claude Code', copilot: 'GitHub Copilot', cursor: 'Cursor',
-  windsurf: 'Windsurf', assemblyai: 'AssemblyAI', deepgram: 'Deepgram',
+  claudecode: 'Claude Code', codex: 'Codex', cursor: 'Cursor',
+  copilot: 'GitHub Copilot', windsurf: 'Windsurf',
+  assemblyai: 'AssemblyAI', deepgram: 'Deepgram',
 }
 
 // Category-based display order (matches dashboard)
@@ -62,11 +65,12 @@ const CATEGORY_ORDER = [
   'claudeai', 'chatgpt', 'characterai',
   // LLM API
   'claude', 'openai', 'gemini', 'bedrock', 'azureopenai', 'mistral', 'cohere', 'groq',
-  'together', 'perplexity', 'xai', 'deepseek', 'openrouter',
+  'together', 'fireworks', 'perplexity', 'xai', 'deepseek', 'openrouter',
   // Voice & Inference
-  'elevenlabs', 'assemblyai', 'deepgram', 'huggingface', 'replicate', 'pinecone', 'stability',
+  'elevenlabs', 'assemblyai', 'deepgram', 'huggingface', 'replicate', 'pinecone',
+  'stability', 'voyageai', 'modal',
   // Coding Agents
-  'claudecode', 'copilot', 'cursor', 'windsurf',
+  'claudecode', 'codex', 'cursor', 'copilot', 'windsurf',
 ]
 
 function nameToId(name) {
@@ -300,7 +304,7 @@ if (require.main === module) {
         if (history[key]) { lastDataDay = d; break }
       }
 
-      // Use all 30 services in category order (not just incident table)
+      // Use all 31 services in category order (not just incident table)
       const serviceNames = CATEGORY_ORDER.map(id => ID_TO_NAME[id]).filter(Boolean)
 
       const heatmapSvg = generateUptimeHeatmapSvg(serviceNames, history, daysInMonth, monthKey, monitoringStartDay, lastDataDay)


### PR DESCRIPTION
Refs [bentleypark/aiwatch#294](https://github.com/bentleypark/aiwatch/issues/294) Phase 3 — Reports repo sync.

## Summary

Sync with the AIWatch main repo's service additions. Codex is the 5th coding agent (main-repo #294, Phase 1 #295, Phase 2 #300, uptime #302), and **fireworks / voyageai / modal** were added in earlier main-repo PRs but were never backfilled here. Scripts claimed 27 services, text copy claimed 30. Bring everything to **31** in one pass.

## Changes (5 files)

### Text updates
- \`README.md\` methodology: \`30 services / 4 coding agents\` → \`31 / 5\`
- \`_config.yml\` site description
- \`_templates/monthly-report.md\` — front-matter \`description\` (propagates to every future report's SEO meta, caught in review), body \"Services monitored\" line, monitoring-frequency footnote (3 edits)
- \`index.md\` top-level landing (meta description + body)
- \`scripts/generate-charts.js\` comment

### scripts/generate-charts.js structural
- \`ID_TO_NAME\`: add \`fireworks\` (Fireworks AI), \`voyageai\` (Voyage AI), \`modal\` (Modal), \`codex\` (Codex)
- \`CATEGORY_ORDER\`:
  - \`fireworks\` inserted in LLM API section (after together)
  - \`voyageai\` + \`modal\` appended to Inference section
  - \`codex\` positioned after \`claudecode\` in Coding Agents
- Full coding-agent order matches main repo convention (aiwatch#302): **claudecode → codex → cursor → copilot → windsurf**

## Historical preservation

\`2026-03/index.md\` and \`assets/2026-03/*.svg\` intentionally **untouched**. March 2026 monitored 27 services during Mar 20–31 — a real point-in-time snapshot that predates fireworks/voyageai/modal/codex. Overwriting would be historically dishonest. Only the **template + generator** are updated; future reports (April+) pick up the new structure.

## Test plan

- [x] \`bundle exec jekyll serve --port 4000\` — index renders \"31 AI services\", methodology shows \"31 / 5 coding agents\"
- [x] \`curl /\` confirmed 5 occurrences of \"31 AI services\" rendered (meta + body + Jekyll SEO)
- [x] \`/2026-03/\` historical page renders unchanged (27 services)
- [x] No stray \"30 AI services\" / \"4 coding agents\" references remain outside 2026-03 historical + _site cache

## Review

1 Critical caught — missing bump in \`_templates/monthly-report.md\` front-matter \`description\` (would have shipped wrong SEO meta for every future monthly report). Fixed before commit. 0 Important remaining.

## Deploy

GitHub Pages auto-builds on merge to main. No manual action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)