### PR TITLE
feat: reinstate SEO consolidation — canonical + JS redirect (refs aiwatch#264)

### DIFF
--- a/2026-03/index.md
+++ b/2026-03/index.md
@@ -267,7 +267,7 @@ OpenAI API (2h 56m total downtime), Groq Cloud (zero incidents), DeepSeek API (1
 - **Live status** — [ai-watch.dev](https://ai-watch.dev)
 - **Slack/Discord alerts** — [ai-watch.dev/#settings](https://ai-watch.dev/#settings)
 - **Score methodology** — [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
-- **All reports** — [reports.ai-watch.dev](https://reports.ai-watch.dev)
+- **All reports** — [ai-watch.dev/reports](https://ai-watch.dev/reports/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Monthly AI service reliability reports covering uptime, incidents, and performance across 30 major AI services.
 
-**Live site**: [reports.ai-watch.dev](https://reports.ai-watch.dev)
+**Live site**: [ai-watch.dev/reports](https://ai-watch.dev/reports/) (served via Vercel rewrite; legacy `reports.ai-watch.dev` self-redirects to the canonical path — #264)
 **Data source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
 
 ---
@@ -11,7 +11,7 @@
 
 | Month | Link | Services | Status |
 |---|---|---|---|
-| March 2026 | [View →](https://reports.ai-watch.dev/2026-03/) | 27 | Published |
+| March 2026 | [View →](https://ai-watch.dev/reports/2026-03/) | 27 | Published |
 
 ---
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: AIWatch Reports
 description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 31 AI services
-baseurl: ""
-url: https://reports.ai-watch.dev
+baseurl: "/reports"
+url: https://ai-watch.dev
 theme: minima
 lang: en
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,8 +16,11 @@ document.addEventListener('click', function(e) {
   var href = a.getAttribute('href') || '';
   var inFooter = !!a.closest('footer');
   var page = location.pathname.match(/\/(\d{4}-\d{2})\//)?.[1] || 'index';
-  // ai-watch.dev links — classify by destination
-  if (href.includes('ai-watch.dev') && !href.includes('reports.ai-watch.dev')) {
+  // ai-watch.dev links — classify by destination. After #264 migration, report
+  // pages live at ai-watch.dev/reports/, so exclude any /reports/ path here to
+  // avoid mis-classifying report-to-report navigation as dashboard clicks.
+  // Trailing slash anchors the match to path-prefix, not hash (#reports-info).
+  if (href.includes('ai-watch.dev') && !href.includes('/reports/')) {
     if (href.includes('#settings')) {
       gtag('event', 'click_cta_alerts', { location: 'reports_site', source: inFooter ? 'footer' : 'body', page: page });
     } else if (href.includes('#about-score')) {

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,13 @@
 <head>
+  <script>
+  // #264: reports moved to ai-watch.dev/reports/. Subdomain visitors bounce
+  // to the canonical main-domain URL so SEO consolidates and internal links
+  // (which now use baseurl=/reports) resolve correctly. Placed first so it
+  // fires before CSS/asset loading and GA4 — redirect happens immediately.
+  if (location.hostname === 'reports.ai-watch.dev') {
+    location.replace('https://ai-watch.dev/reports' + location.pathname + location.search + location.hash);
+  }
+  </script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -188,7 +188,7 @@ Unlike raw uptime %, it incorporates incident frequency (how often things break)
 - **Live status** — [ai-watch.dev](https://ai-watch.dev)
 - **Slack/Discord alerts** — [ai-watch.dev/#settings](https://ai-watch.dev/#settings)
 - **Score methodology** — [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
-- **All reports** — [reports.ai-watch.dev](https://reports.ai-watch.dev)
+- **All reports** — [ai-watch.dev/reports](https://ai-watch.dev/reports/)
 
 ---
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://reports.ai-watch.dev/sitemap.xml
+Sitemap: https://ai-watch.dev/reports/sitemap.xml


### PR DESCRIPTION
## Summary

Re-applies the reverted PR #7 via `git revert b41e990` (= \"revert of the revert\"). Pairs with aiwatch PR #341 which implements the Vercel Edge Function proxy on the main site.

- `_config.yml`: `baseurl \"/reports\"` + `url: ai-watch.dev` — Jekyll now emits canonical/og:url/sitemap entries pointing to `ai-watch.dev/reports/...`, consolidating SEO authority on the apex domain.
- `_includes/head.html`: JS redirect (`location.replace`) from `reports.ai-watch.dev/*` to `ai-watch.dev/reports/*`. Placed first in `<head>` so it fires before CSS/asset load and before GA4 init — no visible flash on the subdomain.
- `_includes/footer.html`: GA4 click-classifier filter changed from `!href.includes('reports.ai-watch.dev')` to `!href.includes('/reports/')`, so report-to-report navigation is not misclassified as dashboard clicks.
- `robots.txt`: sitemap URL → `ai-watch.dev/reports/sitemap.xml`.
- `README.md`, `_templates/monthly-report.md`, `2026-03/index.md`: \"All reports\" link migrated to the canonical apex path.

## ⚠️ Do not merge until aiwatch#341 is deployed to PRODUCTION

This PR's JS redirect sends subdomain visitors to `ai-watch.dev/reports/*`. Until aiwatch#341 merges AND Vercel auto-deploys, that path 404s / falls through to the SPA on production. Merging this PR first would bounce users into a broken URL.

Correct sequence:
1. aiwatch#341 merge → wait for Vercel production deploy
2. Smoke-test `https://ai-watch.dev/reports/` (dashboard theme + assets load)
3. Merge this PR → wait for GH Pages rebuild (~1-2 min)
4. Smoke-test `https://reports.ai-watch.dev/` (should auto-redirect to apex)

## Interaction with aiwatch#341's HTML rewriter

aiwatch#341's Edge Function defensively rewrites `<tag href|src=\"/assets/...\">` → `/reports/assets/...` and `<tag href=\"/\">` → `/reports/` at the proxy layer. With `baseurl=/reports` applied here, Jekyll emits those paths natively — the rewriter finds no matches (verified: no-op). Both PRs are compatible; the rewriter is defense-in-depth while this PR is the SEO-correct source of truth.

## Test plan

- [x] `jekyll build` succeeds locally
- [x] `_site/2026-03/index.html` canonical = `https://ai-watch.dev/reports/2026-03/`
- [x] `_site/sitemap.xml` all `<loc>` on apex domain
- [x] Internal asset links resolve under `/reports/assets/*`
- [x] `location.replace` fires only when `hostname === 'reports.ai-watch.dev'`
- [ ] Post-merge: verify `reports.ai-watch.dev/*` redirects cleanly in browser (JS enabled)
- [ ] Post-merge: verify `ai-watch.dev/reports/*` serves Jekyll content through the proxy (both trailing-slash and no-slash)

## Follow-up (deferred ~2-3 months)

Once Google absorbs the canonical signal, add a DNS-level 301 for `reports.ai-watch.dev` → `ai-watch.dev/reports` as belt-and-braces. Tracking via label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)