### PR TITLE
fix: buildLatencyTable emits only the p75 column (closes #17)

### DIFF
--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -353,12 +353,19 @@ function buildLatencyTable(services, meta) {
   // descending comparator yields "faster = higher rank" and ties get "N=" suffix.
   const ranked = competitionRank(withLatency, s => -s.data.avgLatencyMs)
 
+  // Only p75 (avgLatencyMs) exists in the archive today. The p95 / Spikes / vs-Last-Month
+  // columns were dropped (#17) — they rendered as a literal "—" in every cell, every month.
+  // To re-enable a column: add its field to MonthlyServiceData in the aiwatch worker
+  // (worker/src/monthly-archive.ts), surface it via /api/report, then append it here:
+  //   p95 (ms)      ← s.data.p95LatencyMs
+  //   Spikes        ← s.data.latencySpikes
+  //   vs Last Month ← delta from s.data.prevMonthLatencyMs (or read the prior archive)
   const header = [
-    '| Rank | Service | p75 (ms) | p95 (ms) | Spikes | vs Last Month |',
-    '|---|---|---|---|---|---|',
+    '| Rank | Service | p75 (ms) |',
+    '|---|---|---|',
   ]
   const rows = ranked.map(r =>
-    `| ${r.rankLabel} | ${serviceName(r.item.id, meta)} | ${Math.round(r.item.data.avgLatencyMs)} | — | — | — |`,
+    `| ${r.rankLabel} | ${serviceName(r.item.id, meta)} | ${Math.round(r.item.data.avgLatencyMs)} |`,
   )
   return [...header, ...rows].join('\n')
 }

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -200,6 +200,19 @@ test('sorts by latency asc (fastest first)', () => {
   eq(dataRows.length, 3)
   assert.ok(dataRows[0].includes('Cohere API'), `fastest should be Cohere (230ms): ${dataRows[0]}`)
 })
+test('emits only the p75 column — no empty p95/Spikes/vs-Last-Month placeholders (#17)', () => {
+  const table = buildLatencyTable(sampleServices, sampleMeta)
+  const lines = table.split('\n')
+  eq(lines[0], '| Rank | Service | p75 (ms) |')
+  eq(lines[1], '|---|---|---|')
+  // No row may carry the old 6-column placeholder dashes.
+  assert.ok(!table.includes('| — | — | — |'), 'must not emit empty placeholder columns')
+  // Every data row has exactly 3 cells (4 pipes).
+  const dataRows = lines.filter(l => /^\| \d+/.test(l))
+  for (const row of dataRows) {
+    eq((row.match(/\|/g) || []).length, 4, `row should have 3 columns (4 pipes): ${row}`)
+  }
+})
 test('excludes NO_PROBE services', () => {
   const services = [
     { id: 'bedrock', data: { score: 90, grade: 'excellent', uptime: null, incidents: 0, avgResolutionMin: null, avgLatencyMs: 999 } },


### PR DESCRIPTION
## Summary

`buildLatencyTable()` always emitted 6 columns (`Rank | Service | p75 | p95 | Spikes | vs Last Month`), but the monthly archive only carries `avgLatencyMs` (= p75). The p95 / Spikes / vs-Last-Month cells rendered as a literal `—` in every row, every month — the April 2026 report (PR #14) had to strip them by hand, and `replaceTableBody` was overwriting the template's already-3-column placeholder with the 6-column body.

## Fix
- `buildLatencyTable()` now emits only `| Rank | Service | p75 (ms) |`.
- Comment marker documents which archive field re-enables each dropped column (`p95←p95LatencyMs`, `Spikes←latencySpikes`, `vs Last Month←prevMonthLatencyMs`) — separate aiwatch-worker schema work, out of scope.
- competition-ranking + NO_PROBE filter unchanged.

## Verification
`node scripts/generate-report.js 2026-04` against the live archive → 3-column table, **zero `| — | — | — |` placeholders**, matching the published PR #14 version. (The regenerated `2026-04/index.md` was reverted — generate overwrites it; only the latency table was being verified.)

New test: p75-only header, no placeholder-dashes substring, 3-column (4-pipe) rows. Full suite 108 pass.

## AC coverage
- [x] AC1 — `buildLatencyTable()` emits only p75
- [x] AC5 — re-enable comment marker
- [x] AC4 — `generate-report.js 2026-04` matches PR #14's hand-cleaned table
- [x] AC2/AC3 — "Spike definition" line + "probe-covered" comment were already fixed in `_templates/monthly-report.md`; this closes the generate-report.js side

closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)