### PR TITLE
feat(generator): auto-render the Detection & RTT section via buildDetectionSection() (closes #28)

### DIFF
--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -135,64 +135,13 @@ These p75 figures are the input to the **Responsiveness** component (20% weight)
 
 ---
 
-## Detection & RTT Degradation
-
-<!-- #464 redefinition: AIWatch does NOT claim to detect "before the official status page."
-     Diagnostic data showed status-page-based detection is structurally bounded by polling lag
-     (always at/after the official publish), and genuine probe-first leads are rare. The two
-     honest, verifiable framings are detection latency (MTTD) and RTT degradation detection.
-     Do NOT reinstate any "X minutes ahead of the official status page" headline claim. -->
-
-### Detection Latency
-
-AIWatch independently detects incidents and alerts within **~5 minutes** — the probe/poll cadence, the upper bound on how long an issue can go unnoticed by our monitoring. This is independent, low-latency awareness across all monitored services, not a timing comparison against any provider's status page.
-
-### RTT Degradation Detection
-
-<!-- Include this subsection ONLY when archive:monthly:{YYYY-MM}.degradation is non-null
-     (aiwatch#511). Omit for months before aiwatch#512 deployed (no probe-degradation:monthly
-     accumulator existed — e.g. any month ≤ 2026-05) or with zero degradations.
-     Data source: GET /api/report?month=YYYY-MM → degradation.{total, noStatusTotal,
-     byService, noStatusByService}. Backed by probe-degradation:monthly:* (60d TTL). -->
-
-AIWatch's direct RTT probes flagged **<!-- N -->** latency degradations this month, of which **<!-- M -->** were **not reflected on the providers' official status pages** — slowdowns status pages typically don't report, only hard outages.
-
-| Service | RTT Degradations | Not on Status Page |
-|---|---|---|
-| | | |
-
-> **RTT degradation detection** is AIWatch's differentiator: synthetic probes measure real latency degradation that official status pages (which report hard-down, not slowness) often omit entirely.
-
-### Early RTT Detections
-
-<!-- Include this subsection ONLY when archive:monthly:{YYYY-MM}.detectionLead is non-null
-     (topExamples has entries). These are the RARE genuine cases where a probe RTT spike was
-     flagged before the official update — honest per-event evidence, NOT a headline metric.
-     Data source: detectionLead.{count, avgLeadMs, medianLeadMs, maxLeadMs, byService, topExamples},
-     backed by detection:lead:monthly:* (60d TTL, aiwatch#369). Omit the whole subsection when
-     topExamples is empty (the common case — #464 showed in_window events are rare).
-     COLUMN → SOURCE (each row from a detectionLead.topExamples entry {svcId, incId, leadMs, detectedAt}):
-       • Incident       = incId
-       • Service        = svcId (→ display name)
-       • Probe Flagged  = detectedAt (the ISO timestamp, rendered UTC)
-       • Official Update= NOT in the payload — compute as detectedAt + leadMs (the official publish
-                          is leadMs *after* the probe flagged it). Drop this column if you'd rather
-                          not derive it.
-       • Earlier By     = leadMs (format as "Nm") -->
-
-| Incident | Service | Probe Flagged (UTC) | Official Update (UTC) | Earlier By |
-|---|---|---|---|---|
-| | | | | |
-
-<!-- "Average early detection" line: include ONLY when detectionLead.count >= 5, mirroring the
-     worker canPresentLeadAverage / MIN_LEAD_SAMPLE_SIZE gate (aiwatch#464). Below 5 samples the
-     average is statistically thin — show the per-event rows above but DROP this averaged line so
-     no marketing-grade figure rests on a handful of samples. -->
-**Average early detection**: <!-- X min --> (across N events) <!-- ONLY when count ≥ 5 -->
-
-> Occasional cases where AIWatch's RTT probe flagged degradation before the official status update. Rare by design — the headline metrics are detection latency and degradation detection above, not a "faster than official" average.
-
----
+<!-- DETECTION_SECTION -->
+<!-- ^ Auto-rendered by generate-report.js (buildDetectionSection) from archive.degradation
+     (aiwatch#511) + archive.detectionLead (aiwatch#369). Emits the whole "## Detection & RTT
+     Degradation" section ending in its own `---` when there's data, and is omitted entirely
+     otherwise (the case for any month ≤ 2026-05). #464 framing is fixed — detection latency
+     (MTTD) + RTT degradation, never a "faster than the official status page" claim. Do not
+     hand-author. -->
 
 ## Incident Summary
 

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -347,6 +347,99 @@ function buildSecuritySection(security) {
   return parts.join('\n')
 }
 
+// ── Detection & RTT Degradation section (#28) ────────────────────────
+// Auto-renders the "## Detection & RTT Degradation" section from the archive's `degradation`
+// (RTT degradation rising edges, aiwatch#511/#512) and `detectionLead` (rare probe-first leads,
+// aiwatch#369). The whole section is OMITTED when neither exists — the common case for months
+// ≤ 2026-05 (no accumulator) and any month with no data — matching what 2026-04/2026-05 did by
+// hand. Emits its own trailing `---` (like buildSecuritySection) so the marker carries no
+// separator in the template. The #464 framing is fixed: detection latency (MTTD) + RTT
+// degradation, NOT any "faster than the official status page" headline.
+const DETECTION_LEAD_MIN_SAMPLE = 5  // mirrors worker MIN_LEAD_SAMPLE_SIZE / canPresentLeadAverage
+
+function fmtUtcMinute(iso) {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  const p = (n) => String(n).padStart(2, '0')
+  return `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())} ${p(d.getUTCHours())}:${p(d.getUTCMinutes())} UTC`
+}
+
+function fmtLeadMin(ms) {
+  if (ms === null || ms === undefined || Number.isNaN(ms)) return '—'
+  return `${Math.round(ms / 60000)}m`
+}
+
+function buildDetectionSection(archive, meta) {
+  const deg = archive && archive.degradation
+  const lead = archive && archive.detectionLead
+  const hasDeg = deg && typeof deg.total === 'number' && deg.total > 0
+  const examples = lead && Array.isArray(lead.topExamples) ? lead.topExamples : []
+  const hasLeads = examples.length > 0
+  if (!hasDeg && !hasLeads) return ''
+
+  const parts = [
+    '## Detection & RTT Degradation',
+    '',
+    '### Detection Latency',
+    '',
+    "AIWatch independently detects incidents and alerts within **~5 minutes** — the probe/poll cadence, the upper bound on how long an issue can go unnoticed by our monitoring. This is independent, low-latency awareness across all monitored services, not a timing comparison against any provider's status page.",
+    '',
+  ]
+
+  if (hasDeg) {
+    const byService = deg.byService || {}
+    const noStatus = deg.noStatusByService || {}
+    const ids = Object.keys(byService).sort((a, b) => (byService[b] || 0) - (byService[a] || 0))
+    parts.push(
+      '### RTT Degradation Detection',
+      '',
+      `AIWatch's direct RTT probes flagged **${deg.total}** latency degradations this month, of which **${deg.noStatusTotal ?? 0}** were **not reflected on the providers' official status pages** — slowdowns status pages typically don't report, only hard outages.`,
+      '',
+    )
+    // Only emit the table when there's a per-service breakdown — a total>0 with an empty
+    // byService (shouldn't happen with real worker data) would otherwise render a bodyless table.
+    if (ids.length) {
+      parts.push(
+        '| Service | RTT Degradations | Not on Status Page |',
+        '|---|---|---|',
+        ...ids.map(id => `| ${serviceName(id, meta)} | ${byService[id] || 0} | ${noStatus[id] || 0} |`),
+        '',
+      )
+    }
+    parts.push(
+      "> **RTT degradation detection** is AIWatch's differentiator: synthetic probes measure real latency degradation that official status pages (which report hard-down, not slowness) often omit entirely.",
+      '',
+    )
+  }
+
+  if (hasLeads) {
+    parts.push(
+      '### Early RTT Detections',
+      '',
+      '| Incident | Service | Probe Flagged (UTC) | Official Update (UTC) | Earlier By |',
+      '|---|---|---|---|---|',
+      ...examples.map(e => {
+        const official = (e.detectedAt && typeof e.leadMs === 'number' && !Number.isNaN(new Date(e.detectedAt).getTime()))
+          ? fmtUtcMinute(new Date(new Date(e.detectedAt).getTime() + e.leadMs).toISOString())
+          : '—'
+        return `| ${e.incId || '—'} | ${serviceName(e.svcId, meta)} | ${fmtUtcMinute(e.detectedAt)} | ${official} | ${fmtLeadMin(e.leadMs)} |`
+      }),
+      '',
+    )
+    // Averaged figure only above the sample-size gate (#464) — below it, show per-event rows only.
+    if (typeof lead.count === 'number' && lead.count >= DETECTION_LEAD_MIN_SAMPLE && typeof lead.avgLeadMs === 'number') {
+      parts.push(`**Average early detection**: ${fmtLeadMin(lead.avgLeadMs)} (across ${lead.count} events)`, '')
+    }
+    parts.push(
+      '> Occasional cases where AIWatch\'s RTT probe flagged degradation before the official status update. Rare by design — the headline metrics are detection latency and degradation detection above, not a "faster than official" average.',
+      '',
+    )
+  }
+
+  parts.push('---', '')
+  return parts.join('\n')
+}
+
 function buildLatencyTable(services, meta) {
   const withLatency = services.filter(s => s.data.avgLatencyMs !== null && !NO_PROBE.has(s.id))
   // Competition rank with ascending sort: negate avgLatencyMs so competitionRank's
@@ -491,6 +584,17 @@ function fillTemplate(template, month, archive, meta) {
     out = out.replace(/<!-- SECURITY_SECTION -->/, securityBlock)
   } else {
     out = out.replace(/\n*<!-- SECURITY_SECTION -->\n*/, '\n\n')
+  }
+
+  // Detection & RTT Degradation section (#28) — same pattern as security: buildDetectionSection
+  // emits the whole section (ending in its own `---`) when there's degradation/detectionLead
+  // data, else nothing. When omitted, strip the marker + its one-line explainer comment AND the
+  // trailing `---` so the preceding API-Response `---` stands as the single separator.
+  const detectionSection = buildDetectionSection(archive, meta)
+  if (detectionSection) {
+    out = out.replace(/<!-- DETECTION_SECTION -->(?:\n*<!--[\s\S]*?-->)?/, detectionSection)
+  } else {
+    out = out.replace(/\n*<!-- DETECTION_SECTION -->(?:\n*<!--[\s\S]*?-->)?\n*(?:---\n*)?/, '\n\n')
   }
 
   return out
@@ -802,6 +906,8 @@ module.exports = {
   buildTimelineDetails,
   buildTopFindings,
   buildSecuritySection,
+  buildDetectionSection,
+  fmtLeadMin,
   fmtIso,
   monthName,
   lastDayOfMonth,

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -16,6 +16,8 @@ const {
   buildTimelineDetails,
   buildTopFindings,
   buildSecuritySection,
+  buildDetectionSection,
+  fmtLeadMin,
   monthName,
   lastDayOfMonth,
   nextMonthName,
@@ -512,6 +514,51 @@ test('omits subsections that have no data but still renders the heading + total'
   assert.ok(!out.includes('### Top Findings'), 'top findings omitted when empty')
 })
 
+// ── buildDetectionSection (#28) ─────────────────────────────────────
+console.log('\nfmtLeadMin')
+test('formats ms → whole minutes', () => eq(fmtLeadMin(900000), '15m'))
+test('handles null', () => eq(fmtLeadMin(null), '—'))
+
+console.log('\nbuildDetectionSection (#28)')
+const detMeta = { deepgram: { name: 'Deepgram' }, mistral: { name: 'Mistral API' }, gemini: { name: 'Gemini API' } }
+test('omits the whole section when no degradation and no detectionLead', () => {
+  eq(buildDetectionSection({}, detMeta), '')
+  eq(buildDetectionSection({ degradation: { total: 0 }, detectionLead: { topExamples: [] } }, detMeta), '')
+  eq(buildDetectionSection({ degradation: null, detectionLead: null }, detMeta), '')
+})
+test('renders RTT Degradation from archive.degradation', () => {
+  const out = buildDetectionSection({
+    degradation: { total: 12, noStatusTotal: 8, byService: { deepgram: 5, mistral: 4 }, noStatusByService: { deepgram: 4, mistral: 3 } },
+  }, detMeta)
+  assert.ok(out.startsWith('## Detection & RTT Degradation'), `heading first: ${out.slice(0, 40)}`)
+  assert.ok(out.includes('### Detection Latency'), 'keeps the static Detection Latency blurb')
+  assert.ok(/flagged \*\*12\*\* latency degradations/.test(out), `total: ${out}`)
+  assert.ok(/\*\*8\*\* were \*\*not reflected/.test(out), 'noStatus total rendered')
+  assert.ok(/\| Deepgram \| 5 \| 4 \|/.test(out), 'degradation row rendered with display name')
+  assert.ok(!out.includes('### Early RTT Detections'), 'no Early RTT subsection without leads')
+  assert.ok(out.trimEnd().endsWith('---'), 'section ends with its own trailing separator')
+})
+test('renders Early RTT Detections + Official Update = detectedAt + leadMs', () => {
+  const out = buildDetectionSection({
+    detectionLead: { count: 6, avgLeadMs: 480000, topExamples: [
+      { svcId: 'mistral', incId: '01ABC', leadMs: 900000, detectedAt: '2026-04-12T14:30:00Z' },
+    ] },
+  }, detMeta)
+  assert.ok(out.includes('### Early RTT Detections'), 'Early RTT subsection rendered')
+  assert.ok(/\| 01ABC \| Mistral API \| 2026-04-12 14:30 UTC \| 2026-04-12 14:45 UTC \| 15m \|/.test(out), `row: ${out}`)
+  assert.ok(/\*\*Average early detection\*\*: 8m \(across 6 events\)/.test(out), 'average shown when count >= 5')
+  assert.ok(!out.includes('### RTT Degradation Detection'), 'no degradation subsection without degradation data')
+})
+test('drops the Average line below the sample-size gate (count < 5)', () => {
+  const out = buildDetectionSection({
+    detectionLead: { count: 3, avgLeadMs: 480000, topExamples: [
+      { svcId: 'gemini', incId: '01DEF', leadMs: 300000, detectedAt: '2026-04-18T09:05:00Z' },
+    ] },
+  }, detMeta)
+  assert.ok(out.includes('### Early RTT Detections'), 'still shows per-event rows')
+  assert.ok(!out.includes('**Average early detection**'), 'no averaged figure below MIN_LEAD_SAMPLE_SIZE')
+})
+
 // ── fillTemplate × security ─────────────────────────────────────────
 console.log('\nfillTemplate × security')
 test('inserts the security block when archive.security has data', () => {
@@ -863,6 +910,35 @@ test('full pipeline against real April archive — Opening reflects 24 of 31, no
   // location and is not stripped or broken by injectAutoDraft.
   assert.ok(!out.includes('<!-- SECURITY_SECTION -->'),
     'fillTemplate should have consumed the security placeholder; injectAutoDraft must leave that intact')
+})
+
+// ── fillTemplate × detection (#28) ──────────────────────────────────
+console.log('\nfillTemplate × detection')
+test('real template: Detection section omitted (no double rule) when archive has no detection data', () => {
+  const archive = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '_data', '2026-04.json'), 'utf-8'))
+  // 2026-04 has neither degradation nor detectionLead — the common ≤2026-05 case.
+  const tmpl = fs.readFileSync(path.join(__dirname, '..', '_templates', 'monthly-report.md'), 'utf-8')
+  const meta = {}
+  for (const id of Object.keys(archive.services)) meta[id] = { name: id }
+  const out = fillTemplate(tmpl, '2026-04', archive, meta)
+  assert.ok(!out.includes('## Detection & RTT Degradation'), 'no Detection section without data')
+  assert.ok(!out.includes('<!-- DETECTION_SECTION -->'), 'marker consumed on omission')
+  assert.ok(!out.includes('buildDetectionSection)'), 'explainer comment removed on omission')
+  assert.ok(!/---\s*\n\s*---/.test(out), 'no double horizontal rule after omission')
+  assert.ok(/## API Response[\s\S]*?\n---\n[\s\S]*?## Incident Summary/.test(out), 'API Response → Incident Summary stay separated by one rule')
+})
+test('real template: Detection section renders when degradation/detectionLead present', () => {
+  const archive = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '_data', '2026-04.json'), 'utf-8'))
+  archive.degradation = { total: 12, noStatusTotal: 8, byService: { deepgram: 5 }, noStatusByService: { deepgram: 4 } }
+  archive.detectionLead = { count: 6, avgLeadMs: 480000, topExamples: [{ svcId: 'mistral', incId: '01ABC', leadMs: 900000, detectedAt: '2026-04-12T14:30:00Z' }] }
+  const tmpl = fs.readFileSync(path.join(__dirname, '..', '_templates', 'monthly-report.md'), 'utf-8')
+  const meta = {}
+  for (const id of Object.keys(archive.services)) meta[id] = { name: id }
+  const out = fillTemplate(tmpl, '2026-04', archive, meta)
+  assert.ok(out.includes('## Detection & RTT Degradation'), 'section renders')
+  assert.ok(!out.includes('<!-- DETECTION_SECTION -->'), 'marker consumed')
+  assert.ok(!out.includes('buildDetectionSection)'), 'explainer not leaked')
+  assert.ok(!/---\s*\n\s*---/.test(out.slice(out.indexOf('## API Response'), out.indexOf('## Incident Summary'))), 'no double rule around the section')
 })
 
 // ── injectNarrativeDraft (refs aiwatch-reports#4 Phase 3 / aiwatch#426) ──


### PR DESCRIPTION
## Problem
The "## Detection & RTT Degradation" section was a manual template — conditional HTML-comment instructions the operator hand-filled or deleted every month. (2026-04 and 2026-05 both omitted it by hand because there was no data.)

## Fix
New `buildDetectionSection(archive, meta)` auto-renders it, mirroring the `buildSecuritySection` / `<!-- SECURITY_SECTION -->` pattern:
- **Detection Latency** (static MTTD blurb) + **RTT Degradation Detection** (from `archive.degradation`, aiwatch#511) + **Early RTT Detections** (from `archive.detectionLead.topExamples`, aiwatch#369).
- **Omits the whole section** when neither exists — the case for any month ≤ 2026-05 (no accumulator). Emits its own trailing `---`.
- "Official Update" column derived as `detectedAt + leadMs`; the **"Average early detection"** line is gated at `count >= 5` (worker `MIN_LEAD_SAMPLE_SIZE` / `canPresentLeadAverage`, aiwatch#464).
- **#464 framing kept**: detection latency (MTTD) + RTT degradation, never a "faster than the official status page" claim.
- Degradation table only emitted with a per-service breakdown (no bodyless table on an empty `byService`).
- Template: manual section → `<!-- DETECTION_SECTION -->` + one-line explainer; main() injects/collapses it like the security marker.

## Verification
`fillTemplate` against `_data/2026-04.json` (no data → section omitted, no double rule, API Response → Incident Summary stay separated) **and** synthetic `degradation`/`detectionLead` (renders both subsections + average gate). **116 tests pass.** PR review: **0 Critical / 0 Important**.

## Notes
- Data is empty until **June 2026+** (post aiwatch#511/#512 deploy) — the section stays omitted until then and lights up automatically once the archive carries the fields.
- Branched off `main`, so this PR does not include the `<!-- SECURITY_SECTION -->` marker from #27 (PR #30) or the estimate handling from #29 (PR #31) — they touch different functions/regions and won't conflict.
- No month's `index.md` changed (generator/template/test only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)