### PR TITLE
feat: workflow auto-commit _data + auto-update index.md (#15)

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -57,6 +57,21 @@ jobs:
           MONTH: ${{ steps.month.outputs.month }}
         run: node scripts/generate-charts.js "${MONTH}/index.md"
 
+      - name: Snapshot archive JSON to _data/ (#15)
+        # Persists /api/report?month=YYYY-MM as _data/{MONTH}.json for long-term
+        # git preservation alongside the KV archive — see _data/README.md for
+        # provenance + rebuild caveats.
+        env:
+          MONTH: ${{ steps.month.outputs.month }}
+        run: bash scripts/fetch-archive.sh "$MONTH"
+
+      - name: Update top-level index.md (#15)
+        # Inserts/refreshes the entry for $MONTH in the front-page Reports list
+        # using services count + daysCollected from the snapshot above. Idempotent.
+        env:
+          MONTH: ${{ steps.month.outputs.month }}
+        run: node scripts/update-index.js "$MONTH"
+
       - name: Create branch + draft PR
         env:
           MONTH: ${{ steps.month.outputs.month }}
@@ -76,7 +91,9 @@ jobs:
             git checkout -b "$BRANCH"
           fi
 
-          git add "${MONTH}/" "assets/${MONTH}/" 2>/dev/null || true
+          # _data/${MONTH}.json (snapshot) and index.md (Reports list entry) are added
+          # alongside the report file + assets so the draft PR is self-contained — #15.
+          git add "${MONTH}/" "assets/${MONTH}/" "_data/${MONTH}.json" index.md 2>/dev/null || true
 
           if git diff --cached --quiet; then
             echo "::notice::No changes vs previous draft — skipping commit"

--- a/_data/README.md
+++ b/_data/README.md
@@ -4,3 +4,8 @@ JSON snapshots from AIWatch Worker `/api/report?month=YYYY-MM` endpoint.
 Stored alongside KV for long-term git preservation and trend analysis.
 
 Files are named `{YYYY-MM}.json` (e.g., `2026-03.json`).
+
+Snapshots are auto-committed by `.github/workflows/generate-report.yml`
+during monthly draft generation (#15). For one-off backfills or manual
+refreshes, run `bash scripts/fetch-archive.sh {YYYY-MM}` and commit the
+result.

--- a/scripts/update-index.js
+++ b/scripts/update-index.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// update-index.js — Insert / refresh the top-level `index.md` entry for a given
+// month. Called by `.github/workflows/generate-report.yml` after the report
+// draft + archive snapshot are produced (#15) so the front-page list stays in
+// step with what's actually published — no more hand-editing on first-of-month.
+//
+// Usage: node scripts/update-index.js 2026-04
+//
+// Reads `_data/{MONTH}.json` (already committed by the same workflow run via
+// scripts/fetch-archive.sh) for `services` count + `daysCollected`. The date
+// range follows the existing convention: end-aligned within the month, so a
+// 12-day window in a 31-day month renders as "Mar 20–31" — matches the
+// hand-authored 2026-03 entry. Full months render as "Apr 1–30".
+//
+// Idempotent: if a line for the same month already exists in `## Reports`,
+// it's replaced rather than duplicated. Re-running the workflow for the same
+// month produces no diff if the archive numbers haven't shifted.
+
+const fs = require('fs')
+const path = require('path')
+
+const REPO_ROOT = path.join(__dirname, '..')
+const INDEX_PATH = path.join(REPO_ROOT, 'index.md')
+const DATA_DIR = path.join(REPO_ROOT, '_data')
+
+const MONTH_NAMES = [
+  '', 'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+]
+const MONTH_ABBR = [
+  '', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+]
+
+function lastDayOfMonth(year, month) {
+  // month is 1-12. JS Date with day=0 of next month gives last day of current.
+  return new Date(Date.UTC(year, month, 0)).getUTCDate()
+}
+
+function parseMonth(arg) {
+  if (!arg || !/^\d{4}-(0[1-9]|1[0-2])$/.test(arg)) {
+    throw new Error(`Invalid month: expected YYYY-MM, got "${arg}"`)
+  }
+  const [yearStr, monthStr] = arg.split('-')
+  return { year: Number(yearStr), month: Number(monthStr), period: arg }
+}
+
+function buildPeriodSuffix(year, month, daysCollected) {
+  const lastDay = lastDayOfMonth(year, month)
+  // End-aligned: a partial window is treated as days at the end of the month
+  // (matches the 2026-03 hand-authored entry: 12 days → Mar 20–31).
+  const startDay = Math.max(1, lastDay - daysCollected + 1)
+  const abbr = MONTH_ABBR[month]
+  return `${daysCollected}-day monitoring period (${abbr} ${startDay}–${lastDay})`
+}
+
+function buildEntry({ period, year, month, services, daysCollected }) {
+  const fullName = `${MONTH_NAMES[month]} ${year}`
+  const periodSuffix = buildPeriodSuffix(year, month, daysCollected)
+  return `- [**${fullName}**](${period}/) — ${services} services, ${periodSuffix}`
+}
+
+function readArchiveSnapshot(period) {
+  const snapshotPath = path.join(DATA_DIR, `${period}.json`)
+  if (!fs.existsSync(snapshotPath)) {
+    throw new Error(`Snapshot not found: ${snapshotPath}. Run scripts/fetch-archive.sh ${period} first.`)
+  }
+  const raw = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'))
+  // The Worker archive shape (MonthlyArchive in worker/src/monthly-archive.ts)
+  // has `services` as a Record<svcId, MonthlyServiceData>. Count keys, not array length.
+  const services = raw.services && typeof raw.services === 'object'
+    ? Object.keys(raw.services).length
+    : 0
+  const daysCollected = typeof raw.daysCollected === 'number' ? raw.daysCollected : 0
+  return { services, daysCollected }
+}
+
+/**
+ * Insert or replace the index entry for `period` in the markdown body.
+ * Pure function — deterministic in (body, period, entry); tested in isolation.
+ *
+ * @param {string} body  Raw `index.md` content
+ * @param {string} period  Target month, e.g. "2026-04"
+ * @param {string} newEntry  The full bullet line for the entry
+ * @returns {string} Updated body
+ */
+function upsertIndexEntry(body, period, newEntry) {
+  const lines = body.split('\n')
+  const reportsIdx = lines.findIndex((l) => l.trim() === '## Reports')
+  if (reportsIdx === -1) {
+    throw new Error('index.md missing "## Reports" heading — cannot determine insertion point')
+  }
+
+  // Match existing entry by the period URL so we don't accidentally edit
+  // a paragraph that mentions the month name in passing.
+  const periodUrlPattern = new RegExp(`\\]\\(${period}/\\)`)
+  const existingIdx = lines.findIndex((l, i) => i > reportsIdx && periodUrlPattern.test(l))
+
+  if (existingIdx !== -1) {
+    // Replace in place — preserves whatever ordering the maintainer arranged.
+    lines[existingIdx] = newEntry
+    return lines.join('\n')
+  }
+
+  // Insert at top of the list (newest-first ordering, matches existing convention).
+  // Skip exactly one blank line after `## Reports` if present — standard markdown
+  // spacing — so the new entry sits one blank line below the heading regardless of
+  // whether the list is empty or already has older entries.
+  let insertAt = reportsIdx + 1
+  if (insertAt < lines.length && lines[insertAt].trim() === '') insertAt++
+  return [
+    ...lines.slice(0, insertAt),
+    newEntry,
+    ...lines.slice(insertAt),
+  ].join('\n')
+}
+
+function main() {
+  const arg = process.argv[2]
+  const { year, month, period } = parseMonth(arg)
+  const { services, daysCollected } = readArchiveSnapshot(period)
+
+  if (services === 0 && daysCollected === 0) {
+    // Empty snapshot is almost certainly a corrupt archive or a backfill run
+    // before the cron landed. Failing loud surfaces it to the workflow log
+    // rather than producing a misleading "0 services, 0-day" entry.
+    throw new Error(`Snapshot for ${period} reports 0 services and 0 days — refusing to write a misleading entry`)
+  }
+
+  const newEntry = buildEntry({ period, year, month, services, daysCollected })
+  const body = fs.readFileSync(INDEX_PATH, 'utf8')
+  const updated = upsertIndexEntry(body, period, newEntry)
+
+  if (updated === body) {
+    console.log(`[update-index] No changes — entry for ${period} already up to date.`)
+    return
+  }
+
+  fs.writeFileSync(INDEX_PATH, updated)
+  console.log(`[update-index] ✓ ${period}: ${services} services, ${daysCollected}-day window`)
+}
+
+if (require.main === module) {
+  try {
+    main()
+  } catch (err) {
+    console.error(`[update-index] ${err.message}`)
+    process.exit(1)
+  }
+}
+
+module.exports = {
+  parseMonth,
+  lastDayOfMonth,
+  buildPeriodSuffix,
+  buildEntry,
+  upsertIndexEntry,
+}

--- a/scripts/update-index.js
+++ b/scripts/update-index.js
@@ -65,7 +65,14 @@ function readArchiveSnapshot(period) {
   if (!fs.existsSync(snapshotPath)) {
     throw new Error(`Snapshot not found: ${snapshotPath}. Run scripts/fetch-archive.sh ${period} first.`)
   }
-  const raw = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'))
+  let raw
+  try {
+    raw = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'))
+  } catch (err) {
+    // Re-throw with the file path so the workflow log identifies the bad snapshot
+    // directly instead of just "Unexpected token …".
+    throw new Error(`Snapshot ${snapshotPath} is not valid JSON: ${err.message}`)
+  }
   // The Worker archive shape (MonthlyArchive in worker/src/monthly-archive.ts)
   // has `services` as a Record<svcId, MonthlyServiceData>. Count keys, not array length.
   const services = raw.services && typeof raw.services === 'object'

--- a/scripts/update-index.test.js
+++ b/scripts/update-index.test.js
@@ -1,0 +1,219 @@
+// update-index.test.js — Plain Node + assert, mirrors generate-report.test.js style.
+
+const {
+  parseMonth,
+  lastDayOfMonth,
+  buildPeriodSuffix,
+  buildEntry,
+  upsertIndexEntry,
+} = require('./update-index')
+const assert = require('assert')
+
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (err) {
+    failed++
+    console.log(`  ✗ ${name}`)
+    console.log(`    ${err.message}`)
+  }
+}
+
+console.log('parseMonth')
+test('accepts valid YYYY-MM', () => {
+  const result = parseMonth('2026-04')
+  assert.strictEqual(result.year, 2026)
+  assert.strictEqual(result.month, 4)
+  assert.strictEqual(result.period, '2026-04')
+})
+
+test('rejects malformed month strings', () => {
+  for (const bad of ['', undefined, '2026', '2026-4', '2026-13', '2026-00', '26-04', '2026-04-01']) {
+    assert.throws(() => parseMonth(bad), /Invalid month/)
+  }
+})
+
+console.log('\nlastDayOfMonth')
+test('returns 30 for April 2026', () => {
+  assert.strictEqual(lastDayOfMonth(2026, 4), 30)
+})
+
+test('returns 31 for January / March / December', () => {
+  assert.strictEqual(lastDayOfMonth(2026, 1), 31)
+  assert.strictEqual(lastDayOfMonth(2026, 3), 31)
+  assert.strictEqual(lastDayOfMonth(2026, 12), 31)
+})
+
+test('returns 28 for February in non-leap years', () => {
+  assert.strictEqual(lastDayOfMonth(2026, 2), 28)
+  assert.strictEqual(lastDayOfMonth(2027, 2), 28)
+})
+
+test('returns 29 for February in leap years', () => {
+  assert.strictEqual(lastDayOfMonth(2024, 2), 29)
+  assert.strictEqual(lastDayOfMonth(2028, 2), 29)
+})
+
+console.log('\nbuildPeriodSuffix')
+test('full-month windows render the whole range', () => {
+  // 30-day April → "Apr 1–30"
+  assert.strictEqual(
+    buildPeriodSuffix(2026, 4, 30),
+    '30-day monitoring period (Apr 1–30)',
+  )
+  // 31-day January → "Jan 1–31"
+  assert.strictEqual(
+    buildPeriodSuffix(2026, 1, 31),
+    '31-day monitoring period (Jan 1–31)',
+  )
+})
+
+test('partial windows align to the end of the month (matches 2026-03 hand-authored entry)', () => {
+  // 12-day window in 31-day March → "Mar 20–31" (lastDay 31 - 12 + 1 = 20)
+  assert.strictEqual(
+    buildPeriodSuffix(2026, 3, 12),
+    '12-day monitoring period (Mar 20–31)',
+  )
+})
+
+test('clamps start day to 1 if window exceeds month length', () => {
+  // 35-day window in 30-day April — abnormal but defensive: clamp at Apr 1 rather
+  // than emit "Apr -4–30" or similar nonsense.
+  assert.strictEqual(
+    buildPeriodSuffix(2026, 4, 35),
+    '35-day monitoring period (Apr 1–30)',
+  )
+})
+
+test('renders single-day partial as a degenerate range', () => {
+  // 1-day window at end of February 2026 → "Feb 28–28"
+  assert.strictEqual(
+    buildPeriodSuffix(2026, 2, 1),
+    '1-day monitoring period (Feb 28–28)',
+  )
+})
+
+console.log('\nbuildEntry')
+test('renders the full markdown bullet for April 2026', () => {
+  const entry = buildEntry({
+    period: '2026-04', year: 2026, month: 4,
+    services: 31, daysCollected: 30,
+  })
+  assert.strictEqual(
+    entry,
+    '- [**April 2026**](2026-04/) — 31 services, 30-day monitoring period (Apr 1–30)',
+  )
+})
+
+test('matches the 2026-03 hand-authored entry exactly (regression baseline)', () => {
+  // The hand-authored line in main was:
+  // - [**March 2026**](2026-03/) — 27 services, 12-day monitoring period (Mar 20–31)
+  const entry = buildEntry({
+    period: '2026-03', year: 2026, month: 3,
+    services: 27, daysCollected: 12,
+  })
+  assert.strictEqual(
+    entry,
+    '- [**March 2026**](2026-03/) — 27 services, 12-day monitoring period (Mar 20–31)',
+  )
+})
+
+console.log('\nupsertIndexEntry')
+
+function makeBody({ entries = [] } = {}) {
+  return [
+    '---',
+    'layout: home',
+    'title: AIWatch Monthly Reports',
+    '---',
+    '',
+    'Some intro paragraph.',
+    '',
+    '## Reports',
+    '',
+    ...entries,
+    '',
+  ].join('\n')
+}
+
+test('inserts new entry at top of empty Reports list', () => {
+  const body = makeBody({ entries: [] })
+  const out = upsertIndexEntry(
+    body,
+    '2026-04',
+    '- [**April 2026**](2026-04/) — 31 services, 30-day monitoring period (Apr 1–30)',
+  )
+  assert.match(out, /## Reports\n\n- \[\*\*April 2026\*\*\]\(2026-04\/\) — 31 services/)
+})
+
+test('inserts new entry at top, above existing entries (newest-first)', () => {
+  const body = makeBody({
+    entries: ['- [**March 2026**](2026-03/) — 27 services, 12-day monitoring period (Mar 20–31)'],
+  })
+  const out = upsertIndexEntry(
+    body,
+    '2026-04',
+    '- [**April 2026**](2026-04/) — 31 services, 30-day monitoring period (Apr 1–30)',
+  )
+  const reportsBlock = out.split('## Reports')[1]
+  // April line precedes March line
+  const aprilIdx = reportsBlock.indexOf('April 2026')
+  const marchIdx = reportsBlock.indexOf('March 2026')
+  assert.ok(aprilIdx !== -1 && aprilIdx < marchIdx, 'April entry should appear before March')
+})
+
+test('replaces existing entry for same month rather than duplicating (idempotent re-run)', () => {
+  const oldEntry = '- [**April 2026**](2026-04/) — 30 services, 30-day monitoring period (Apr 1–30)'
+  const newEntry = '- [**April 2026**](2026-04/) — 31 services, 30-day monitoring period (Apr 1–30)'
+  const body = makeBody({ entries: [oldEntry] })
+  const out = upsertIndexEntry(body, '2026-04', newEntry)
+  // Exactly one April entry, with the new service count
+  const matches = out.match(/April 2026/g) || []
+  assert.strictEqual(matches.length, 1, 'should not duplicate')
+  assert.ok(out.includes('31 services'), 'new content present')
+  assert.ok(!out.includes('30 services'), 'old content gone')
+})
+
+test('only matches by period URL — does not edit prose mentioning the month name', () => {
+  // A paragraph mentioning "April 2026" outside the Reports list must not be touched.
+  const body = [
+    '---',
+    'title: index',
+    '---',
+    '',
+    'Welcome — see the April 2026 report below for highlights.',
+    '',
+    '## Reports',
+    '',
+    '- [**March 2026**](2026-03/) — 27 services, 12-day monitoring period (Mar 20–31)',
+    '',
+  ].join('\n')
+  const newEntry = '- [**April 2026**](2026-04/) — 31 services, 30-day monitoring period (Apr 1–30)'
+  const out = upsertIndexEntry(body, '2026-04', newEntry)
+  assert.ok(out.includes('Welcome — see the April 2026 report below'), 'prose preserved verbatim')
+  // Reports list got the new entry
+  assert.ok(out.includes('](2026-04/)'), 'new entry inserted')
+})
+
+test('no-op when entry exists with identical content', () => {
+  const entry = '- [**April 2026**](2026-04/) — 31 services, 30-day monitoring period (Apr 1–30)'
+  const body = makeBody({ entries: [entry] })
+  const out = upsertIndexEntry(body, '2026-04', entry)
+  assert.strictEqual(out, body, 'unchanged body')
+})
+
+test('throws when "## Reports" heading is missing', () => {
+  const body = '# Some other doc\n\nNo reports section.\n'
+  assert.throws(
+    () => upsertIndexEntry(body, '2026-04', '- entry'),
+    /missing "## Reports" heading/,
+  )
+})
+
+console.log(`\n${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Summary
- Extend `.github/workflows/generate-report.yml` with two new steps that run **before** the existing branch + draft PR step:
  1. **Snapshot archive JSON** — runs the existing `scripts/fetch-archive.sh` so `_data/{MONTH}.json` is committed alongside the report.
  2. **Update top-level `index.md`** — runs the new `scripts/update-index.js`, which upserts a single bullet under `## Reports` using services count + daysCollected from the snapshot.
- Extend the `git add` line in `Create branch + draft PR` to include `_data/{MONTH}.json` and `index.md` so the draft PR is self-contained.
- Add `scripts/update-index.js` (5 exported pure helpers) + `scripts/update-index.test.js` (18 tests).
- Update `_data/README.md` to document the new auto-commit path.

## Why now
- PR aiwatch-reports#14 (April 2026 draft) shipped without an `index.md` entry and without `_data/2026-04.json` because the workflow only handled the report file and chart SVGs. The maintainer hand-edited both — easy to forget for any month where the workflow runs unattended.
- Pairs cleanly with aiwatch#343 (Discord ping when archive lands) — operator clicks the ping, workflow runs, and the resulting draft PR now also carries the `_data` snapshot + `index.md` entry. No follow-up manual steps for the routine path.

## Idempotency / regression coverage
- Same-month re-run replaces the existing `index.md` entry rather than duplicating (matches `--force-with-lease` semantics in the same workflow).
- Identical content is a no-op — workflow's "No changes vs previous draft — skipping commit" guard still covers the empty-diff case.
- 2026-03 hand-authored entry (`27 services, 12-day monitoring period (Mar 20–31)`) is locked in as a regression baseline test — same inputs reproduce the same string byte-for-byte.

## Test plan
- [x] `node scripts/update-index.test.js` — 18 passed
- [x] `node scripts/generate-report.test.js` — 74 passed (no regression from the existing #11 suite)
- [x] `js-yaml` parse confirms valid workflow YAML; step order: Resolve report month → Generate report draft → Generate charts → **Snapshot archive JSON to _data/** → **Update top-level index.md** → Create branch + draft PR
- [x] End-to-end manual: ran `scripts/fetch-archive.sh 2026-04` followed by `scripts/update-index.js 2026-04` against a synthetic `index.md` containing only the March 2026 entry; output had April inserted above March, both with their hand-authored format
- [ ] First real cron firing on 2026-06-01 — verify the May 2026 draft PR includes `_data/2026-05.json` and an updated `index.md` without manual follow-up

## Backfill
The 2026-03 and 2026-04 `_data` snapshots are already committed via aiwatch-reports#14 (the April report draft). No additional backfill needed in this PR.

closes #15
refs aiwatch-reports#14
refs aiwatch#343

🤖 Generated with [Claude Code](https://claude.com/claude-code)