### PR TITLE
fix: remove generate-charts.yml schedule (#12)

### DIFF
--- a/.github/workflows/generate-charts.yml
+++ b/.github/workflows/generate-charts.yml
@@ -1,13 +1,21 @@
 name: Generate Monthly Charts
 
 on:
+  # workflow_dispatch only — charts are normally generated as part of
+  # generate-report.yml when an operator triggers a monthly report draft.
+  # This workflow remains as an opt-in chart-only re-run tool (e.g. when an
+  # operator updates the report frontmatter and needs to regenerate SVGs
+  # without re-running the full report draft pipeline).
+  #
+  # No `schedule:` trigger — that was removed because it ran on the 1st of
+  # the month before the operator had a chance to trigger generate-report.yml,
+  # so the existence check at "Report not found: {prev-month}/index.md" failed
+  # every month (#12).
   workflow_dispatch:
     inputs:
       report_path:
         description: 'Report file path (e.g., 2026-04/index.md)'
         required: true
-  schedule:
-    - cron: '0 0 1 * *'
 
 jobs:
   generate:


### PR DESCRIPTION
## Summary
- Remove the \`schedule: '0 0 1 * *'\` trigger from \`.github/workflows/generate-charts.yml\`. The cron fired on the 1st of every month before the operator triggered \`generate-report.yml\`, so the existence check at \`Report not found: {prev-month}/index.md\` failed every month.
- Retain \`workflow_dispatch\` so the workflow remains usable as an opt-in chart-only re-run tool (e.g., after editing report frontmatter without re-running the full report draft pipeline).

The chart generation step is already part of \`generate-report.yml\` (\`run: node scripts/generate-charts.js \"\${MONTH}/index.md\"\`), so the standalone scheduled run was both redundant and incorrectly assumed a precondition it cannot guarantee. Operator-driven design is intentional per \`generate-report.yml\`'s header comment ("Archive data quality is operator-verified before draft generation").

## Latest failure (motivation)
[Run #25200731066](https://github.com/bentleypark/aiwatch-reports/actions/runs/25200731066) — 2026-05-01 03:23 UTC, exit 1 with \`Report not found: 2026-04/index.md\`.

## Test plan
- [x] YAML syntax validated via \`js-yaml\` parse
- [x] Diff is minimal: only the \`schedule:\` block removed; explanatory comment added above \`workflow_dispatch:\`
- [ ] Verify next 1st-of-month does NOT show a failed \`Generate Monthly Charts\` run (manual observation post-merge)
- [ ] Verify \`workflow_dispatch\` manual trigger still works for re-runs (operator can confirm next time charts need regenerating)

closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)