### PR TITLE
feat: migrate reports to ai-watch.dev/reports/ for SEO consolidation (refs aiwatch#264)

### DIFF
--- a/2026-03/index.md
+++ b/2026-03/index.md
@@ -267,7 +267,7 @@ OpenAI API (2h 56m total downtime), Groq Cloud (zero incidents), DeepSeek API (1
 - **Live status** — [ai-watch.dev](https://ai-watch.dev)
 - **Slack/Discord alerts** — [ai-watch.dev/#settings](https://ai-watch.dev/#settings)
 - **Score methodology** — [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
-- **All reports** — [reports.ai-watch.dev](https://reports.ai-watch.dev)
+- **All reports** — [ai-watch.dev/reports](https://ai-watch.dev/reports/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Monthly AI service reliability reports covering uptime, incidents, and performance across 30 major AI services.
 
-**Live site**: [reports.ai-watch.dev](https://reports.ai-watch.dev)
+**Live site**: [ai-watch.dev/reports](https://ai-watch.dev/reports/) (served via Vercel rewrite; legacy `reports.ai-watch.dev` self-redirects to the canonical path — #264)
 **Data source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
 
 ---
@@ -11,7 +11,7 @@
 
 | Month | Link | Services | Status |
 |---|---|---|---|
-| March 2026 | [View →](https://reports.ai-watch.dev/2026-03/) | 27 | Published |
+| March 2026 | [View →](https://ai-watch.dev/reports/2026-03/) | 27 | Published |
 
 ---
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: AIWatch Reports
 description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 31 AI services
-baseurl: ""
-url: https://reports.ai-watch.dev
+baseurl: "/reports"
+url: https://ai-watch.dev
 theme: minima
 lang: en
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,8 +16,11 @@ document.addEventListener('click', function(e) {
   var href = a.getAttribute('href') || '';
   var inFooter = !!a.closest('footer');
   var page = location.pathname.match(/\/(\d{4}-\d{2})\//)?.[1] || 'index';
-  // ai-watch.dev links — classify by destination
-  if (href.includes('ai-watch.dev') && !href.includes('reports.ai-watch.dev')) {
+  // ai-watch.dev links — classify by destination. After #264 migration, report
+  // pages live at ai-watch.dev/reports/, so exclude any /reports/ path here to
+  // avoid mis-classifying report-to-report navigation as dashboard clicks.
+  // Trailing slash anchors the match to path-prefix, not hash (#reports-info).
+  if (href.includes('ai-watch.dev') && !href.includes('/reports/')) {
     if (href.includes('#settings')) {
       gtag('event', 'click_cta_alerts', { location: 'reports_site', source: inFooter ? 'footer' : 'body', page: page });
     } else if (href.includes('#about-score')) {

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,13 @@
 <head>
+  <script>
+  // #264: reports moved to ai-watch.dev/reports/. Subdomain visitors bounce
+  // to the canonical main-domain URL so SEO consolidates and internal links
+  // (which now use baseurl=/reports) resolve correctly. Placed first so it
+  // fires before CSS/asset loading and GA4 — redirect happens immediately.
+  if (location.hostname === 'reports.ai-watch.dev') {
+    location.replace('https://ai-watch.dev/reports' + location.pathname + location.search + location.hash);
+  }
+  </script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -188,7 +188,7 @@ Unlike raw uptime %, it incorporates incident frequency (how often things break)
 - **Live status** — [ai-watch.dev](https://ai-watch.dev)
 - **Slack/Discord alerts** — [ai-watch.dev/#settings](https://ai-watch.dev/#settings)
 - **Score methodology** — [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
-- **All reports** — [reports.ai-watch.dev](https://reports.ai-watch.dev)
+- **All reports** — [ai-watch.dev/reports](https://ai-watch.dev/reports/)
 
 ---
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://reports.ai-watch.dev/sitemap.xml
+Sitemap: https://ai-watch.dev/reports/sitemap.xml


### PR DESCRIPTION
refs bentleypark/aiwatch#264

## Summary
- Step 1 of 2 for the monthly-reports domain migration. This PR (Jekyll side) rewrites every canonical URL + sitemap entry + og:url to point at the main domain (\`ai-watch.dev/reports/...\`) and adds a JS redirect so direct subdomain visitors bounce to the canonical path.
- Step 2 (Vercel rewrite + internal-link updates) is in main aiwatch repo as PR #339.
- Merging consolidates all backlinks / click-through authority on the primary domain instead of the \`reports.ai-watch.dev\` subdomain.

## Changes

| File | Change |
|---|---|
| \`_config.yml\` | \`baseurl "" → /reports\`, \`url reports.ai-watch.dev → ai-watch.dev\` — drives canonical + sitemap via \`jekyll-seo-tag\`/\`jekyll-sitemap\` |
| \`_includes/head.html\` | Prepend 8-line JS redirect at top of \`<head>\` (before \`<meta charset>\`). Subdomain visitors immediately bounce to \`ai-watch.dev/reports/...\`. Essential because baseurl=/reports makes internal asset paths \`/reports/assets/*\` which 404 on subdomain root |
| \`_includes/footer.html\` | GA4 filter: \`!href.includes('reports.ai-watch.dev')\` → \`!href.includes('/reports/')\` (path-anchored, won't match hash fragments like \`#reports-info\`) |
| \`robots.txt\` | Sitemap URL → \`ai-watch.dev/reports/sitemap.xml\` |
| \`README.md\` | Live site URL + March link migrated with Vercel rewrite context |
| \`_templates/monthly-report.md\` | Footer "All reports" link migrated (future reports pick up the new URL) |
| \`2026-03/index.md\` | Same footer link update (retroactive; content unchanged) |

## Local build verification (2026-04-24)
- \`canonical\` on \`2026-03/index.html\`: \`https://ai-watch.dev/reports/2026-03/\` ✅
- \`og:url\`: same ✅
- \`canonical\` on home \`index.html\`: \`https://ai-watch.dev/reports/\` ✅
- \`sitemap.xml\`: both \`<loc>\` rewritten to main-domain URLs ✅
- \`robots.txt\`: \`Sitemap: https://ai-watch.dev/reports/sitemap.xml\` ✅
- \`head.html\`: redirect script lands absolutely first, before \`<meta charset>\` — fires before CSS/assets load ✅
- Internal asset links generated as \`/reports/assets/main.css\` — matches the Vercel rewrite path on the main repo ✅

## Code review outcome (Round 1 — 0 Critical / 0 Important)
Two sub-threshold suggestions evaluated:
- **Meta refresh no-JS fallback** — REJECTED: a static meta refresh would self-refresh-loop on the main domain (same URL redirect target). Canonical tag + JS redirect handles both JS-enabled users and Googlebot. No-JS users see a visually broken subdomain page, but the canonical steers search engines correctly.
- **GA4 filter substring precision** — APPLIED: \`/reports\` → \`/reports/\` to anchor on path-prefix.

## ⚠️ Deploy order (critical)

This PR must merge + GH Pages rebuild **before** aiwatch PR #339 merges. Without this PR deployed first:
- aiwatch.dev/reports/ request → Vercel proxies to reports.ai-watch.dev → returns OLD Jekyll HTML (canonical still subdomain, baseurl empty)
- Internal assets still resolve to \`/assets/*\` (no \`/reports/\` prefix) — no asset issue
- But canonical points at subdomain → Google sees conflicting signal, SEO consolidation doesn't happen

If this PR deploys first:
- reports.ai-watch.dev/* direct visits → JS redirect to ai-watch.dev/reports/*
- Once PR #339 merges, Vercel proxy activates → full clean chain

## Step 3 (deferred)
DNS-level 301 redirect for \`reports.ai-watch.dev → ai-watch.dev/reports\`, ~2-3 months from now after Google absorbs main-domain canonicals.

## Rollback
If the JS redirect misbehaves after deploy:
1. Revert this PR → GH Pages rebuilds → subdomain serves as before
2. Main aiwatch PR #339 (if not merged) is unaffected; if merged, revert PR #339 to disable Vercel rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)