### PR TITLE
fix(generator): distinguish estimate-only services in Score table + ranking (closes #29)

### DIFF
--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -77,6 +77,8 @@ published: true
 
 Combines four components — Uptime (40%), Incident affected days (25%), Recovery speed (15%), Responsiveness (20%, derived from p75 probe RTT). The per-service p75 RTT figures feeding Responsiveness are listed in the [API Response Time — Monthly p75](#api-response-time--monthly-p75) section below; full breakdown of weights, fallbacks, and penalties is in [About This Report](#about-this-report). [How it's calculated →](https://ai-watch.dev/#about-score)
 
+<!-- SCORE_RANKING_NOTE -->
+
 | Rank | Service | Score | Grade | Uptime Source | Why |
 |---|---|---|---|---|---|
 | 1 | | | | | |
@@ -85,13 +87,6 @@ Combines four components — Uptime (40%), Incident affected days (25%), Recover
 
 <!-- Generate with: node scripts/generate-charts.js [YYYY-MM]/index.md -->
 ![AIWatch Score Rankings](../assets/[YYYY-MM]/score-chart.svg)
-
-<!-- Add this footnote only when the Score table has rows ending with " *" — a trailing
-     asterisk marker for estimate-only services (services that do not publish a rolling
-     30-day uptime metric and instead use an industry-average assumption).
-     Footnote line begins with an escaped asterisk so it doesn't render as a list item:
-*\* Estimate-based services* — [Service A] and [Service B] do not publish accessible uptime metrics; the Uptime component of their score uses an industry-average assumption (99.5%). Score reflects zero observed incidents, not measured availability.
--->
 
 > **Uptime Source column**: **Official** (read directly from the service's status page) · **Estimate** (no official metric; only the Score input is computed — the % itself is not surfaced) · **Partial (Nd)** (service newly tracked mid-month). Full definitions: [About This Report → Uptime Source](#about-this-report).
 > <!-- Cycle-specific notes (e.g. "Codex was added on 22 Apr, mid-month") can be appended after the Partial label. Keep this caption short — full definitions live in the About This Report methodology section to avoid duplication. -->

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -31,11 +31,24 @@ const API_BASE = process.env.AIWATCH_API_BASE || 'https://aiwatch-worker.p2c2kbf
 const TEMPLATE_PATH = path.join(__dirname, '..', '_templates', 'monthly-report.md')
 const OUT_DIR_ROOT = path.join(__dirname, '..')
 
-// Services that do NOT publish an accessible uptime metric — their archive.uptime is null.
-// Keep in sync with the note in _templates/monthly-report.md (Official Uptime section).
+// Services whose uptime is an estimate, not an official rolling-30-day metric read directly
+// from a status page — either no published metric (industry-average assumption) or a
+// poll/incident-derived figure. Marked "Estimate" in the Score table's Uptime Source column
+// and excluded from the Official Uptime table. (#29 — `bedrock` was previously missing here,
+// so it leaked a stray "100.00%" row into the Official Uptime table.)
+// TODO(#29): drive this from an archive `uptimeSource` field once the Worker exposes it
+// (it would also fold in chatgpt's group-aggregate case, tracked separately as aiwatch#586),
+// instead of this maintained constant.
 const NO_PUBLIC_UPTIME = new Set([
-  'azureopenai', 'deepgram', 'gemini', 'mistral', 'perplexity', 'xai',
+  'bedrock', 'azureopenai', 'deepgram', 'gemini', 'mistral', 'perplexity', 'xai',
 ])
+
+// Estimate-uptime services that ALSO have no reliable incident feed (RSS-only — a blank
+// incident count is monitoring coverage, not a verified zero). With neither an accessible
+// uptime metric nor trustworthy incident data there's nothing to score fairly, so they're
+// dropped from the Score ranking entirely. Subset of NO_PUBLIC_UPTIME; matches the 2026-04
+// report's "29 of 31 ranked — Bedrock/Azure excluded" handling.
+const NO_INCIDENT_FEED = new Set(['bedrock', 'azureopenai'])
 
 // Services without direct probe coverage (excluded from API Response Time ranking).
 // Archive.avgLatencyMs will be null for these — tracked for explicit messaging.
@@ -146,10 +159,13 @@ function competitionRank(items, valueFn) {
 
 // ── "Why" text generation for Score Ranking ──────────────────────────
 // Formulaic — intentional. Human editors refine as needed.
-function buildWhy(svc) {
+function buildWhy(svc, id) {
   const { incidents, uptime, avgResolutionMin } = svc.data
   const pieces = []
   if (incidents === 0) {
+    // Estimate-uptime service with zero incidents: there's no comparable 30-day % to cite,
+    // and "Zero incidents, 100% uptime" would overstate what we can actually measure (#29).
+    if (NO_PUBLIC_UPTIME.has(id)) return 'Zero incidents (no published 30-day uptime)'
     pieces.push('Zero incidents')
     if (uptime !== null && uptime !== undefined) pieces.push(`${Number(uptime).toFixed(2)}% uptime`)
   } else if (incidents === 1) {
@@ -171,22 +187,50 @@ function gradeLabel(grade) {
   return grade.charAt(0).toUpperCase() + grade.slice(1)
 }
 
-// Confidence heuristic: High when uptime AND incident data both present; Medium otherwise.
+// Confidence heuristic — High when uptime AND incident data are both present, Medium otherwise.
+// NOTE: no longer shown in the Score table (#29 replaced that column with Uptime Source), but
+// still used by the auto-draft analyzer (generate-summary) to pick high-confidence candidates
+// for the Summary narrative (`r.Confidence === 'High'`). Kept for archiveToAnalysisRows.
 function confidence(svc) {
   if (svc.data.uptime !== null && svc.data.incidents !== null) return 'High'
   return 'Medium'
 }
 
+// Uptime Source label for the Score table: Official (read directly from a status page) vs
+// Estimate (no published 30-day metric; industry-average or poll-derived). #29 replaced the
+// prior "Confidence" column here — it marked estimate-uptime services as "High" and hid that
+// their score rests on an assumed uptime. ("Partial (Nd)" for mid-month additions stays a
+// manual edit; not derivable from the archive yet.)
+function uptimeSourceLabel(id) {
+  return NO_PUBLIC_UPTIME.has(id) ? 'Estimate' : 'Official'
+}
+
+// Ranking-exclusion note (#29). NO_INCIDENT_FEED services have neither an accessible uptime
+// metric nor a reliable incident feed, so they're dropped from the Score ranking and called
+// out above the table. Returns '' when none are excluded (the marker then collapses).
+function buildRankingNote(services, meta) {
+  const scored = services.filter(s => s.data.score !== null)
+  const excluded = scored.filter(s => NO_INCIDENT_FEED.has(s.id))
+  if (excluded.length === 0) return ''
+  const ranked = scored.length - excluded.length
+  const names = excluded.map(s => serviceName(s.id, meta))
+  const nameList = names.length === 2 ? names.join(' and ') : names.join(', ')
+  const verb = excluded.length === 1 ? 'is' : 'are'
+  return `*${ranked} of ${scored.length} services ranked. **${nameList} ${verb} excluded from this ranking** — neither publishes an accessible uptime metric, so their Score would otherwise inherit an industry-average assumption rather than a measured value, and AIWatch has no reliable incident feed for them (see "No incident feed" under [Incident Summary](#incident-summary)).*`
+}
+
 // ── Table builders ───────────────────────────────────────────────────
 function buildScoreTable(services, meta) {
-  const withScore = services.filter(s => s.data.score !== null)
+  // Drop NO_INCIDENT_FEED services (no uptime metric + no reliable incidents) from the ranking;
+  // they're surfaced in the ranking-exclusion note + the Incident Summary "No incident feed" line.
+  const withScore = services.filter(s => s.data.score !== null && !NO_INCIDENT_FEED.has(s.id))
   const ranked = competitionRank(withScore, s => s.data.score)
   const rows = ranked.map(r => {
     const s = r.item
-    return `| ${r.rankLabel} | ${serviceName(s.id, meta)} | ${s.data.score} | ${gradeLabel(s.data.grade)} | ${confidence(s)} | ${buildWhy(s)} |`
+    return `| ${r.rankLabel} | ${serviceName(s.id, meta)} | ${s.data.score} | ${gradeLabel(s.data.grade)} | ${uptimeSourceLabel(s.id)} | ${buildWhy(s, s.id)} |`
   })
   return [
-    '| Rank | Service | Score | Grade | Confidence | Why |',
+    '| Rank | Service | Score | Grade | Uptime Source | Why |',
     '|---|---|---|---|---|---|',
     ...rows,
   ].join('\n')
@@ -205,8 +249,20 @@ function buildIncidentTable(services, meta) {
     return `<tr><td>${serviceName(s.id, meta)}</td><td>${inc}</td><td>${totalWithLongest}</td><td class="hide-mobile">${longest}</td><td class="hide-mobile">${avg}</td></tr>`
   })
 
-  const zeroInc = services.filter(s => s.data.incidents === 0).map(s => serviceName(s.id, meta))
-  const zeroIncLine = `**Zero incidents (${zeroInc.length} services):** ${zeroInc.join(', ')}`
+  // Zero-incident services split (#29): a "confirmed zero" needs a real incident feed.
+  // Estimate-uptime services (NO_PUBLIC_UPTIME) with zero incidents are coverage-limited —
+  // a blank count reflects what AIWatch can see, not verified incident-free operation.
+  const zero = services.filter(s => s.data.incidents === 0)
+  const confirmed = zero.filter(s => !NO_PUBLIC_UPTIME.has(s.id)).map(s => serviceName(s.id, meta))
+  const noFeed = zero.filter(s => NO_PUBLIC_UPTIME.has(s.id)).map(s => serviceName(s.id, meta))
+  const zeroLines = []
+  if (confirmed.length) {
+    zeroLines.push(`**Zero incidents (${confirmed.length} services):** ${confirmed.join(', ')} — confirmed via their status-page incident feeds.`)
+  }
+  if (noFeed.length) {
+    zeroLines.push(`**No incident feed (${noFeed.length} services):** ${noFeed.join(', ')} — AIWatch has no reliable incident feed for these (RSS / estimate-only), so a blank incident count reflects monitoring coverage, not verified incident-free operation.`)
+  }
+  const zeroIncLine = zeroLines.join('\n\n')
 
   return {
     tableRows: rows.join('\n'),
@@ -451,6 +507,7 @@ function fillTemplate(template, month, archive, meta) {
 
   // Build tables
   const scoreTable = buildScoreTable(services, meta)
+  const rankingNote = buildRankingNote(services, meta)
   const { tableRows: incidentRows, zeroIncLine } = buildIncidentTable(services, meta)
   const uptimeRows = buildUptimeTable(services, meta)
   const latencyTable = buildLatencyTable(services, meta)
@@ -472,6 +529,13 @@ function fillTemplate(template, month, archive, meta) {
 
   // Tables
   out = replaceTableBody(out, 'AIWatch Score', scoreTable)
+  // Ranking-exclusion note (#29) — sits above the Score table; collapse the marker when
+  // nothing is excluded so no stray blank line / double rule is left behind.
+  if (rankingNote) {
+    out = out.replace(/<!-- SCORE_RANKING_NOTE -->/, rankingNote)
+  } else {
+    out = out.replace(/\n*<!-- SCORE_RANKING_NOTE -->\n*/, '\n\n')
+  }
   out = replaceTableBody(out, 'API Response Time', latencyTable)
   // Incident Summary + Official Uptime use HTML <tbody>
   out = replaceTableBody(out, 'Incident Summary', incidentRows)
@@ -792,6 +856,8 @@ module.exports = {
   buildWhy,
   gradeLabel,
   confidence,
+  uptimeSourceLabel,
+  buildRankingNote,
   buildScoreTable,
   buildIncidentTable,
   buildUptimeTable,

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -6,6 +6,8 @@ const {
   buildWhy,
   gradeLabel,
   confidence,
+  uptimeSourceLabel,
+  buildRankingNote,
   buildScoreTable,
   buildIncidentTable,
   buildUptimeTable,
@@ -85,13 +87,18 @@ test('three-way tie', () => {
 
 // ── Why text ─────────────────────────────────────────────
 console.log('\nbuildWhy')
-test('zero incidents with uptime', () => {
-  const w = buildWhy({ data: { incidents: 0, uptime: 100, avgResolutionMin: null } })
+test('zero incidents with uptime (official service)', () => {
+  const w = buildWhy({ data: { incidents: 0, uptime: 100, avgResolutionMin: null } }, 'cohere')
   eq(w, 'Zero incidents, 100.00% uptime')
 })
 test('zero incidents no uptime data', () => {
-  const w = buildWhy({ data: { incidents: 0, uptime: null, avgResolutionMin: null } })
+  const w = buildWhy({ data: { incidents: 0, uptime: null, avgResolutionMin: null } }, 'cohere')
   eq(w, 'Zero incidents')
+})
+test('zero incidents, estimate-uptime service → "(no published 30-day uptime)" (#29)', () => {
+  // perplexity is in NO_PUBLIC_UPTIME — must NOT assert "Zero incidents, X% uptime"
+  const w = buildWhy({ data: { incidents: 0, uptime: 99.5, avgResolutionMin: null } }, 'perplexity')
+  eq(w, 'Zero incidents (no published 30-day uptime)')
 })
 test('many incidents with fast recovery', () => {
   const w = buildWhy({ data: { incidents: 20, uptime: 99.5, avgResolutionMin: 25 } })
@@ -104,12 +111,39 @@ console.log('\ngradeLabel')
 test('capitalizes grade', () => eq(gradeLabel('excellent'), 'Excellent'))
 test('handles null', () => eq(gradeLabel(null), '—'))
 
-console.log('\nconfidence')
+console.log('\nconfidence (analyzer signal — still used by generate-summary)')
 test('High when uptime + incidents present', () => {
   eq(confidence({ data: { uptime: 99.5, incidents: 3 } }), 'High')
 })
 test('Medium when uptime null', () => {
   eq(confidence({ data: { uptime: null, incidents: 3 } }), 'Medium')
+})
+
+console.log('\nuptimeSourceLabel (#29)')
+test('Official for a status-page-read service', () => {
+  eq(uptimeSourceLabel('cohere'), 'Official')
+})
+test('Estimate for a NO_PUBLIC_UPTIME service', () => {
+  eq(uptimeSourceLabel('perplexity'), 'Estimate')
+  eq(uptimeSourceLabel('bedrock'), 'Estimate')
+})
+
+console.log('\nbuildRankingNote (#29)')
+test('names the NO_INCIDENT_FEED services excluded from the ranking', () => {
+  const services = [
+    { id: 'modal', data: { score: 97 } },
+    { id: 'bedrock', data: { score: 90 } },
+    { id: 'azureopenai', data: { score: 90 } },
+  ]
+  const meta = { modal: { name: 'Modal' }, bedrock: { name: 'Amazon Bedrock' }, azureopenai: { name: 'Azure OpenAI' } }
+  const note = buildRankingNote(services, meta)
+  assert.ok(note.includes('1 of 3 services ranked'), `got: ${note}`)
+  assert.ok(note.includes('Amazon Bedrock and Azure OpenAI'), `got: ${note}`)
+  assert.ok(note.includes('excluded from this ranking'), `got: ${note}`)
+})
+test('returns empty string when nothing is excluded', () => {
+  const services = [{ id: 'modal', data: { score: 97 } }, { id: 'cohere', data: { score: 89 } }]
+  eq(buildRankingNote(services, { modal: { name: 'Modal' }, cohere: { name: 'Cohere API' } }), '')
 })
 
 // ── Date helpers ─────────────────────────────────────────
@@ -155,6 +189,32 @@ test('renders rows sorted by score desc', () => {
   assert.ok(rows[2].includes('100'), `score 100 missing: ${rows[2]}`)
   assert.ok(rows[4].includes('Claude API'), `last row not Claude: ${rows[4]}`)
 })
+test('header is "Uptime Source" (not "Confidence") and marks the estimate cohort (#29)', () => {
+  const services = [
+    { id: 'modal', data: { score: 97, grade: 'excellent', uptime: 99.4, incidents: 5, avgResolutionMin: 65 } },
+    { id: 'perplexity', data: { score: 68, grade: 'fair', uptime: 99.6, incidents: 1, avgResolutionMin: 240 } },
+  ]
+  const meta = { modal: { name: 'Modal' }, perplexity: { name: 'Perplexity' } }
+  const table = buildScoreTable(services, meta)
+  assert.ok(table.includes('| Rank | Service | Score | Grade | Uptime Source | Why |'), 'header must use Uptime Source')
+  assert.ok(!table.includes('Confidence'), 'Confidence column must be gone')
+  const perplexityRow = table.split('\n').find(r => r.includes('Perplexity'))
+  assert.ok(/\| Estimate \|/.test(perplexityRow), `estimate cohort must be marked Estimate: ${perplexityRow}`)
+  const modalRow = table.split('\n').find(r => r.includes('Modal'))
+  assert.ok(/\| Official \|/.test(modalRow), `status-page service must be Official: ${modalRow}`)
+})
+test('excludes NO_INCIDENT_FEED services (Bedrock/Azure) from the ranking (#29)', () => {
+  const services = [
+    { id: 'modal', data: { score: 97, grade: 'excellent', uptime: 99.4, incidents: 5, avgResolutionMin: 65 } },
+    { id: 'bedrock', data: { score: 90, grade: 'excellent', uptime: 100, incidents: 0, avgResolutionMin: null } },
+    { id: 'azureopenai', data: { score: 90, grade: 'excellent', uptime: 99.9, incidents: 0, avgResolutionMin: null } },
+  ]
+  const meta = { modal: { name: 'Modal' }, bedrock: { name: 'Amazon Bedrock' }, azureopenai: { name: 'Azure OpenAI' } }
+  const table = buildScoreTable(services, meta)
+  assert.ok(!table.includes('Amazon Bedrock'), 'Bedrock must not be ranked')
+  assert.ok(!table.includes('Azure OpenAI'), 'Azure must not be ranked')
+  assert.ok(table.includes('Modal'), 'a ranked service still appears')
+})
 
 console.log('\nbuildIncidentTable')
 test('excludes services with zero incidents from the table body', () => {
@@ -170,6 +230,17 @@ test('sorts by incident count desc', () => {
   const openaiIdx = tableRows.indexOf('OpenAI API')
   assert.ok(claudeIdx > 0 && openaiIdx > 0, 'both should appear')
   assert.ok(claudeIdx < openaiIdx, 'Claude (9 inc) should appear before OpenAI (1 inc)')
+})
+test('splits zero-incident services into confirmed vs no-feed (estimate) (#29)', () => {
+  const services = [
+    { id: 'cohere', data: { score: 89, incidents: 0, uptime: 100, avgResolutionMin: null, totalDowntimeMin: null, longestIncidentMin: null } },
+    { id: 'bedrock', data: { score: 90, incidents: 0, uptime: 100, avgResolutionMin: null, totalDowntimeMin: null, longestIncidentMin: null } },
+  ]
+  const meta = { cohere: { name: 'Cohere API' }, bedrock: { name: 'Amazon Bedrock' } }
+  const { zeroIncLine } = buildIncidentTable(services, meta)
+  // Official-uptime zero → confirmed; estimate-uptime zero (bedrock) → "No incident feed"
+  assert.ok(/\*\*Zero incidents \(1 services\):\*\* Cohere API — confirmed/.test(zeroIncLine), `confirmed line: ${zeroIncLine}`)
+  assert.ok(/\*\*No incident feed \(1 services\):\*\* Amazon Bedrock/.test(zeroIncLine), `no-feed line: ${zeroIncLine}`)
 })
 
 console.log('\nbuildUptimeTable')


### PR DESCRIPTION
## Problem
The monthly-report generator (`scripts/generate-report.js`) didn't separate **estimate-only** services from genuinely-measured ones, forcing the same hand-corrections every month:
- estimate-uptime services rendered as Score **"Confidence: High"** (hiding that their score rests on an assumed uptime),
- **Amazon Bedrock + Azure OpenAI** were ranked and shown as "Zero incidents, 100% uptime" despite having no reliable incident feed,
- the **"Zero incidents"** note lumped real-feed and no-feed services together,
- **Bedrock** leaked a stray "100.00%" row into the Official Uptime table.

The 2026-04 report did all of this correctly (manually). This makes the generator reproduce it.

## Changes
- **Sets**: `bedrock` added to `NO_PUBLIC_UPTIME` (fixes the stray uptime-table row); new `NO_INCIDENT_FEED = {bedrock, azureopenai}` (estimate + no reliable feed; ⊂ NO_PUBLIC_UPTIME).
- **Score table**: "Confidence" column → **"Uptime Source"** (Official/Estimate) via `uptimeSourceLabel()`; NO_INCIDENT_FEED services excluded from the ranking and surfaced in a new `buildRankingNote()` ("*X of N services ranked … excluded*") injected via a `<!-- SCORE_RANKING_NOTE -->` marker.
- **`buildWhy(svc, id)`**: estimate-uptime + zero incidents → "Zero incidents (no published 30-day uptime)".
- **Zero-incidents note** splits into confirmed (real feed) vs **"No incident feed"** (estimate).
- `confidence()` **kept** — the auto-draft analyzer (`generate-summary.js`) still reads `r.Confidence === 'High'` to pick candidates; it's just no longer the Score-table column.
- Removed the stale `*`-asterisk estimate-footnote template comment (superseded by the column).

## Verification
`fillTemplate` against `_data/2026-04.json` (no month's `index.md` regenerated): Estimate marks on gemini/mistral/perplexity/xai/deepgram, Bedrock/Azure excluded ("29 of 31 ranked"), zero-incidents split = 3 confirmed (groq/pinecone/stability) / 4 no-feed (bedrock/azure/perplexity/xai), Bedrock gone from the uptime table. **116 tests pass.** PR review: **0 Critical / 0 Important**.

## Notes
- `chatgpt` is intentionally NOT in NO_PUBLIC_UPTIME (its broken group-aggregate uptime is aiwatch#586). A fully data-driven version (reading an archive `uptimeSource` field) wants the Worker to expose it — TODO left in code.
- Does not retroactively change `2026-05/index.md` (#26 is finalized; regenerating would clobber its hand edits). Future months auto-apply this handling.
- Sibling generator issue: #28 (Detection/RTT auto-render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)