### PR TITLE
revert: #264 migration — Vercel external rewrite not working, restore subdomain

### DIFF
--- a/2026-03/index.md
+++ b/2026-03/index.md
@@ -267,7 +267,7 @@ OpenAI API (2h 56m total downtime), Groq Cloud (zero incidents), DeepSeek API (1
 - **Live status** — [ai-watch.dev](https://ai-watch.dev)
 - **Slack/Discord alerts** — [ai-watch.dev/#settings](https://ai-watch.dev/#settings)
 - **Score methodology** — [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
-- **All reports** — [ai-watch.dev/reports](https://ai-watch.dev/reports/)
+- **All reports** — [reports.ai-watch.dev](https://reports.ai-watch.dev)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Monthly AI service reliability reports covering uptime, incidents, and performance across 30 major AI services.
 
-**Live site**: [ai-watch.dev/reports](https://ai-watch.dev/reports/) (served via Vercel rewrite; legacy `reports.ai-watch.dev` self-redirects to the canonical path — #264)
+**Live site**: [reports.ai-watch.dev](https://reports.ai-watch.dev)
 **Data source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
 
 ---
@@ -11,7 +11,7 @@
 
 | Month | Link | Services | Status |
 |---|---|---|---|
-| March 2026 | [View →](https://ai-watch.dev/reports/2026-03/) | 27 | Published |
+| March 2026 | [View →](https://reports.ai-watch.dev/2026-03/) | 27 | Published |
 
 ---
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: AIWatch Reports
 description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 31 AI services
-baseurl: "/reports"
-url: https://ai-watch.dev
+baseurl: ""
+url: https://reports.ai-watch.dev
 theme: minima
 lang: en
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,11 +16,8 @@ document.addEventListener('click', function(e) {
   var href = a.getAttribute('href') || '';
   var inFooter = !!a.closest('footer');
   var page = location.pathname.match(/\/(\d{4}-\d{2})\//)?.[1] || 'index';
-  // ai-watch.dev links — classify by destination. After #264 migration, report
-  // pages live at ai-watch.dev/reports/, so exclude any /reports/ path here to
-  // avoid mis-classifying report-to-report navigation as dashboard clicks.
-  // Trailing slash anchors the match to path-prefix, not hash (#reports-info).
-  if (href.includes('ai-watch.dev') && !href.includes('/reports/')) {
+  // ai-watch.dev links — classify by destination
+  if (href.includes('ai-watch.dev') && !href.includes('reports.ai-watch.dev')) {
     if (href.includes('#settings')) {
       gtag('event', 'click_cta_alerts', { location: 'reports_site', source: inFooter ? 'footer' : 'body', page: page });
     } else if (href.includes('#about-score')) {

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,13 +1,4 @@
 <head>
-  <script>
-  // #264: reports moved to ai-watch.dev/reports/. Subdomain visitors bounce
-  // to the canonical main-domain URL so SEO consolidates and internal links
-  // (which now use baseurl=/reports) resolve correctly. Placed first so it
-  // fires before CSS/asset loading and GA4 — redirect happens immediately.
-  if (location.hostname === 'reports.ai-watch.dev') {
-    location.replace('https://ai-watch.dev/reports' + location.pathname + location.search + location.hash);
-  }
-  </script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -188,7 +188,7 @@ Unlike raw uptime %, it incorporates incident frequency (how often things break)
 - **Live status** — [ai-watch.dev](https://ai-watch.dev)
 - **Slack/Discord alerts** — [ai-watch.dev/#settings](https://ai-watch.dev/#settings)
 - **Score methodology** — [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
-- **All reports** — [ai-watch.dev/reports](https://ai-watch.dev/reports/)
+- **All reports** — [reports.ai-watch.dev](https://reports.ai-watch.dev)
 
 ---
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://ai-watch.dev/reports/sitemap.xml
+Sitemap: https://reports.ai-watch.dev/sitemap.xml


### PR DESCRIPTION
Hotfix revert of #7. Root cause: main aiwatch repo's Vercel external URL rewrite (PR aiwatch#339) is NOT proxying requests to reports.ai-watch.dev — `/reports/*` instead falls through to the SPA catch-all and serves the dashboard. With Step 1 deployed but Step 2 broken, users visiting reports.ai-watch.dev get JS-redirected to ai-watch.dev/reports/ → sees dashboard SPA instead of their monthly report.

Reverting Step 1 restores subdomain as authoritative serving origin. Will re-approach Step 2 with an Edge Function proxy (`api/reports.ts`) instead of external-URL rewrites, then re-ship Step 1.