### PR TITLE
fix(generator): wire Security Alerts auto-render via SECURITY_SECTION marker (closes #27)

### DIFF
--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -249,49 +249,9 @@ Actionable takeaways per service. Descriptive context for each event lives in ea
 
 ---
 
-## Security Alerts
-
-<!-- Include this section ONLY when the month had security detections. Sources:
-     OSV.dev (AI SDK package vulnerabilities), Hacker News (security posts
-     mentioning monitored services). Section omitted entirely for months
-     without detections. -->
-
-> **Note:** Security alerts captured during the month from OSV.dev (AI SDK package vulnerabilities) and Hacker News (security posts mentioning monitored services). Section omitted for months without detections.
-
-**Total alerts:** <!-- N -->
-
-**By source**
-
-| Source | Count |
-|---|---|
-| OSV.dev | |
-| Hacker News | |
-
-**By severity**
-
-| Critical | High | Medium | Low |
-| --- | --- | --- | --- |
-| | | | |
-
-**Most affected services**
-
-| Service | Count |
-|---|---|
-| | |
-
-### Top Findings
-
-<!-- One block per finding. Surface only Fix Version inline — Stage / At / Severity
-     are already in the heading + Detected line, so a Timeline <details> block
-     would be pure duplication (April 2026 dropped them for that reason). -->
-
-#### 1. [Title with link to advisory] · `severity`
-- **Source:** OSV.dev
-- **Affected:** [Service]
-- **Detected:** [YYYY-MM-DD]
-- **Fix Version:** [version]
-
----
+<!-- SECURITY_SECTION -->
+<!-- ^ Auto-rendered by generate-report.js (buildSecuritySection), which emits the section
+     ending in its own `---` separator (or nothing when there are no detections). Do not hand-author. -->
 
 ## About This Report
 

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -483,14 +483,18 @@ function fillTemplate(template, month, archive, meta) {
     zeroIncLine,
   )
 
-  // Security section — when archive.security is null/empty, collapse the placeholder + its
-  // surrounding blank lines down to a single blank line so the preceding `---` separator
-  // doesn't end up adjacent to a second one (would render as two horizontal rules).
+  // Security section — the template carries `<!-- SECURITY_SECTION -->` plus a one-line
+  // "do not hand-author" comment, placed right after the Observations `---` separator (and
+  // with NO `---` of its own after it). buildSecuritySection emits the whole "## Security
+  // Alerts" section *ending in its own trailing `---`* when archive.security has detections;
+  // when empty it emits nothing, so we strip the marker + comment and let the preceding `---`
+  // stand as the single separator before About. The `(?:---\n*)?` is a guard only — it would
+  // absorb a literal `---` if one were ever placed after the marker (none is today).
   const securityBlock = buildSecuritySection(archive.security)
   if (securityBlock) {
-    out = out.replace(/<!-- SECURITY_SECTION -->/, securityBlock)
+    out = out.replace(/<!-- SECURITY_SECTION -->(?:\n*<!--[\s\S]*?-->)?/, securityBlock)
   } else {
-    out = out.replace(/\n*<!-- SECURITY_SECTION -->\n*/, '\n\n')
+    out = out.replace(/\n*<!-- SECURITY_SECTION -->(?:\n*<!--[\s\S]*?-->)?\n*(?:---\n*)?/, '\n\n')
   }
 
   return out

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -859,10 +859,33 @@ test('full pipeline against real April archive — Opening reflects 24 of 31, no
   const fenceBlock = out.slice(out.indexOf(SUMMARY_OPEN_MARKER), out.indexOf(SUMMARY_CLOSE_MARKER) + SUMMARY_CLOSE_MARKER.length)
   assert.ok(!/undefined/.test(fenceBlock), `auto-draft must not contain literal "undefined"; got: ${fenceBlock.slice(0, 300)}`)
 
-  // The security-section placeholder (or its rendered block) lives at a different
-  // location and is not stripped or broken by injectAutoDraft.
+  // #27 — the Security Alerts section auto-renders from archive.security via the
+  // SECURITY_SECTION marker. (Previously the template shipped a hand-authored block and
+  // NO marker, so buildSecuritySection never fired and every month was filled by hand.)
   assert.ok(!out.includes('<!-- SECURITY_SECTION -->'),
-    'fillTemplate should have consumed the security placeholder; injectAutoDraft must leave that intact')
+    'fillTemplate should consume the SECURITY_SECTION marker')
+  assert.ok(!out.includes('Do not hand-author'),
+    'the marker explainer comment must not leak into the rendered report')
+  assert.ok(out.includes('## Security Alerts'),
+    'April archive has detections → the Security Alerts section must render')
+  assert.ok(new RegExp(`\\*\\*Total alerts:\\*\\* ${archive.security.totalAlerts}\\b`).test(out),
+    'rendered Total alerts must match archive.security.totalAlerts')
+  assert.ok(!/---\s*\n\s*---/.test(out),
+    'no double horizontal rule around the auto-rendered security section')
+})
+
+test('security section omitted with no double `---` when archive.security is null — real template', () => {
+  const archive = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '_data', '2026-04.json'), 'utf-8'))
+  archive.security = null
+  const tmpl = fs.readFileSync(path.join(__dirname, '..', '_templates', 'monthly-report.md'), 'utf-8')
+  const meta = {}
+  for (const id of Object.keys(archive.services)) meta[id] = { name: id }
+  const { fillTemplate } = require('./generate-report')
+  const out = fillTemplate(tmpl, '2026-04', archive, meta)
+  assert.ok(!out.includes('## Security Alerts'), 'no Security section when archive.security is null')
+  assert.ok(!out.includes('<!-- SECURITY_SECTION -->'), 'marker removed on omission')
+  assert.ok(!out.includes('Do not hand-author'), 'explainer comment removed on omission')
+  assert.ok(!/---\s*\n\s*---/.test(out), 'the marker + its separator collapse without leaving a double rule')
 })
 
 // ── injectNarrativeDraft (refs aiwatch-reports#4 Phase 3 / aiwatch#426) ──


### PR DESCRIPTION
## Problem
`scripts/generate-report.js` already had a tested `buildSecuritySection()` that renders the full **## Security Alerts** section and injects it by replacing a `<!-- SECURITY_SECTION -->` marker. But `_templates/monthly-report.md` still shipped a **hand-authored Security block with no marker**, so the builder never fired — every month's Security section had to be filled by hand (e.g. the May report's 18 OSV findings).

## Fix
- **Template**: replace the manual Security block with `<!-- SECURITY_SECTION -->` + a one-line "do not hand-author" comment. Removed the `---` that followed it — `buildSecuritySection` emits its **own** trailing `---` (`generate-report.js:~348`), so keeping both rendered a double horizontal rule.
- **generate-report.js**: the inject/omit regexes now also consume the explainer comment after the marker, and the omit branch absorbs an optional trailing `---`, so a no-detections month doesn't leave a double rule.
- **Tests**: strengthened the real-template integration test (Security renders for April, `Total alerts` matches the archive, no marker/explainer leak, no double `---`) + added an empty-case test (`security = null` → omitted cleanly). **109 passed / 0 failed.**

## Verification
`fillTemplate` against the real template + the **2026-04** archive (which has detections) — data-driven, no month's `index.md` was regenerated/clobbered. Both branches byte-traced to leave exactly one separator. PR review: **0 Critical / 0 Important**.

## Notes
- Does **not** retroactively change `2026-05/index.md` (that report is finalized in #26; regenerating would clobber its hand edits). Future months auto-render the section from `archive.security`.
- Sibling generator issues: #28 (Detection/RTT auto-render), #29 (estimate-only handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)