### PR TITLE
feat: render AI retrospective narrative into the report (closes #4)

### DIFF
--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -615,6 +615,104 @@ function applyAutoDraft(filled, archive, meta, month, summaryMod = summary) {
   }
 }
 
+// ── AI retrospective narrative injection (refs aiwatch-reports#4 Phase 3) ──
+//
+// The Worker bakes an AI-generated retrospective draft into the archive at
+// build time — `archive.narrative` (shape: MonthlyNarrativeDraft from
+// worker/src/monthly-narrative.ts, refs aiwatch#426). This renders it into the
+// Notable Incidents + Observations sections as fenced auto-draft blocks, the
+// same operator-review pattern as the Summary/Key Insight injection above.
+//
+// Forward-compatible: archives written before aiwatch#426 (or months where AI
+// generation failed) carry no `narrative` / `narrative: null` — injection is a
+// no-op and the report keeps its hand-written placeholders.
+//
+// Each section gets its own marker pair so the idempotency guard is per-block
+// and an operator deleting one fence doesn't disturb the other.
+
+const NOTABLE_OPEN_MARKER = '<!-- BEGIN AUTO-DRAFT (Notable Incidents) — review, adapt into the entries below, then DELETE this entire block before merge -->'
+const NOTABLE_CLOSE_MARKER = '<!-- END AUTO-DRAFT (Notable Incidents) -->'
+const OBSERVATIONS_OPEN_MARKER = '<!-- BEGIN AUTO-DRAFT (Observations) — review, adapt into the bullets below, then DELETE this entire block before merge -->'
+const OBSERVATIONS_CLOSE_MARKER = '<!-- END AUTO-DRAFT (Observations) -->'
+
+// Render the Notable Incidents draft body: each AI-drafted incident as a ready
+// `### N.` entry matching the template's structure, so the operator can lift
+// entries directly. `e` fields come straight from MonthlyNarrativeDraft.
+//
+// Defensive against malformed elements: the Worker's parseMonthlyNarrative
+// already validates incident rows, but the data crosses a KV JSON round-trip
+// and a manual workflow_dispatch — a hand-edited / partially-written archive is
+// reachable. Skip rows missing the load-bearing `title` / `narrative` fields
+// (same rule as the Worker's own validator) rather than emitting the literal
+// string "undefined" into the published report. Returns null when nothing
+// valid remains — the caller treats null as "skip this section".
+function buildNotableIncidentsDraft(notableIncidents, model) {
+  const valid = notableIncidents.filter(
+    e => e && typeof e.title === 'string' && typeof e.narrative === 'string',
+  )
+  if (valid.length === 0) return null
+  const entries = valid.map((e, i) => [
+    `### ${i + 1}. ${e.title}`,
+    `**Affected**: ${typeof e.affected === 'string' && e.affected ? e.affected : '—'}`,
+    `**Duration**: ${typeof e.durationLabel === 'string' && e.durationLabel ? e.durationLabel : '—'}`,
+    '',
+    e.narrative,
+  ].join('\n'))
+  return [
+    NOTABLE_OPEN_MARKER,
+    `_Auto-generated retrospective draft (${model}) — review for accuracy, adapt, then delete this block._`,
+    '',
+    entries.join('\n\n'),
+    '',
+    NOTABLE_CLOSE_MARKER,
+  ].join('\n')
+}
+
+// Same defensive contract as buildNotableIncidentsDraft — keep only string
+// observations, return null when none remain.
+function buildObservationsDraft(observations, model) {
+  const valid = observations.filter(o => typeof o === 'string' && o.trim().length > 0)
+  if (valid.length === 0) return null
+  return [
+    OBSERVATIONS_OPEN_MARKER,
+    `_Auto-generated retrospective draft (${model}) — review, adapt into prescriptive bullets, then delete this block._`,
+    '',
+    valid.map(o => `- ${o}`).join('\n'),
+    '',
+    OBSERVATIONS_CLOSE_MARKER,
+  ].join('\n')
+}
+
+// Inject the archive's AI narrative into Notable Incidents + Observations.
+// Returns `filled` unchanged when there's nothing to inject (no narrative,
+// malformed narrative, or empty sections) — never throws.
+function injectNarrativeDraft(filled, narrative) {
+  // Forward-compat + failure isolation: null/absent/malformed → no-op.
+  if (!narrative || typeof narrative !== 'object') return filled
+  const model = typeof narrative.model === 'string' ? narrative.model : 'AI'
+  let out = filled
+
+  // Notable Incidents — insert the fenced block right after the heading.
+  // `^## Notable Incidents$` (m flag) anchors the line so we don't splice into
+  // any other heading. Idempotency: skip if the block is already present.
+  const incidents = Array.isArray(narrative.notableIncidents) ? narrative.notableIncidents : []
+  if (incidents.length > 0 && !out.includes(NOTABLE_OPEN_MARKER)) {
+    const block = buildNotableIncidentsDraft(incidents, model)
+    // block is null when every candidate row was malformed — skip rather than
+    // splice an empty fence.
+    if (block) out = out.replace(/^## Notable Incidents$/m, `## Notable Incidents\n\n${block}`)
+  }
+
+  // Observations — same pattern.
+  const observations = Array.isArray(narrative.observations) ? narrative.observations : []
+  if (observations.length > 0 && !out.includes(OBSERVATIONS_OPEN_MARKER)) {
+    const block = buildObservationsDraft(observations, model)
+    if (block) out = out.replace(/^## Observations$/m, `## Observations\n\n${block}`)
+  }
+
+  return out
+}
+
 // ── Main ─────────────────────────────────────────────────────────────
 async function main() {
   const month = parseCliMonth(process.argv)
@@ -636,9 +734,30 @@ async function main() {
   // Auto-draft narrative is best-effort — never blocks the deterministic data pipeline.
   // applyAutoDraft swallows analyzer/parsing failures (logs `console.warn`, returns
   // `filled` unchanged); see its docstring above for the contract.
-  const withDraft = applyAutoDraft(filled, archive, meta, month)
+  let withDraft = applyAutoDraft(filled, archive, meta, month)
   if (withDraft !== filled) {
     console.log('[generate-report] Injected auto-draft narrative (Opening → Key Insight; TL;DR → Summary).')
+  }
+
+  // AI retrospective narrative (aiwatch#426) — render archive.narrative into the
+  // Notable Incidents + Observations sections. No-op when the archive carries no
+  // narrative (pre-feature months / AI-failed builds). Wrapped defensively so a
+  // malformed narrative can't break the report write.
+  try {
+    const beforeNarrative = withDraft
+    withDraft = injectNarrativeDraft(withDraft, archive.narrative)
+    if (withDraft !== beforeNarrative) {
+      console.log('[generate-report] Injected AI retrospective draft (Notable Incidents + Observations).')
+    } else if (!archive.narrative) {
+      console.log('[generate-report] No archive.narrative — Notable Incidents / Observations keep their placeholders.')
+    } else {
+      // narrative is a truthy object but produced no injection — empty sections,
+      // non-array fields, or every candidate row malformed. Surface it: a garbage
+      // narrative from the Worker should be visible, not silently swallowed.
+      console.warn('[generate-report] archive.narrative present but yielded no injection (empty or malformed) — sections keep their placeholders.')
+    }
+  } catch (err) {
+    console.warn('[generate-report] Narrative injection failed (continuing without it):', err instanceof Error ? err.message : err)
   }
 
   const outDir = path.join(OUT_DIR_ROOT, month)
@@ -685,6 +804,13 @@ module.exports = {
   injectAutoDraft,
   archiveToAnalysisRows,
   applyAutoDraft,
+  injectNarrativeDraft,
+  buildNotableIncidentsDraft,
+  buildObservationsDraft,
   SUMMARY_OPEN_MARKER,
   SUMMARY_CLOSE_MARKER,
+  NOTABLE_OPEN_MARKER,
+  NOTABLE_CLOSE_MARKER,
+  OBSERVATIONS_OPEN_MARKER,
+  OBSERVATIONS_CLOSE_MARKER,
 }

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -852,5 +852,185 @@ test('full pipeline against real April archive — Opening reflects 24 of 31, no
     'fillTemplate should have consumed the security placeholder; injectAutoDraft must leave that intact')
 })
 
+// ── injectNarrativeDraft (refs aiwatch-reports#4 Phase 3 / aiwatch#426) ──
+//
+// Renders archive.narrative (AI retrospective draft baked in by the Worker)
+// into the Notable Incidents + Observations sections as fenced auto-draft
+// blocks. Must be forward-compatible: archives without `narrative` keep their
+// placeholders untouched.
+
+const {
+  injectNarrativeDraft,
+  buildNotableIncidentsDraft,
+  buildObservationsDraft,
+  NOTABLE_OPEN_MARKER,
+  NOTABLE_CLOSE_MARKER,
+  OBSERVATIONS_OPEN_MARKER,
+  OBSERVATIONS_CLOSE_MARKER,
+} = require('./generate-report')
+
+console.log('\ninjectNarrativeDraft')
+
+const NARRATIVE_FILLED = [
+  '## Incident Summary',
+  '',
+  '<tbody></tbody>',
+  '',
+  '## Notable Incidents',
+  '',
+  '<!-- Top 5-6 notable incidents -->',
+  '',
+  '### 1. [Title]',
+  '',
+  '## Observations',
+  '',
+  'Actionable takeaways per service.',
+  '',
+  '- **If you build on [Service]**:',
+  '',
+  '## Security Alerts',
+].join('\n')
+
+const SAMPLE_NARRATIVE = {
+  model: 'gemma',
+  generatedAt: '2026-06-01T00:05:00Z',
+  notableIncidents: [
+    { service: 'Gemini API', title: 'Vertex API key issue', affected: 'Gemini API — EU', durationLabel: '10 days', narrative: 'A key-rotation bug degraded Vertex auth.' },
+    { service: 'Deepgram', title: 'Voice agent degradation', affected: 'Deepgram streaming', durationLabel: '74h', narrative: 'Streaming endpoints saw elevated latency.' },
+  ],
+  observations: [
+    'Prefer Claude for latency-sensitive workloads this month.',
+    'Treat Deepgram streaming as fallback-only until the fix is confirmed.',
+  ],
+}
+
+test('returns filled unchanged when narrative is null/undefined (forward-compat)', () => {
+  eq(injectNarrativeDraft(NARRATIVE_FILLED, null), NARRATIVE_FILLED)
+  eq(injectNarrativeDraft(NARRATIVE_FILLED, undefined), NARRATIVE_FILLED)
+})
+
+test('returns filled unchanged when narrative is not an object (malformed)', () => {
+  eq(injectNarrativeDraft(NARRATIVE_FILLED, 'oops'), NARRATIVE_FILLED)
+  eq(injectNarrativeDraft(NARRATIVE_FILLED, 42), NARRATIVE_FILLED)
+})
+
+test('injects Notable Incidents block after the heading with each incident as a ### entry', () => {
+  const out = injectNarrativeDraft(NARRATIVE_FILLED, SAMPLE_NARRATIVE)
+  assert.ok(out.includes(NOTABLE_OPEN_MARKER), 'notable open marker present')
+  assert.ok(out.includes(NOTABLE_CLOSE_MARKER), 'notable close marker present')
+  // Both incidents rendered, with their fields.
+  assert.ok(out.includes('### 1. Vertex API key issue'), 'incident 1 heading')
+  assert.ok(out.includes('### 2. Voice agent degradation'), 'incident 2 heading')
+  assert.ok(out.includes('**Affected**: Gemini API — EU'))
+  assert.ok(out.includes('**Duration**: 10 days'))
+  assert.ok(out.includes('A key-rotation bug degraded Vertex auth.'))
+  // Block sits inside ## Notable Incidents — before ## Observations.
+  const notableIdx = out.indexOf(NOTABLE_OPEN_MARKER)
+  const obsHeadingIdx = out.indexOf('## Observations')
+  const notableHeadingIdx = out.indexOf('## Notable Incidents')
+  assert.ok(notableIdx > notableHeadingIdx && notableIdx < obsHeadingIdx, 'block is inside Notable Incidents section')
+})
+
+test('injects Observations block after the heading with each observation as a bullet', () => {
+  const out = injectNarrativeDraft(NARRATIVE_FILLED, SAMPLE_NARRATIVE)
+  assert.ok(out.includes(OBSERVATIONS_OPEN_MARKER), 'observations open marker present')
+  assert.ok(out.includes(OBSERVATIONS_CLOSE_MARKER), 'observations close marker present')
+  assert.ok(out.includes('- Prefer Claude for latency-sensitive workloads this month.'))
+  assert.ok(out.includes('- Treat Deepgram streaming as fallback-only until the fix is confirmed.'))
+})
+
+test('does not touch ## Incident Summary (substring overlap with "Incidents")', () => {
+  // `^## Notable Incidents$` line-anchored — must NOT splice into `## Incident Summary`.
+  const out = injectNarrativeDraft(NARRATIVE_FILLED, SAMPLE_NARRATIVE)
+  const incSummaryBlock = out.slice(out.indexOf('## Incident Summary'), out.indexOf('## Notable Incidents'))
+  assert.ok(!incSummaryBlock.includes(NOTABLE_OPEN_MARKER), 'Incident Summary section untouched')
+})
+
+test('preserves the template placeholders below each injected block (operator fills them)', () => {
+  const out = injectNarrativeDraft(NARRATIVE_FILLED, SAMPLE_NARRATIVE)
+  assert.ok(out.includes('### 1. [Title]'), 'Notable Incidents placeholder retained')
+  assert.ok(out.includes('- **If you build on [Service]**:'), 'Observations placeholder retained')
+})
+
+test('model label appears in the draft attribution line', () => {
+  const out = injectNarrativeDraft(NARRATIVE_FILLED, SAMPLE_NARRATIVE)
+  assert.ok(out.includes('(gemma)'), 'gemma model attribution shown')
+})
+
+test('injects only Observations when notableIncidents is empty', () => {
+  const obsOnly = { model: 'sonnet', notableIncidents: [], observations: ['Use X.'] }
+  const out = injectNarrativeDraft(NARRATIVE_FILLED, obsOnly)
+  assert.ok(!out.includes(NOTABLE_OPEN_MARKER), 'no notable block when incidents empty')
+  assert.ok(out.includes(OBSERVATIONS_OPEN_MARKER), 'observations block present')
+})
+
+test('injects only Notable Incidents when observations is empty', () => {
+  const incOnly = { model: 'gemma', notableIncidents: SAMPLE_NARRATIVE.notableIncidents, observations: [] }
+  const out = injectNarrativeDraft(NARRATIVE_FILLED, incOnly)
+  assert.ok(out.includes(NOTABLE_OPEN_MARKER), 'notable block present')
+  assert.ok(!out.includes(OBSERVATIONS_OPEN_MARKER), 'no observations block when empty')
+})
+
+test('handles non-array notableIncidents / observations without crashing', () => {
+  const bad = { model: 'gemma', notableIncidents: 'nope', observations: null }
+  const out = injectNarrativeDraft(NARRATIVE_FILLED, bad)
+  eq(out, NARRATIVE_FILLED, 'malformed arrays → no-op')
+})
+
+test('skips malformed incident elements rather than emitting the string "undefined"', () => {
+  // The Worker's parseMonthlyNarrative validates rows, but a KV round-trip +
+  // manual workflow_dispatch makes a hand-edited / partial archive reachable.
+  // Rows missing the load-bearing title / narrative fields must be dropped, not
+  // rendered as "### 1. undefined".
+  const mixed = {
+    model: 'gemma',
+    notableIncidents: [
+      {},                                                            // all missing → skip
+      { title: 'Has title only' },                                   // missing narrative → skip
+      { service: 'X', title: 'Good one', narrative: 'Real prose.' },  // valid
+    ],
+    observations: [],
+  }
+  const out = injectNarrativeDraft(NARRATIVE_FILLED, mixed)
+  assert.ok(out.includes(NOTABLE_OPEN_MARKER), 'block injected (one valid row remains)')
+  assert.ok(out.includes('### 1. Good one'), 'valid row rendered')
+  assert.ok(!out.includes('undefined'), 'no literal "undefined" leaked into the report')
+  // Soft fields absent on the valid row → em-dash fallback, not "undefined".
+  assert.ok(out.includes('**Affected**: —'), 'missing affected falls back to em-dash')
+  assert.ok(out.includes('**Duration**: —'), 'missing durationLabel falls back to em-dash')
+})
+
+test('skips the Notable Incidents section entirely when every incident row is malformed', () => {
+  const allBad = { model: 'gemma', notableIncidents: [{}, { title: 'no narrative' }], observations: [] }
+  const out = injectNarrativeDraft(NARRATIVE_FILLED, allBad)
+  assert.ok(!out.includes(NOTABLE_OPEN_MARKER), 'no fence when zero valid rows')
+  assert.ok(!out.includes('undefined'), 'no "undefined" leak')
+  eq(out, NARRATIVE_FILLED, 'whole-doc no-op when nothing valid')
+})
+
+test('filters non-string / empty observations rather than rendering "- null" / "- 42"', () => {
+  const noisy = { model: 'sonnet', notableIncidents: [], observations: ['real bullet', null, 42, '', '  '] }
+  const out = injectNarrativeDraft(NARRATIVE_FILLED, noisy)
+  assert.ok(out.includes('- real bullet'), 'valid observation rendered')
+  assert.ok(!out.includes('- null') && !out.includes('- 42'), 'non-string observations dropped')
+})
+
+test('idempotent — a second injection does not stack a duplicate fence', () => {
+  const once = injectNarrativeDraft(NARRATIVE_FILLED, SAMPLE_NARRATIVE)
+  const twice = injectNarrativeDraft(once, SAMPLE_NARRATIVE)
+  const notableMarkers = (twice.match(new RegExp(NOTABLE_OPEN_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length
+  const obsMarkers = (twice.match(new RegExp(OBSERVATIONS_OPEN_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length
+  eq(notableMarkers, 1, 'exactly one Notable Incidents fence after double-inject')
+  eq(obsMarkers, 1, 'exactly one Observations fence after double-inject')
+})
+
+test('buildNotableIncidentsDraft / buildObservationsDraft are fenced + carry the model label', () => {
+  const nb = buildNotableIncidentsDraft(SAMPLE_NARRATIVE.notableIncidents, 'sonnet')
+  assert.ok(nb.startsWith(NOTABLE_OPEN_MARKER) && nb.endsWith(NOTABLE_CLOSE_MARKER), 'notable draft fenced')
+  assert.ok(nb.includes('(sonnet)'))
+  const ob = buildObservationsDraft(SAMPLE_NARRATIVE.observations, 'sonnet')
+  assert.ok(ob.startsWith(OBSERVATIONS_OPEN_MARKER) && ob.endsWith(OBSERVATIONS_CLOSE_MARKER), 'observations draft fenced')
+})
+
 console.log(`\n${passed} passed, ${failed} failed`)
 process.exit(failed > 0 ? 1 : 0)

--- a/scripts/preview-narrative.mjs
+++ b/scripts/preview-narrative.mjs
@@ -1,0 +1,128 @@
+// Dev / verification tool — preview the Phase 3 AI-narrative rendering
+// (aiwatch-reports#4 / aiwatch#426) without deploying the Worker or hitting an
+// AI endpoint.
+//
+// Why this exists: the Worker bakes `archive.narrative` into the monthly
+// archive at build time, and `generate-report.js` renders it into the Notable
+// Incidents + Observations sections as fenced auto-draft blocks. Verifying that
+// end-to-end against live data needs a redeployed Worker + an archive rebuild.
+// This script short-circuits that: it splices a sample narrative into a local
+// archive snapshot and runs the real render pipeline, so you can eyeball the
+// operator-facing draft output offline.
+//
+// Usage:
+//   node scripts/preview-narrative.mjs                 # uses _data/2026-04.json
+//   node scripts/preview-narrative.mjs _data/2026-05.json
+//
+// The sample narrative is shaped exactly like the Worker's MonthlyNarrativeDraft
+// (worker/src/monthly-narrative.ts) and its content is modeled on the published
+// 2026-04 Notable Incidents, so the preview is faithful to a populated archive.
+// Note: real archives written before aiwatch#426 carry no `narrative` field —
+// against those, generate-report.js is a no-op and keeps the placeholders;
+// this script injects a sample so there's something to look at.
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
+const require = createRequire(import.meta.url)
+const gr = require(path.join(REPO_ROOT, 'scripts/generate-report.js'))
+
+// Sample narrative — MonthlyNarrativeDraft shape. Content mirrors the real
+// published April 2026 Notable Incidents so the preview reads authentically.
+const SAMPLE_NARRATIVE = {
+  model: 'gemma',
+  generatedAt: '2026-05-01T00:06:00Z',
+  notableIncidents: [
+    {
+      service: 'Gemini API',
+      title: 'Vertex API key rotation issue',
+      affected: 'Gemini API — Vertex (EU + US regions)',
+      durationLabel: '10 days',
+      narrative: 'A key-rotation regression degraded Vertex authentication for ten days (Apr 17–28), the longest single incident of the month. Requests intermittently failed authorization until the rotation pipeline was corrected.',
+    },
+    {
+      service: 'Deepgram',
+      title: 'Voice agent degradation',
+      affected: 'Deepgram streaming endpoints',
+      durationLabel: '74h',
+      narrative: 'Streaming voice-agent endpoints saw sustained elevated latency across roughly 74 hours. Batch transcription was largely unaffected; the degradation was concentrated on the real-time path.',
+    },
+    {
+      service: 'OpenAI API',
+      title: 'Apr 20 error-rate cluster',
+      affected: 'OpenAI API (independent of the ChatGPT incident the same day)',
+      durationLabel: '36h 2m',
+      narrative: 'A 36-hour cluster of elevated API error rates on Apr 20, tracked separately from the same-day ChatGPT outage since they hit independent components.',
+    },
+    {
+      service: 'GitHub Copilot',
+      title: 'Recurring availability incidents',
+      affected: 'GitHub Copilot',
+      durationLabel: '84h 32m',
+      narrative: 'Copilot recorded 26 separate incidents totaling 84h 32m of downtime — the highest incident count of any monitored service this month, pointing to a chronic stability pattern rather than a single event.',
+    },
+  ],
+  observations: [
+    'Prefer Claude or OpenAI for latency-sensitive production workloads — both held high scores with fast recovery.',
+    'Treat Gemini Vertex as fallback-only until the key-rotation fix is confirmed stable across a full month.',
+    "For coding-agent workloads, weight GitHub Copilot's 26-incident pattern heavily — Claude Code and Cursor were materially steadier.",
+  ],
+}
+
+function sectionSlice(md, heading) {
+  const start = md.indexOf(`## ${heading}`)
+  if (start === -1) return `(section "${heading}" not found)`
+  const rest = md.slice(start + heading.length + 3)
+  const next = rest.indexOf('\n## ')
+  return md.slice(start, next === -1 ? undefined : start + heading.length + 3 + next)
+}
+
+function main() {
+  const archiveArg = process.argv[2] ?? '_data/2026-04.json'
+  const archivePath = path.isAbsolute(archiveArg) ? archiveArg : path.join(REPO_ROOT, archiveArg)
+  if (!fs.existsSync(archivePath)) {
+    console.error(`[preview-narrative] archive snapshot not found: ${archivePath}`)
+    process.exit(1)
+  }
+
+  const archive = JSON.parse(fs.readFileSync(archivePath, 'utf-8'))
+  // Period is derived from the snapshot's own `period` field; fall back to the
+  // filename stem (e.g. _data/2026-04.json → 2026-04).
+  const period = archive.period ?? path.basename(archiveArg).replace(/\.json$/, '')
+
+  // Splice in the sample narrative so there's something to render. A real
+  // post-aiwatch#426 archive would already carry `archive.narrative`.
+  if (!archive.narrative) {
+    archive.narrative = SAMPLE_NARRATIVE
+    console.log('[preview-narrative] archive has no narrative — injecting the sample fixture for preview.\n')
+  } else {
+    console.log('[preview-narrative] archive already carries a narrative — previewing it as-is.\n')
+  }
+
+  // Service id → display name. The archive doesn't carry display names; the
+  // Worker passes them from services:latest. Locally, ids are good enough.
+  const meta = {}
+  for (const id of Object.keys(archive.services ?? {})) meta[id] = { name: id }
+
+  const template = fs.readFileSync(path.join(REPO_ROOT, '_templates/monthly-report.md'), 'utf-8')
+
+  let out = gr.fillTemplate(template, period, archive, meta)
+  out = gr.applyAutoDraft(out, archive, meta, period)        // Phase 1: Summary / Key Insight
+  out = gr.injectNarrativeDraft(out, archive.narrative)       // Phase 3: Notable Incidents / Observations
+
+  const outPath = path.join(os.tmpdir(), `${period}-narrative-preview.md`)
+  fs.writeFileSync(outPath, out)
+
+  console.log('═══════════════════════════════════════════════════════════')
+  console.log(`  FULL PREVIEW: ${outPath}`)
+  console.log('═══════════════════════════════════════════════════════════\n')
+  console.log(sectionSlice(out, 'Notable Incidents'))
+  console.log('\n───────────────────────────────────────────────────────────\n')
+  console.log(sectionSlice(out, 'Observations'))
+}
+
+main()


### PR DESCRIPTION
Consumption half of #4 Phase 3. The Worker (aiwatch#426, merged) bakes an AI retrospective draft into `archive.narrative`; `generate-report.js` now renders it into the **Notable Incidents** + **Observations** sections.

## What

- `injectNarrativeDraft(filled, narrative)` — injects two fenced auto-draft blocks (one after `## Notable Incidents`, one after `## Observations`), using the same BEGIN/END marker + operator-review pattern as the Phase 1 Summary/Key Insight injection. Each AI incident renders as a ready `### N.` entry (title / Affected / Duration / narrative) matching the template structure so the operator lifts entries directly. The template's placeholders stay intact below each fence.
- `buildNotableIncidentsDraft` / `buildObservationsDraft` — render the fenced block bodies. Per-section marker pairs → per-block idempotency guard.
- `main()` wires it after `applyAutoDraft`, in a try/catch.

## Forward-compatible

Archives written before aiwatch#426 carry no `narrative` key; months where the Worker's AI call failed carry `narrative: null`. Both → `injectNarrativeDraft` is a no-op, the report keeps its hand-written placeholders. The April 2026 archive (pre-feature) renders exactly as before.

## Defensive against malformed elements (review round 1)

The Worker's `parseMonthlyNarrative` validates rows, but the data crosses a KV JSON round-trip + a manual `workflow_dispatch` — a hand-edited / partially-written archive is reachable. `buildNotableIncidentsDraft` skips rows missing the load-bearing `title`/`narrative` fields and em-dashes absent soft fields, rather than emitting the literal string `"undefined"` into the published report; `buildObservationsDraft` filters non-string observations. Both return `null` when nothing valid remains → the section is skipped, not fenced empty. `main()` warns when `archive.narrative` is present but yields no injection.

## Tests

**107 generate-report cases pass** (+16): forward-compat (null / undefined / non-object), both-sections + single-section injection, `## Incident Summary` non-collision, placeholder preservation, idempotency, and the malformed-element paths (no `"undefined"` / `"- null"` leak, whole-section skip when all rows bad). All 4 `scripts/*.test.js` suites green (charts 24 + report 107 + summary 32 + update-index 18).

PR review converged round 2 — Critical 0 / Important 0. Round 1 found the `"undefined"`-leakage Important; round 2 verified the defensive filtering.

## Operator workflow after this lands

`workflow_dispatch` → draft PR carries the data tables + Phase 1 Summary/TL;DR auto-draft + **now** Notable Incidents + Observations AI drafts (fenced, model-attributed). Operator reviews each draft, adapts into the template structure, deletes the fences, flips `published: true`.

## Scope

`closes #4` — with aiwatch#426 (Worker, merged) + this PR, Phase 3 is delivered end-to-end. Phase 1 + 2 already shipped (#10, #16, #21). The `## Choosing the Right Provider` section stays fully manual by design (editorial judgment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)