### PR TITLE
feat(generator): exclude stale-source services from the Score ranking (#591 PR B)

### DIFF
--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -66,6 +66,15 @@ const NO_INCIDENT_FEED = new Set(['bedrock', 'azureopenai'])
 // Maintained constant — REMOVE a service here once its feed is reachable again (aiwatch#507).
 const STALE_SOURCE = new Set(['deepseek'])
 
+// aiwatch#591 — is a service's incident source stale this month? PRIMARY signal is the archive's
+// per-service `incidentSourceStale` flag (the deployed Worker sets it from ServiceConfig; absent ⇒
+// not stale on a post-#591 archive). The STALE_SOURCE constant is the FALLBACK for archives built
+// before the Worker emitted the flag. Stale services are excluded from the Score ranking (their
+// frozen empty incident window would inflate the Score — DeepSeek ranked #4 live before the fix).
+function isStaleSource(s) {
+  return !!(s.data.incidentSourceStale ?? STALE_SOURCE.has(s.id))
+}
+
 // Services without direct probe coverage (excluded from API Response Time ranking).
 // Archive.avgLatencyMs will be null for these — tracked for explicit messaging.
 const NO_PROBE = new Set(['bedrock', 'azureopenai', 'pinecone'])
@@ -224,22 +233,38 @@ function uptimeSourceLabel(id) {
 // Ranking-exclusion note (#29). NO_INCIDENT_FEED services have neither an accessible uptime
 // metric nor a reliable incident feed, so they're dropped from the Score ranking and called
 // out above the table. Returns '' when none are excluded (the marker then collapses).
+// Joins display names with " and " for two, commas otherwise.
+function joinNames(svcs, meta) {
+  const names = svcs.map(s => serviceName(s.id, meta))
+  return names.length === 2 ? names.join(' and ') : names.join(', ')
+}
+
 function buildRankingNote(services, meta) {
   const scored = services.filter(s => s.data.score !== null)
-  const excluded = scored.filter(s => NO_INCIDENT_FEED.has(s.id))
-  if (excluded.length === 0) return ''
-  const ranked = scored.length - excluded.length
-  const names = excluded.map(s => serviceName(s.id, meta))
-  const nameList = names.length === 2 ? names.join(' and ') : names.join(', ')
-  const verb = excluded.length === 1 ? 'is' : 'are'
-  return `*${ranked} of ${scored.length} services ranked. **${nameList} ${verb} excluded from this ranking** — neither publishes an accessible uptime metric, so their Score would otherwise inherit an industry-average assumption rather than a measured value, and AIWatch has no reliable incident feed for them (see "No incident feed" under [Incident Summary](#incident-summary)).*`
+  const noFeed = scored.filter(s => NO_INCIDENT_FEED.has(s.id))
+  // STALE_SOURCE that isn't already a no-feed service (avoid double-listing) — #591.
+  const stale = scored.filter(s => isStaleSource(s) && !NO_INCIDENT_FEED.has(s.id))
+  if (noFeed.length === 0 && stale.length === 0) return ''
+  const ranked = scored.length - noFeed.length - stale.length
+  const clauses = []
+  if (noFeed.length) {
+    const verb = noFeed.length === 1 ? 'is' : 'are'
+    clauses.push(`**${joinNames(noFeed, meta)} ${verb} excluded from this ranking** — neither publishes an accessible uptime metric, so their Score would otherwise inherit an industry-average assumption rather than a measured value, and AIWatch has no reliable incident feed for them (see "No incident feed" under [Incident Summary](#incident-summary))`)
+  }
+  if (stale.length) {
+    const verb = stale.length === 1 ? 'is' : 'are'
+    const poss = stale.length === 1 ? 'its' : 'their'
+    clauses.push(`**${joinNames(stale, meta)} ${verb} excluded from this ranking** — ${poss} status source migrated to a platform AIWatch can't reach, so the incident feed is frozen and the Score would be inflated by an empty 30-day window (see "Stale source" under [Incident Summary](#incident-summary))`)
+  }
+  return `*${ranked} of ${scored.length} services ranked. ${clauses.join('. ')}.*`
 }
 
 // ── Table builders ───────────────────────────────────────────────────
 function buildScoreTable(services, meta) {
-  // Drop NO_INCIDENT_FEED services (no uptime metric + no reliable incidents) from the ranking;
-  // they're surfaced in the ranking-exclusion note + the Incident Summary "No incident feed" line.
-  const withScore = services.filter(s => s.data.score !== null && !NO_INCIDENT_FEED.has(s.id))
+  // Drop NO_INCIDENT_FEED services (no uptime metric + no reliable incidents) and STALE_SOURCE
+  // services (#591 — frozen feed inflates the Score from an empty window) from the ranking; both are
+  // surfaced in the ranking-exclusion note + the Incident Summary ("No incident feed" / "Stale source").
+  const withScore = services.filter(s => s.data.score !== null && !NO_INCIDENT_FEED.has(s.id) && !isStaleSource(s))
   const ranked = competitionRank(withScore, s => s.data.score)
   const rows = ranked.map(r => {
     const s = r.item
@@ -1032,6 +1057,7 @@ module.exports = {
   uptimeSourceLabel,
   buildRankingNote,
   buildScoreTable,
+  isStaleSource,
   buildIncidentTable,
   officialUptimeFor,
   buildStaleSourceCaveat,

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -8,6 +8,7 @@ const {
   confidence,
   uptimeSourceLabel,
   buildRankingNote,
+  isStaleSource,
   buildScoreTable,
   buildIncidentTable,
   officialUptimeFor,
@@ -148,6 +149,40 @@ test('names the NO_INCIDENT_FEED services excluded from the ranking', () => {
 test('returns empty string when nothing is excluded', () => {
   const services = [{ id: 'modal', data: { score: 97 } }, { id: 'cohere', data: { score: 89 } }]
   eq(buildRankingNote(services, { modal: { name: 'Modal' }, cohere: { name: 'Cohere API' } }), '')
+})
+
+// #591 — stale-source services are excluded from the Score ranking (frozen feed inflates the Score).
+console.log('\nisStaleSource (#591)')
+test('archive flag true → stale; absent falls back to the STALE_SOURCE constant', () => {
+  eq(isStaleSource({ id: 'openai', data: { incidentSourceStale: true } }), true)   // new archive flag
+  eq(isStaleSource({ id: 'deepseek', data: {} }), true)                            // legacy archive → constant
+  eq(isStaleSource({ id: 'cohere', data: {} }), false)                             // neither
+})
+
+console.log('\nbuildScoreTable + buildRankingNote — stale exclusion (#591)')
+test('buildScoreTable drops a stale service from the ranking', () => {
+  const services = [
+    { id: 'cohere', data: { score: 89, grade: 'good', uptime: 100, incidents: 0, avgResolutionMin: null } },
+    { id: 'deepseek', data: { score: 88, grade: 'good', uptime: 99.92, incidents: 3, avgResolutionMin: 18, incidentSourceStale: true } },
+  ]
+  const meta = { cohere: { name: 'Cohere API' }, deepseek: { name: 'DeepSeek API' } }
+  const table = buildScoreTable(services, meta)
+  assert.ok(table.includes('Cohere API'), 'non-stale service still ranked')
+  assert.ok(!table.includes('DeepSeek API'), 'stale service dropped from the Score table')
+})
+test('buildRankingNote names stale + no-feed in separate clauses with distinct reasons', () => {
+  const services = [
+    { id: 'modal', data: { score: 97 } },
+    { id: 'bedrock', data: { score: 90 } },                       // NO_INCIDENT_FEED
+    { id: 'deepseek', data: { score: 88, incidentSourceStale: true } }, // STALE_SOURCE
+  ]
+  const meta = { modal: { name: 'Modal' }, bedrock: { name: 'Amazon Bedrock' }, deepseek: { name: 'DeepSeek API' } }
+  const note = buildRankingNote(services, meta)
+  assert.ok(note.includes('1 of 3 services ranked'), `got: ${note}`)
+  assert.ok(/Amazon Bedrock is excluded from this ranking/.test(note), `no-feed clause: ${note}`)
+  assert.ok(/no reliable incident feed/.test(note), `no-feed reason: ${note}`)
+  assert.ok(/DeepSeek API is excluded from this ranking/.test(note), `stale clause: ${note}`)
+  assert.ok(/incident feed is frozen/.test(note), `stale reason: ${note}`)
 })
 
 // ── Date helpers ─────────────────────────────────────────


### PR DESCRIPTION
## What

A stale-source service (frozen status feed — DeepSeek → Flashduty, [#507](https://github.com/bentleypark/aiwatch/issues/507)) has an empty recent-incident window that **inflates the AIWatch Score** (full incidents + recovery from *missing* data). The live dashboard already excludes such services from its ranking ([bentleypark/aiwatch#591](https://github.com/bentleypark/aiwatch/issues/591) PR A, deployed — DeepSeek dropped from #4); this brings the **monthly-report generator** to parity so the published ranking matches the dashboard.

## Change

- **`isStaleSource(s)`** = `s.data.incidentSourceStale ?? STALE_SOURCE.has(s.id)` — the archive's per-service flag (the deployed Worker now threads `incidentSourceStale` into `MonthlyServiceData`, set only when true) is **PRIMARY**; the hand-maintained `STALE_SOURCE` constant (already used for the Incident-Summary "Stale source" caveat, aiwatch-reports#35) is the **FALLBACK** for archives built before the Worker emitted the flag.
- **`buildScoreTable`** drops stale services from the ranking (alongside `NO_INCIDENT_FEED`).
- **`buildRankingNote`** now emits two clauses with distinct reasons:
  - NO_INCIDENT_FEED — "neither publishes an accessible uptime metric…"
  - STALE_SOURCE — "its status source migrated to a platform AIWatch can't reach, so the incident feed is frozen and the Score would be inflated by an empty 30-day window"
  - A service that is both is listed once (no-feed clause).

## Scope

Applies **from the 2026-06 report on**. The published **2026-05** report keeps DeepSeek ranked (#15=, on 3 *real* early-May incidents) with its existing "Stale source" caveat (#35) — not the egregious empty-window inflation this guards against — so it is left as-is.

## Verification (non-destructive — no published report regenerated)

- **Live 2026-05 archive** (no flag → constant fallback): `isStaleSource(deepseek)=true`, DeepSeek **dropped** from the Score table, note reads "30 of 33 services ranked".
- **New-archive fixture** (flag present): DeepSeek dropped, ranking note includes the frozen-feed clause.
- **+3 tests** (isStaleSource flag/constant/neither; buildScoreTable drops stale; buildRankingNote two-clause). **141 generator tests pass.** No #29 regression.
- code-reviewer: **0 Critical / 0 Important**.

`refs bentleypark/aiwatch#591` — completes the report-generator acceptance item; #591 closes after the post-deploy verify (live #4 gone, already confirmed) is finalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)