### PR TITLE
feat: render Security Alerts section in monthly report (refs aiwatch#290 + aiwatch#291)

### DIFF
--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -149,6 +149,8 @@ Unlike raw uptime %, it incorporates incident frequency (how often things break)
 
 ---
 
+<!-- SECURITY_SECTION -->
+
 ## Notable Incidents
 
 <!-- Top 5-6 notable incidents with raw vs adjusted duration where applicable -->

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -221,6 +221,131 @@ function buildUptimeTable(services, meta) {
   ).join('\n')
 }
 
+// ── Security section (refs aiwatch#290 / aiwatch#291) ───────────────
+//
+// Schema: archive.security shape from MonthlySecuritySummary in worker/src/monthly-archive.ts:
+//   { totalAlerts, bySource: { osv, hackernews }, bySeverity: { critical, high, medium, low },
+//     byService: { [serviceName]: count },
+//     topFindings: { title, url, source, severity?, service?, detectedAt, timeline? }[] }
+// `timeline` only present on OSV findings whose security:timeline:osv:{id} key existed at
+// archive build time (#291). HN findings never carry a timeline.
+//
+// Returns the full markdown block (heading included) or '' when there's nothing to surface.
+
+const SEVERITY_ORDER = ['critical', 'high', 'medium', 'low']
+
+function fmtIso(d) {
+  if (!d) return '—'
+  // Sanitize: only emit a recognizable YYYY-MM-DD prefix. Falling through to `String(d)` would
+  // leak unescaped pipes / newlines into a markdown table cell on a malformed `at` field.
+  const m = /^(\d{4}-\d{2}-\d{2})/.exec(String(d))
+  return m ? m[1] : '—'
+}
+
+function buildBySourceTable(bySource) {
+  const rows = []
+  if (bySource.osv > 0) rows.push(`| OSV.dev | ${bySource.osv} |`)
+  if (bySource.hackernews > 0) rows.push(`| Hacker News | ${bySource.hackernews} |`)
+  if (rows.length === 0) return ''
+  return ['| Source | Count |', '|---|---|', ...rows].join('\n')
+}
+
+function buildBySeverityTable(bySeverity) {
+  // Always render all four buckets — readers can scan severity at a glance even when zero.
+  const headers = SEVERITY_ORDER.map(s => s.charAt(0).toUpperCase() + s.slice(1))
+  const counts = SEVERITY_ORDER.map(s => bySeverity[s] ?? 0)
+  if (counts.every(c => c === 0)) return ''
+  return [
+    `| ${headers.join(' | ')} |`,
+    `| ${headers.map(() => '---').join(' | ')} |`,
+    `| ${counts.join(' | ')} |`,
+  ].join('\n')
+}
+
+function buildByServiceTable(byService, limit = 5) {
+  const entries = Object.entries(byService || {})
+    .filter(([, count]) => count > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+  if (entries.length === 0) return ''
+  const rows = entries.map(([name, count]) => `| ${name} | ${count} |`)
+  return ['| Service | Count |', '|---|---|', ...rows].join('\n')
+}
+
+function buildTimelineDetails(timeline) {
+  if (!Array.isArray(timeline) || timeline.length === 0) return ''
+  const rows = timeline.map(e =>
+    `| ${e.stage ?? '—'} | ${fmtIso(e.at)} | ${e.severity ?? '—'} | ${e.fixedVersion ?? '—'} |`,
+  )
+  return [
+    '<details markdown="1">',
+    '<summary>Timeline</summary>',
+    '',
+    '| Stage | At (UTC) | Severity | Fix Version |',
+    '|---|---|---|---|',
+    ...rows,
+    '',
+    '</details>',
+  ].join('\n')
+}
+
+function buildTopFindings(findings) {
+  if (!Array.isArray(findings) || findings.length === 0) return ''
+  const sections = findings.map((f, i) => {
+    const sev = f.severity ? `\`${f.severity}\`` : '`unrated`'
+    const sourceLabel = f.source === 'osv' ? 'OSV.dev' : f.source === 'hackernews' ? 'Hacker News' : f.source
+    const titleLink = f.url ? `[${f.title}](${f.url})` : f.title
+    const heading = `#### ${i + 1}. ${titleLink} · ${sev}`
+    const meta = [
+      `- **Source:** ${sourceLabel}`,
+      `- **Detected:** ${fmtIso(f.detectedAt)}`,
+    ]
+    if (f.service) meta.splice(1, 0, `- **Affected:** ${f.service}`)
+    const timelineBlock = f.source === 'osv' ? buildTimelineDetails(f.timeline) : ''
+    return [heading, '', meta.join('\n'), timelineBlock].filter(Boolean).join('\n')
+  })
+  return ['### Top Findings', '', ...sections].join('\n\n')
+}
+
+function buildSecuritySection(security) {
+  // Schema-aligned fast paths — surface nothing when there's nothing to report.
+  if (!security) return ''
+  // Distinguish "no alerts this month" from "malformed archive". The worker writer
+  // (summarizeSecurityAlerts) always sets totalAlerts; if it's missing while other fields
+  // are populated, log so build-time CI / operators notice rather than silently dropping.
+  if (typeof security.totalAlerts !== 'number') {
+    if (security.topFindings?.length || security.bySource || security.bySeverity) {
+      console.warn('[security] archive present but totalAlerts missing — section omitted')
+    }
+    return ''
+  }
+  if (security.totalAlerts <= 0) return ''
+
+  const parts = [
+    '## Security Alerts',
+    '',
+    `> **Note:** Security alerts captured during the month from OSV.dev (AI SDK package vulnerabilities) and Hacker News (security posts mentioning monitored services). Section omitted for months without detections.`,
+    '',
+    `**Total alerts:** ${security.totalAlerts}`,
+    '',
+  ]
+
+  const bySrc = buildBySourceTable(security.bySource || { osv: 0, hackernews: 0 })
+  if (bySrc) parts.push('**By source**', '', bySrc, '')
+
+  const bySev = buildBySeverityTable(security.bySeverity || {})
+  if (bySev) parts.push('**By severity**', '', bySev, '')
+
+  const bySvc = buildByServiceTable(security.byService || {})
+  if (bySvc) parts.push('**Most affected services**', '', bySvc, '')
+
+  const top = buildTopFindings(security.topFindings || [])
+  if (top) parts.push(top, '')
+
+  parts.push('---', '')
+  return parts.join('\n')
+}
+
 function buildLatencyTable(services, meta) {
   const withLatency = services.filter(s => s.data.avgLatencyMs !== null && !NO_PROBE.has(s.id))
   // Competition rank with ascending sort: negate avgLatencyMs so competitionRank's
@@ -350,6 +475,16 @@ function fillTemplate(template, month, archive, meta) {
     zeroIncLine,
   )
 
+  // Security section — when archive.security is null/empty, collapse the placeholder + its
+  // surrounding blank lines down to a single blank line so the preceding `---` separator
+  // doesn't end up adjacent to a second one (would render as two horizontal rules).
+  const securityBlock = buildSecuritySection(archive.security)
+  if (securityBlock) {
+    out = out.replace(/<!-- SECURITY_SECTION -->/, securityBlock)
+  } else {
+    out = out.replace(/\n*<!-- SECURITY_SECTION -->\n*/, '\n\n')
+  }
+
   return out
 }
 
@@ -400,6 +535,13 @@ module.exports = {
   buildIncidentTable,
   buildUptimeTable,
   buildLatencyTable,
+  buildBySourceTable,
+  buildBySeverityTable,
+  buildByServiceTable,
+  buildTimelineDetails,
+  buildTopFindings,
+  buildSecuritySection,
+  fmtIso,
   monthName,
   lastDayOfMonth,
   nextMonthName,

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -10,6 +10,12 @@ const {
   buildIncidentTable,
   buildUptimeTable,
   buildLatencyTable,
+  buildBySourceTable,
+  buildBySeverityTable,
+  buildByServiceTable,
+  buildTimelineDetails,
+  buildTopFindings,
+  buildSecuritySection,
   monthName,
   lastDayOfMonth,
   nextMonthName,
@@ -282,6 +288,253 @@ test('NEXT_MONTH resolves year rollover correctly', () => {
   const archive = { services: {}, daysCollected: 0 }
   const out = fillTemplate(tmpl, '2026-12', archive, {})
   assert.ok(out.includes('January'), `expected "January" after December: ${out}`)
+})
+
+// ── Security section (refs aiwatch#290 / aiwatch#291) ───────────────
+console.log('\nbuildBySourceTable')
+test('renders both sources when both fired', () => {
+  const out = buildBySourceTable({ osv: 5, hackernews: 3 })
+  assert.ok(out.includes('OSV.dev | 5'), `osv row: ${out}`)
+  assert.ok(out.includes('Hacker News | 3'), `hn row: ${out}`)
+})
+test('hides zero-count rows so the table stays tight', () => {
+  const out = buildBySourceTable({ osv: 5, hackernews: 0 })
+  assert.ok(out.includes('OSV.dev | 5'))
+  assert.ok(!out.includes('Hacker News'), `HN row should be hidden when count=0: ${out}`)
+})
+test('returns empty string when no source has alerts', () => {
+  eq(buildBySourceTable({ osv: 0, hackernews: 0 }), '')
+})
+
+console.log('\nbuildBySeverityTable')
+test('always shows all four severity buckets including zeros', () => {
+  const out = buildBySeverityTable({ critical: 0, high: 2, medium: 5, low: 1 })
+  assert.ok(out.includes('Critical | High | Medium | Low'), `header: ${out}`)
+  assert.ok(out.includes('0 | 2 | 5 | 1'), `row: ${out}`)
+})
+test('returns empty string when all severities are zero', () => {
+  eq(buildBySeverityTable({ critical: 0, high: 0, medium: 0, low: 0 }), '')
+})
+test('handles missing severity keys (treated as zero)', () => {
+  const out = buildBySeverityTable({ high: 3 })
+  assert.ok(out.includes('0 | 3 | 0 | 0'), `row: ${out}`)
+})
+
+console.log('\nbuildByServiceTable')
+test('sorts by count desc and caps at 5 by default', () => {
+  const counts = { a: 1, b: 5, c: 3, d: 7, e: 2, f: 6, g: 4 }
+  const out = buildByServiceTable(counts)
+  // Should include top 5: d(7), f(6), b(5), g(4), c(3)
+  assert.ok(out.indexOf('d | 7') < out.indexOf('f | 6'), 'highest count first')
+  assert.ok(out.indexOf('f | 6') < out.indexOf('c | 3'), 'descending throughout')
+  assert.ok(!out.includes('a | 1'), 'should drop entries beyond limit')
+  assert.ok(!out.includes('e | 2'), 'should drop entries beyond limit')
+})
+test('returns empty string when byService has only zero-count entries', () => {
+  eq(buildByServiceTable({ a: 0, b: 0 }), '')
+})
+test('returns empty string for missing byService input', () => {
+  eq(buildByServiceTable(undefined), '')
+})
+
+console.log('\nfmtIso edge cases')
+test('returns em dash on null/undefined', () => {
+  const { fmtIso } = require('./generate-report')
+  eq(fmtIso(null), '—')
+  eq(fmtIso(undefined), '—')
+})
+test('returns em dash for non-string objects (defensive against schema drift)', () => {
+  const { fmtIso } = require('./generate-report')
+  // Without sanitization, String({}) leaks "[object Object]" into a markdown table cell.
+  eq(fmtIso({}), '—')
+})
+test('returns em dash for malformed dates so unsanitized text never hits a table cell', () => {
+  const { fmtIso } = require('./generate-report')
+  eq(fmtIso('not-a-date'), '—')
+  eq(fmtIso('2026-04'), '—')   // partial date — no day
+  eq(fmtIso('2026'), '—')      // year only
+})
+
+console.log('\nbuildTimelineDetails')
+test('renders all stages in order with severity + fix version', () => {
+  const out = buildTimelineDetails([
+    { stage: 'detected', at: '2026-04-15T10:00:00Z', severity: 'high' },
+    { stage: 'severity_changed', at: '2026-04-18T12:00:00Z', severity: 'critical' },
+    { stage: 'fix_released', at: '2026-04-22T08:00:00Z', severity: 'critical', fixedVersion: '1.42.0' },
+  ])
+  assert.ok(out.includes('<details'), `wraps in details: ${out}`)
+  assert.ok(out.includes('detected | 2026-04-15 | high | —'), `detected row: ${out}`)
+  assert.ok(out.includes('fix_released | 2026-04-22 | critical | 1.42.0'), `fix row: ${out}`)
+})
+test('returns empty string when timeline is empty', () => {
+  eq(buildTimelineDetails([]), '')
+})
+test('returns empty string when timeline is undefined', () => {
+  eq(buildTimelineDetails(undefined), '')
+})
+test('renders em dash when severity or fix version is missing', () => {
+  const out = buildTimelineDetails([{ stage: 'detected', at: '2026-04-15' }])
+  assert.ok(out.includes('detected | 2026-04-15 | — | —'), `missing fields: ${out}`)
+})
+test('renders em dash for missing stage so undefined never appears in a table cell', () => {
+  const out = buildTimelineDetails([{ at: '2026-04-15' }])
+  assert.ok(!out.includes('undefined'), `stage fallback: ${out}`)
+  assert.ok(out.includes('— | 2026-04-15 | — | —'), `stage = em dash: ${out}`)
+})
+
+console.log('\nbuildTopFindings')
+test('renders OSV finding with timeline expansion', () => {
+  const out = buildTopFindings([{
+    title: 'GHSA-1234 langchain SSRF', url: 'https://example.com/x',
+    source: 'osv', severity: 'high', service: 'langchain',
+    detectedAt: '2026-04-10T12:00:00Z',
+    timeline: [{ stage: 'detected', at: '2026-04-10T12:00:00Z', severity: 'high' }],
+  }])
+  assert.ok(out.includes('### Top Findings'), `top heading: ${out}`)
+  assert.ok(out.includes('1. [GHSA-1234 langchain SSRF](https://example.com/x)'), `link title: ${out}`)
+  assert.ok(out.includes('`high`'), `severity badge: ${out}`)
+  assert.ok(out.includes('**Affected:** langchain'), `affected: ${out}`)
+  assert.ok(out.includes('<details'), `timeline details: ${out}`)
+})
+test('omits timeline section for HN findings even if timeline field set (defensive)', () => {
+  const out = buildTopFindings([{
+    title: 'HN post', url: 'https://news.ycombinator.com/item?id=1',
+    source: 'hackernews', severity: 'medium', detectedAt: '2026-04-12',
+    timeline: [{ stage: 'detected', at: '2026-04-12' }], // shouldn't happen but be safe
+  }])
+  assert.ok(!out.includes('<details'), `HN must never render timeline: ${out}`)
+})
+test('renders unrated badge when severity missing', () => {
+  const out = buildTopFindings([{
+    title: 'foo', url: 'https://example.com',
+    source: 'osv', detectedAt: '2026-04-10',
+  }])
+  assert.ok(out.includes('`unrated`'), `unrated fallback: ${out}`)
+})
+test('omits affected line when service missing', () => {
+  const out = buildTopFindings([{
+    title: 'foo', url: 'https://example.com',
+    source: 'hackernews', detectedAt: '2026-04-10',
+  }])
+  assert.ok(!out.includes('**Affected:**'), `affected omitted when service is null: ${out}`)
+})
+test('returns empty string when findings is empty array', () => {
+  eq(buildTopFindings([]), '')
+})
+test('renders a 15-item input as-is — the worker pre-caps at 10 and pre-sorts; generator does not duplicate', () => {
+  // Documents the contract: this function trusts the upstream cap + sort. If a future
+  // refactor adds slicing/sorting here it would silently drop the worker's authoritative ordering.
+  const findings = Array.from({ length: 15 }, (_, i) => ({
+    title: `f${i}`, url: `https://example.com/${i}`,
+    source: 'osv', severity: 'low', service: 'svc', detectedAt: '2026-04-10',
+  }))
+  const out = buildTopFindings(findings)
+  // All 15 numbered headings should be present
+  for (let i = 1; i <= 15; i++) {
+    assert.ok(out.includes(`#### ${i}.`), `index ${i} should appear: missing in ${out.slice(0, 100)}…`)
+  }
+})
+
+console.log('\nbuildSecuritySection')
+test('returns empty string when security is null', () => {
+  eq(buildSecuritySection(null), '')
+})
+test('returns empty string when totalAlerts is 0', () => {
+  eq(buildSecuritySection({
+    totalAlerts: 0, bySource: { osv: 0, hackernews: 0 },
+    bySeverity: { critical: 0, high: 0, medium: 0, low: 0 }, byService: {}, topFindings: [],
+  }), '')
+})
+test('warns + omits when totalAlerts is missing on a non-empty archive (malformed input)', () => {
+  const origWarn = console.warn
+  const warnings = []
+  console.warn = (...args) => { warnings.push(args.join(' ')) }
+  try {
+    const out = buildSecuritySection({
+      // totalAlerts deliberately omitted; other fields populated
+      bySource: { osv: 1, hackernews: 0 }, bySeverity: { critical: 0, high: 1, medium: 0, low: 0 },
+      byService: { foo: 1 }, topFindings: [{ title: 't', url: 'u', source: 'osv', detectedAt: '2026-04-01' }],
+    })
+    eq(out, '')
+    assert.ok(warnings.some(w => w.includes('totalAlerts missing')), `warning emitted: ${JSON.stringify(warnings)}`)
+  } finally {
+    console.warn = origWarn
+  }
+})
+test('renders full section when totalAlerts > 0', () => {
+  const out = buildSecuritySection({
+    totalAlerts: 8,
+    bySource: { osv: 5, hackernews: 3 },
+    bySeverity: { critical: 1, high: 2, medium: 4, low: 1 },
+    byService: { 'OpenAI Python SDK': 3, 'langchain': 2 },
+    topFindings: [{
+      title: 'GHSA-x foo', url: 'https://osv.dev/GHSA-x', source: 'osv',
+      severity: 'critical', service: 'openai', detectedAt: '2026-04-01',
+      timeline: [{ stage: 'detected', at: '2026-04-01', severity: 'critical' }],
+    }],
+  })
+  assert.ok(out.startsWith('## Security Alerts'), `heading first: ${out.slice(0, 50)}`)
+  assert.ok(out.includes('**Total alerts:** 8'), `total: ${out}`)
+  assert.ok(out.includes('OSV.dev | 5'), `bySource rendered`)
+  assert.ok(out.includes('Critical | High | Medium | Low'), `bySeverity rendered`)
+  assert.ok(out.includes('OpenAI Python SDK | 3'), `byService rendered`)
+  assert.ok(out.includes('### Top Findings'), `top findings rendered`)
+  assert.ok(out.endsWith('---\n'), `terminating separator: ${JSON.stringify(out.slice(-10))}`)
+})
+test('omits subsections that have no data but still renders the heading + total', () => {
+  const out = buildSecuritySection({
+    totalAlerts: 2,
+    bySource: { osv: 2, hackernews: 0 }, // only OSV
+    bySeverity: { critical: 0, high: 0, medium: 0, low: 0 }, // no severities tagged
+    byService: {}, // no service attribution
+    topFindings: [], // no top findings
+  })
+  assert.ok(out.includes('**Total alerts:** 2'))
+  assert.ok(out.includes('OSV.dev | 2'))
+  // Note: the intro `> Note:` text mentions "Hacker News" as a data source — that's expected.
+  // Test the absence of the table-row form ("Hacker News | <n>") instead.
+  assert.ok(!/Hacker News \| \d/.test(out), 'HN table row should be hidden when count=0')
+  assert.ok(!out.includes('**By severity**'), 'severity section omitted when all zero')
+  assert.ok(!out.includes('**Most affected services**'), 'services section omitted when empty')
+  assert.ok(!out.includes('### Top Findings'), 'top findings omitted when empty')
+})
+
+// ── fillTemplate × security ─────────────────────────────────────────
+console.log('\nfillTemplate × security')
+test('inserts the security block when archive.security has data', () => {
+  const tmpl = `intro\n\n<!-- SECURITY_SECTION -->\n\n## Notable Incidents\noutro`
+  const archive = {
+    services: {}, daysCollected: 0,
+    security: {
+      totalAlerts: 1,
+      bySource: { osv: 1, hackernews: 0 },
+      bySeverity: { critical: 0, high: 1, medium: 0, low: 0 },
+      byService: { langchain: 1 },
+      topFindings: [{
+        title: 'foo', url: 'https://example.com', source: 'osv',
+        severity: 'high', service: 'langchain', detectedAt: '2026-04-10',
+      }],
+    },
+  }
+  const out = fillTemplate(tmpl, '2026-04', archive, {})
+  assert.ok(out.includes('## Security Alerts'), `heading: ${out}`)
+  assert.ok(out.includes('## Notable Incidents'), 'notable incidents preserved')
+  assert.ok(!out.includes('<!-- SECURITY_SECTION -->'), 'placeholder removed')
+})
+test('strips the placeholder cleanly when archive.security is null', () => {
+  const tmpl = `intro\n\n<!-- SECURITY_SECTION -->\n\n## Notable Incidents\noutro`
+  const archive = { services: {}, daysCollected: 0, security: null }
+  const out = fillTemplate(tmpl, '2026-04', archive, {})
+  assert.ok(!out.includes('<!-- SECURITY_SECTION -->'), 'placeholder removed')
+  assert.ok(!out.includes('## Security Alerts'), 'no heading injected')
+  assert.ok(!/\n---\n+\n---\n/.test(out), 'no double horizontal rules introduced')
+})
+test('strips the placeholder cleanly when archive.security is missing entirely', () => {
+  const tmpl = `intro\n\n<!-- SECURITY_SECTION -->\n\n## Notable Incidents\noutro`
+  const archive = { services: {}, daysCollected: 0 } // no security key
+  const out = fillTemplate(tmpl, '2026-04', archive, {})
+  assert.ok(!out.includes('<!-- SECURITY_SECTION -->'))
+  assert.ok(!out.includes('## Security Alerts'))
 })
 
 // ── Summary ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a "Security Alerts" section to the monthly report between Detection Lead and Notable Incidents — surfaces total alerts, source/severity/service breakdowns, and top findings (with OSV-only `<details>` Timeline expansion per aiwatch#291).
- Section is omitted entirely (with surrounding `---` separators collapsed) when `archive.security` is null/missing/zero-alerts. Months before aiwatch#290 shipped, or months with no detections, render exactly as before.
- Schema-aligned with `MonthlySecuritySummary` in [aiwatch/worker/src/monthly-archive.ts:60-66](https://github.com/bentleypark/aiwatch/blob/main/worker/src/monthly-archive.ts#L60-L66) — generator trusts the worker's pre-cap (max 10 top findings) + pre-sort (severity desc) and does not duplicate the logic.
- Unblocks the April 2026 report generation on 5/1 (cron-driven via `aiwatch-reports#10` Phase 1 + `aiwatch#343` Phase 2 ping).

## Defensive guards

- Malformed `at` (e.g., truncated date) → `'—'` instead of leaking `String(d)` into a markdown cell.
- Missing `stage` in a timeline entry → `'—'` not the literal string `undefined`.
- Archive with populated fields but missing `totalAlerts` → `console.warn` and skip — surfaces the corruption to build-time CI rather than silently dropping the section.
- HN findings never render a timeline `<details>` (defensive — schema invariant from aiwatch#291; test guards against future drift).

## Test plan

- [x] `node scripts/generate-report.test.js` — 74 passed (was 43; +31 new tests for security section)
- [x] Visual smoke test against synthetic archive (verified section ordering, OSV timeline rendering, HN no-timeline, null-security strip with no double `---`)
- [x] PR review auto-loop converged (Round 1: 1 Critical comment + 2 silent-failure Critical + 3 Important; Round 2: all addressed, no new issues, "ship it")
- [ ] First real run on 2026-05-01 — operator generates April draft via `generate-report.yml` workflow_dispatch, security section populates from `archive.security` in the April archive

## Related

- aiwatch#290 — security alerts in permanent monthly archive (code merged via aiwatch#308)
- aiwatch#291 — OSV-only per-alert timeline (code merged via aiwatch#334)
- aiwatch#343 — Phase 2 Discord ping linking to this workflow (in flight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)