### PR TITLE
fix: remove CNAME so #264 redirect can land (refs #264)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-reports.ai-watch.dev


### PR DESCRIPTION
## Summary

- Remove the `CNAME` file so GH Pages stops 301-redirecting `bentleypark.github.io/aiwatch-reports/*` back to `reports.ai-watch.dev/*`.
- This unblocks the third step of #264 — a Cloudflare Page Rule on the public `reports.ai-watch.dev/*` hostname can finally 301 to `ai-watch.dev/reports/*` without trapping the Vercel proxy in a redirect loop.

## Why now

Companion PR `aiwatch#381` flipped the Vercel proxy upstream from `reports.ai-watch.dev` to `bentleypark.github.io/aiwatch-reports`. While the CNAME file is in place, every proxy fetch hits a GH Pages 301 back to `reports.ai-watch.dev` and Vercel's `redirect: 'follow'` chases it. With the CNAME removed, the proxy fetches the github.io URL directly — no redirect chain — and the public subdomain becomes free for Cloudflare to 301.

## Sequencing & risk

1. ✅ `aiwatch#381` lands first — proxy upstream flipped (still works via the GH Pages 301 chain)
2. **This PR** — CNAME removed, GH Pages stops the 301 hop, proxy now fetches direct
3. Operator step in Cloudflare dashboard — DNS proxy enabled on `reports` CNAME + Page Rule `reports.ai-watch.dev/*` → 301 → `https://ai-watch.dev/reports/$1`

**Brief breakage window** between step 2 and step 3: direct visits to `reports.ai-watch.dev` (not the proxy) will get 404 until the Cloudflare 301 is configured. Proxy-via-`ai-watch.dev/reports/` traffic is unaffected.

The legacy soft-redirect in `_includes/head.html` stays as defense-in-depth — if anyone reaches the github.io URL directly while GH Pages is mid-rebuild, the inline JS still bounces them to the canonical `ai-watch.dev/reports/` location.

## Test plan

- [ ] After merge: `curl -sI https://bentleypark.github.io/aiwatch-reports/2026-03/` returns 200 (no longer 301)
- [ ] After merge: `curl -sI https://ai-watch.dev/reports/2026-03/` still returns 200 (Vercel proxy works without the redirect chain)
- [ ] Operator: Cloudflare DNS — toggle `reports` CNAME proxy to "Proxied" (orange cloud)
- [ ] Operator: Cloudflare Rules → Page Rules → `reports.ai-watch.dev/*` → Forwarding URL 301 → `https://ai-watch.dev/reports/$1`
- [ ] After Cloudflare: `curl -sI https://reports.ai-watch.dev/2026-03/` returns 301 with `location: https://ai-watch.dev/reports/2026-03/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)