### PR TITLE
fix: GA4 consent gate + inline cookie banner (refs aiwatch#352)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -47,3 +47,20 @@ document.addEventListener('click', function(e) {
   }
 });
 </script>
+<!-- #352 Inline cookie banner — hand-synced byte-for-byte with COOKIE_BANNER_HTML from
+     api/_shared/cookie-banner.ts in the main repo (Jekyll cannot import TS). Writes the same
+     aiwatch-cookie-consent localStorage key as the SPA + Edge SSR. Shown only when the key
+     is absent. Origin behavior: when reached via the proxy at ai-watch.dev/reports/* the
+     localStorage is shared with the dashboard so a user who already consented there will
+     not see this banner; when reached directly at bentleypark.github.io/aiwatch-reports/*
+     the origin differs and the banner shows independently. Accept-failure handling: if
+     localStorage.setItem throws, the Accept branch returns without upgrading consent and
+     without hiding the banner — see api/_shared/cookie-banner.ts for the full rationale. -->
+<div id="aiwatch-cookie-banner" hidden role="dialog" aria-label="Cookie consent" aria-live="polite">
+<div class="aiwatch-cb-inner">
+<div class="aiwatch-cb-text"><strong>Cookie Notice</strong><p>AIWatch uses Google Analytics cookies to improve the service. Only anonymous usage statistics are collected. <a href="https://ai-watch.dev/" rel="noopener">Open dashboard</a> to review later.</p></div>
+<div class="aiwatch-cb-actions"><button type="button" data-aiwatch-cb="essential">Essential Only</button><button type="button" data-aiwatch-cb="accept">Accept All</button></div>
+</div>
+</div>
+<style>#aiwatch-cookie-banner{position:fixed;bottom:0;left:0;right:0;z-index:9999;background:#0d1117;color:#e6edf3;border-top:1px solid #30363d;padding:14px 20px;font-family:system-ui,-apple-system,sans-serif;font-size:12px;line-height:1.5;box-shadow:0 -4px 16px rgba(0,0,0,.3)}#aiwatch-cookie-banner[hidden]{display:none}#aiwatch-cookie-banner .aiwatch-cb-inner{max-width:900px;margin:0 auto;display:flex;flex-wrap:wrap;align-items:center;gap:12px 20px;justify-content:space-between}#aiwatch-cookie-banner strong{display:block;font-size:13px;font-weight:600;margin-bottom:4px;color:#e6edf3}#aiwatch-cookie-banner p{margin:0;color:#9ba3ad;font-size:11px}#aiwatch-cookie-banner a{color:#3fb950;text-decoration:none}#aiwatch-cookie-banner .aiwatch-cb-actions{display:flex;gap:8px;flex-shrink:0}#aiwatch-cookie-banner button{padding:7px 14px;border-radius:4px;font-size:11px;font-family:inherit;cursor:pointer;border:1px solid transparent}#aiwatch-cookie-banner button[data-aiwatch-cb=essential]{background:transparent;color:#c9d1d9;border-color:#30363d}#aiwatch-cookie-banner button[data-aiwatch-cb=essential]:hover{color:#e6edf3;border-color:#484f58}#aiwatch-cookie-banner button[data-aiwatch-cb=accept]{background:#3fb950;color:#0d1117;font-weight:600}#aiwatch-cookie-banner button[data-aiwatch-cb=accept]:hover{opacity:.9}@media(max-width:520px){#aiwatch-cookie-banner{padding:12px 14px}#aiwatch-cookie-banner .aiwatch-cb-inner{flex-direction:column;align-items:stretch}#aiwatch-cookie-banner .aiwatch-cb-actions{justify-content:flex-end}}</style>
+<script>(function(){var K='aiwatch-cookie-consent',b=document.getElementById('aiwatch-cookie-banner');if(!b)return;var s=null;try{s=localStorage.getItem(K)}catch(err){}if(s===null)b.hidden=false;function clr(){var h=location.hostname,EXP='expires=Thu, 01 Jan 1970 00:00:00 GMT';document.cookie.split(';').forEach(function(c){var n=c.split('=')[0].trim();if(n.indexOf('_ga')===0||n.indexOf('_gid')===0||n.indexOf('_gcl_au')===0){document.cookie=n+'=;'+EXP+';path=/;domain=.'+h+';SameSite=Lax';document.cookie=n+'=;'+EXP+';path=/;domain='+h+';SameSite=Lax';document.cookie=n+'=;'+EXP+';path=/;SameSite=Lax'}})}b.addEventListener('click',function(e){var t=e.target.closest('[data-aiwatch-cb]');if(!t)return;var a=t.getAttribute('data-aiwatch-cb'),stored=false;try{localStorage.setItem(K,a==='accept'?'granted':'denied');stored=true}catch(err){}if(a==='accept'){if(!stored)return;if(window.gtag)gtag('consent','update',{analytics_storage:'granted'})}else{if(window.gtag)gtag('consent','update',{analytics_storage:'denied',ad_storage:'denied',ad_user_data:'denied',ad_personalization:'denied'});clr()}b.hidden=true})})();</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,7 +15,15 @@
   <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
   {%- feed_meta -%}
   <link rel="icon" type="image/png" href="{{ '/assets/logo.png' | relative_url }}">
-  <!-- GA4 -->
+  <!-- GA4 — Hand-synced byte-for-byte with CONSENT_INIT_SCRIPT from
+       api/_shared/consent-init.ts in the main repo (Jekyll cannot import TS). Honors prior
+       consent set on the SPA via the aiwatch-cookie-consent localStorage key (#352). When
+       the value is anything other than 'granted', also clears any legacy `_ga`/`_gid`/`_gcl_au`
+       cookies left over from before this gate landed. Cookieless pings still flow for
+       aggregate measurement, but no analytics or ad cookies persist. The
+       `bentleypark.github.io/aiwatch-reports/*` direct-access path runs on a different origin
+       so SPA-set consent isn't readable there; that surface stays cookieless until first
+       consent is given on the GH Pages origin itself. -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-D4ZWVHQ7JK"></script>
-  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-D4ZWVHQ7JK');</script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('consent','default',{analytics_storage:'denied',ad_storage:'denied',ad_user_data:'denied',ad_personalization:'denied'});var c='';try{c=localStorage.getItem('aiwatch-cookie-consent');}catch(err){}if(c==='granted'){gtag('consent','update',{analytics_storage:'granted'});}else{var h=location.hostname,EXP='expires=Thu, 01 Jan 1970 00:00:00 GMT';document.cookie.split(';').forEach(function(x){var n=x.split('=')[0].trim();if(n.indexOf('_ga')===0||n.indexOf('_gid')===0||n.indexOf('_gcl_au')===0){document.cookie=n+'=;'+EXP+';path=/;domain=.'+h+';SameSite=Lax';document.cookie=n+'=;'+EXP+';path=/;domain='+h+';SameSite=Lax';document.cookie=n+'=;'+EXP+';path=/;SameSite=Lax';}});}gtag('config','G-D4ZWVHQ7JK');</script>
 </head>


### PR DESCRIPTION
## Summary

Fix GDPR/ePrivacy compliance gap on the Jekyll-served reports site — GA4 fired unconditionally on every page view, ignoring the user's consent state. Refs [aiwatch#352](https://github.com/bentleypark/aiwatch/issues/352).

- **`_includes/head.html`** — Consent Mode v2 default-denied (`analytics_storage` + all three ad signals), upgrades only `analytics_storage` to `'granted'` when `localStorage.aiwatch-cookie-consent === 'granted'`. Otherwise clears any legacy `_ga` / `_gid` / `_gcl_au` cookies under all three scope variants.
- **`_includes/footer.html`** — Inline cookie banner mirroring `src/components/CookieBanner.jsx` UX/copy. Same `aiwatch-cookie-consent` localStorage key. Accept-failure handling: if `localStorage.setItem` throws, the Accept branch returns without upgrading consent and without hiding the banner — prevents single-page-view consent leak.

Both inline payloads are hand-synced byte-for-byte with the canonical shared modules in the main repo (`api/_shared/consent-init.ts` + `api/_shared/cookie-banner.ts`) — see header comments for the sync contract.

## Test plan

- [x] `ai-watch.dev/reports/*` (proxied) honors consent set on the dashboard (same origin → localStorage shared)
- [x] `bentleypark.github.io/aiwatch-reports/*` (direct) shows banner independently (different origin)
- [x] Consent denied/absent → no `_ga` cookie set, any `g/collect` ping carries `gcs=G1*` denied marker
- [x] Consent granted → GA4 fires normally
- [x] Accept-failure → banner stays visible, no consent upgrade fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)