### PR TITLE
chore: bump service count to 33 — Cerebras Inference added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AIWatch Monthly Reports
 
-> Monthly AI service reliability reports covering uptime, incidents, and performance across 32 major AI services.
+> Monthly AI service reliability reports covering uptime, incidents, and performance across 33 major AI services.
 
 **Live site**: [ai-watch.dev/reports](https://ai-watch.dev/reports/) (served via Vercel rewrite; legacy `reports.ai-watch.dev` self-redirects to the canonical path — #264)
 **Data source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
@@ -29,12 +29,12 @@ Each monthly report includes:
 
 ## Methodology
 
-- **32 services monitored**: 14 LLM APIs, 9 voice & inference, 3 AI apps, 6 coding agents
+- **33 services monitored**: 15 LLM APIs, 9 voice & inference, 3 AI apps, 6 coding agents
 - **Data sources**: Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, AWS Health Dashboard, Azure Status RSS, OnlineOrNot
 - **AIWatch Score**: Weighted composite of uptime (40pts), incident affected days (25pts), recovery time (15pts), and probe-based responsiveness (20pts). Services without probe data use 80→100 score redistribution.
 - **Uptime figures**: Official status page metrics — single primary component basis where available, platform-wide average otherwise
 - **Incident counts**: Per-component aggregation — some providers (e.g., Anthropic) report per model, so counts may exceed distinct outages
-- **API probe**: Direct RTT measurement every 5 minutes to 19 services with public endpoints (supplementary monitoring data)
+- **API probe**: Direct RTT measurement every 5 minutes to 20 services with public endpoints (supplementary monitoring data)
 
 Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
 
@@ -70,7 +70,7 @@ After generation, fill in the narrative sections (`Summary`, `Recommendations`, 
 
 ## About AIWatch
 
-AIWatch is an AI service status monitoring dashboard that aggregates real-time status from 32 major AI services.
+AIWatch is an AI service status monitoring dashboard that aggregates real-time status from 33 major AI services.
 
 - **Live dashboard**: [ai-watch.dev](https://ai-watch.dev)
 - **Source code**: [github.com/bentleypark/aiwatch](https://github.com/bentleypark/aiwatch) (AGPL-3.0)

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: AIWatch Reports
-description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 32 AI services
+description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 33 AI services
 baseurl: "/reports"
 url: https://ai-watch.dev
 theme: minima

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "[MON] [YEAR] AI Reliability Report"
-description: "Monthly reliability report for 32 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
+description: "Monthly reliability report for 33 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
 date: [YYYY-MM-DD]
 published: true
 ---
@@ -9,7 +9,7 @@ published: true
 > **Source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
 > **Period**: [MONTH] 1–[LAST_DAY], [YEAR]
 > **Published**: [PUBLISH_MONTH] [YEAR]
-> **Services monitored**: 32 — 23 API services, 6 coding agents, 3 AI apps
+> **Services monitored**: 33 — 24 API services, 6 coding agents, 3 AI apps
 
 ## Summary
 
@@ -121,7 +121,7 @@ Combines four components — Uptime (40%), Incident affected days (25%), Recover
 These p75 figures are the input to the **Responsiveness** component (20% weight) of [AIWatch Score](#aiwatch-score--[month]-[year]-reliability-rankings). Lower is better. The two tables answer different questions: Score Rankings sorts by *which service is safest to rely on* (combining uptime, incidents, recovery, and responsiveness); this table sorts by *which service is fastest at the network layer*.
 
 <!-- Data source: curl https://api.ai-watch.dev/api/probe/history?days=30 -->
-<!-- 19 probe-covered API services. Non-probe services (Bedrock, Azure OpenAI, Pinecone) excluded. -->
+<!-- 20 probe-covered API services. Non-probe services (Bedrock, Azure OpenAI, Pinecone) excluded. -->
 <!-- p95 + Spikes are present in probe:daily:{date} (CLAUDE.md KV schema) but not yet
      surfaced by /api/report. vs-Last-Month additionally requires reading the previous
      month's archive:monthly:* and computing deltas. Re-add the columns once the
@@ -258,7 +258,7 @@ Actionable takeaways per service. Descriptive context for each event lives in ea
 ## About This Report
 
 * **Data Sources:** Real-time data is aggregated from official status pages via multiple frameworks, including Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, OnlineOrNot, and RSS feeds (Source: [ai-watch.dev](https://ai-watch.dev)).
-* **Monitoring Frequency:** All 32 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
+* **Monitoring Frequency:** All 33 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
 * **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). Services without probe data use 80→100 score redistribution **plus a 5% penalty** to reflect the missing responsiveness signal. Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
 * **Uptime Source:** *Official* = service publishes a rolling 30-day uptime metric AIWatch reads directly. *Estimate* = no official metric; AIWatch substitutes an industry-average assumption (99.5%) or its own poll-derived figure for the Score's Uptime input. *Partial (Nd)* = an official source exists but AIWatch's measurement window is shorter than the full month (e.g. service newly tracked mid-month). The label only describes the Uptime input quality — the Score itself is computed identically across all services.
 * **Incident Counting:** Incident counts reflect all affected components per service. Providers differ in reporting granularity — Anthropic reports per-model incidents (Opus/Sonnet/Haiku each counted separately), while others report at the service level.

--- a/index.md
+++ b/index.md
@@ -1,10 +1,10 @@
 ---
 layout: home
 title: AIWatch Monthly Reports
-description: "Monthly AI service incident reports covering 32 AI services — uptime, incidents, and reliability rankings."
+description: "Monthly AI service incident reports covering 33 AI services — uptime, incidents, and reliability rankings."
 ---
 
-Monthly AI service incident reports covering 32 AI services monitored by [AIWatch](https://ai-watch.dev).
+Monthly AI service incident reports covering 33 AI services monitored by [AIWatch](https://ai-watch.dev).
 
 ## Reports
 

--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -47,7 +47,7 @@ function escapeXml(s) {
 const ID_TO_NAME = {
   claude: 'Claude API', openai: 'OpenAI API', gemini: 'Gemini API',
   mistral: 'Mistral API', cohere: 'Cohere API', groq: 'Groq Cloud',
-  together: 'Together AI', fireworks: 'Fireworks AI',
+  together: 'Together AI', fireworks: 'Fireworks AI', cerebras: 'Cerebras Inference',
   perplexity: 'Perplexity', huggingface: 'Hugging Face',
   replicate: 'Replicate', elevenlabs: 'ElevenLabs', xai: 'xAI (Grok)',
   deepseek: 'DeepSeek API', openrouter: 'OpenRouter', bedrock: 'Amazon Bedrock',
@@ -65,7 +65,7 @@ const CATEGORY_ORDER = [
   'claudeai', 'chatgpt', 'characterai',
   // LLM API
   'claude', 'openai', 'gemini', 'bedrock', 'azureopenai', 'mistral', 'cohere', 'groq',
-  'together', 'fireworks', 'perplexity', 'xai', 'deepseek', 'openrouter',
+  'together', 'fireworks', 'cerebras', 'perplexity', 'xai', 'deepseek', 'openrouter',
   // Voice & Inference
   'elevenlabs', 'assemblyai', 'deepgram', 'huggingface', 'replicate', 'pinecone',
   'stability', 'voyageai', 'modal',
@@ -304,7 +304,7 @@ if (require.main === module) {
         if (history[key]) { lastDataDay = d; break }
       }
 
-      // Use all 32 services in category order (not just incident table)
+      // Use all 33 services in category order (not just incident table)
       const serviceNames = CATEGORY_ORDER.map(id => ID_TO_NAME[id]).filter(Boolean)
 
       const heatmapSvg = generateUptimeHeatmapSvg(serviceNames, history, daysInMonth, monthKey, monitoringStartDay, lastDataDay)


### PR DESCRIPTION
## Summary

AIWatch added a new monitored service — **Cerebras Inference** (LLM inference API; aiwatch#391). This bumps the aiwatch-reports site to match:

- Service count `32 → 33` — `README.md`, `index.md`, `_config.yml`, `_templates/monthly-report.md` (incl. `> Services monitored: 33 — 24 API services, 6 coding agents, 3 AI apps`)
- LLM-API sub-count `14 → 15` in the README methodology breakdown (Cerebras is an LLM API)
- Probe coverage `19 → 20` (main repo added a probe target for Cerebras)
- `scripts/generate-charts.js` — `cerebras: 'Cerebras Inference'` added to `ID_TO_NAME`, `'cerebras'` added to `CATEGORY_ORDER` after `'fireworks'` (matches dashboard display order); `// all 32 services` comment → 33

Historical reports `2026-03/`, `2026-04/` and their `_data/*.json` snapshots are intentionally left unchanged — they reflect the roster monitored in those months.

refs aiwatch#391 — part of the "Adding a new service" checklist (items 22–27).

## Test plan

- [x] Arithmetic consistent: `33 = 24 API + 6 agents + 3 apps`; `24 API = 15 LLM + 9 voice & inference`
- [x] `node --check scripts/generate-charts.js` clean; `cerebras` placed correctly in `CATEGORY_ORDER` (byte-for-byte matches the main repo's `SERVICE_AND_APP_IDS` LLM section)
- [x] Repo-wide grep — no remaining stale `32` / `23 API` / `19 probe` / `14 LLM` references (excluding the historical `2026-0[34]` reports + `_data/`)
- [x] `code-reviewer` agent — 0 Critical, 0 Important
- [ ] After merge: GitHub Pages auto-builds; spot-check ai-watch.dev/reports/ renders "33"

🤖 Generated with [Claude Code](https://claude.com/claude-code)