### PR TITLE
feat(reports): add LangChain (LangSmith) — 34 monitored services (#561)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AIWatch Monthly Reports
 
-> Monthly AI service reliability reports covering uptime, incidents, and performance across 33 major AI services.
+> Monthly AI service reliability reports covering uptime, incidents, and performance across 34 major AI services.
 
 **Live site**: [ai-watch.dev/reports](https://ai-watch.dev/reports/) (served via Vercel rewrite; legacy `reports.ai-watch.dev` self-redirects to the canonical path — #264)
 **Data source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
@@ -29,7 +29,7 @@ Each monthly report includes:
 
 ## Methodology
 
-- **33 services monitored**: 15 LLM APIs, 9 voice & inference, 3 AI apps, 6 coding agents
+- **34 services monitored**: 15 LLM APIs, 10 voice & inference, 3 AI apps, 6 coding agents
 - **Data sources**: Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, AWS Health Dashboard, Azure Status RSS, OnlineOrNot
 - **AIWatch Score**: Weighted composite of uptime (40pts), incident affected days (25pts), recovery time (15pts), and probe-based responsiveness (20pts). Services without probe data use 80→100 score redistribution.
 - **Uptime figures**: Official status page metrics — single primary component basis where available, platform-wide average otherwise
@@ -70,7 +70,7 @@ After generation, fill in the narrative sections (`Summary`, `Recommendations`, 
 
 ## About AIWatch
 
-AIWatch is an AI service status monitoring dashboard that aggregates real-time status from 33 major AI services.
+AIWatch is an AI service status monitoring dashboard that aggregates real-time status from 34 major AI services.
 
 - **Live dashboard**: [ai-watch.dev](https://ai-watch.dev)
 - **Source code**: [github.com/bentleypark/aiwatch](https://github.com/bentleypark/aiwatch) (AGPL-3.0)

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: AIWatch Reports
-description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 33 AI services
+description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 34 AI services
 baseurl: "/reports"
 url: https://ai-watch.dev
 theme: minima

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "[MON] [YEAR] AI Reliability Report"
-description: "Monthly reliability report for 33 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
+description: "Monthly reliability report for 34 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
 date: [YYYY-MM-DD]
 published: true
 ---
@@ -9,7 +9,7 @@ published: true
 > **Source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
 > **Period**: [MONTH] 1–[LAST_DAY], [YEAR]
 > **Published**: [PUBLISH_MONTH] [YEAR]
-> **Services monitored**: 33 — 24 API services, 6 coding agents, 3 AI apps
+> **Services monitored**: 34 — 25 API services, 6 coding agents, 3 AI apps
 
 ## Summary
 
@@ -200,7 +200,7 @@ Actionable takeaways per service. Descriptive context for each event lives in ea
 ## About This Report
 
 * **Data Sources:** Real-time data is aggregated from official status pages via multiple frameworks, including Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, OnlineOrNot, and RSS feeds (Source: [ai-watch.dev](https://ai-watch.dev)).
-* **Monitoring Frequency:** All 33 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
+* **Monitoring Frequency:** All 34 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
 * **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). Services without probe data use 80→100 score redistribution **plus a 5% penalty** to reflect the missing responsiveness signal. Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
 * **Uptime Source:** *Official* = service publishes a rolling 30-day uptime metric AIWatch reads directly. *Estimate* = no official metric; AIWatch substitutes an industry-average assumption (99.5%) or its own poll-derived figure for the Score's Uptime input. *Partial (Nd)* = an official source exists but AIWatch's measurement window is shorter than the full month (e.g. service newly tracked mid-month). The label only describes the Uptime input quality — the Score itself is computed identically across all services.
 * **Incident Counting:** Incident counts reflect all affected components per service. Providers differ in reporting granularity — Anthropic reports per-model incidents (Opus/Sonnet/Haiku each counted separately), while others report at the service level.

--- a/index.md
+++ b/index.md
@@ -1,10 +1,10 @@
 ---
 layout: home
 title: AIWatch Monthly Reports
-description: "Monthly AI service incident reports covering 33 AI services — uptime, incidents, and reliability rankings."
+description: "Monthly AI service incident reports covering 34 AI services — uptime, incidents, and reliability rankings."
 ---
 
-Monthly AI service incident reports covering 33 AI services monitored by [AIWatch](https://ai-watch.dev).
+Monthly AI service incident reports covering 34 AI services monitored by [AIWatch](https://ai-watch.dev).
 
 ## Reports
 

--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -52,7 +52,7 @@ const ID_TO_NAME = {
   replicate: 'Replicate', elevenlabs: 'ElevenLabs', xai: 'xAI (Grok)',
   deepseek: 'DeepSeek API', openrouter: 'OpenRouter', bedrock: 'Amazon Bedrock',
   azureopenai: 'Azure OpenAI', pinecone: 'Pinecone', stability: 'Stability AI',
-  voyageai: 'Voyage AI', modal: 'Modal',
+  voyageai: 'Voyage AI', modal: 'Modal', langsmith: 'LangChain (LangSmith)',
   claudeai: 'claude.ai', chatgpt: 'ChatGPT', characterai: 'Character.AI',
   claudecode: 'Claude Code', codex: 'Codex', cursor: 'Cursor',
   copilot: 'GitHub Copilot', windsurf: 'Windsurf', junie: 'Junie',
@@ -68,7 +68,7 @@ const CATEGORY_ORDER = [
   'together', 'fireworks', 'cerebras', 'perplexity', 'xai', 'deepseek', 'openrouter',
   // Voice & Inference
   'elevenlabs', 'assemblyai', 'deepgram', 'huggingface', 'replicate', 'pinecone',
-  'stability', 'voyageai', 'modal',
+  'stability', 'voyageai', 'modal', 'langsmith',
   // Coding Agents
   'claudecode', 'codex', 'cursor', 'copilot', 'windsurf', 'junie',
 ]
@@ -304,7 +304,7 @@ if (require.main === module) {
         if (history[key]) { lastDataDay = d; break }
       }
 
-      // Use all 33 services in category order (not just incident table)
+      // Use all 34 services in category order (not just incident table)
       const serviceNames = CATEGORY_ORDER.map(id => ID_TO_NAME[id]).filter(Boolean)
 
       const heatmapSvg = generateUptimeHeatmapSvg(serviceNames, history, daysInMonth, monthKey, monitoringStartDay, lastDataDay)


### PR DESCRIPTION
## Summary
Reports-site half of the main-repo **#561** LangChain (LangSmith) service addition. Bumps the monitored-service count **33→34** across the Jekyll site metadata and registers LangSmith in the chart generator.

Pairs with main-repo PR **bentleypark/aiwatch#594**.

## Changes
- **Count 33→34** — `README.md` (15 LLM / **10** voice & inference / 3 apps / 6 agents = 34), `_config.yml` description, `_templates/monthly-report.md` (**25** API / 6 agents / 3 apps = 34), `index.md` home copy.
- **`scripts/generate-charts.js`** — `ID_TO_NAME` += `langsmith: 'LangChain (LangSmith)'` (matches worker service config); `CATEGORY_ORDER` += `langsmith` in the **Voice & Inference** group after `modal` (mirrors the main repo's `SERVICE_AND_APP_IDS`); "all 34 services" comment. Service count is derived dynamically from `CATEGORY_ORDER`, so no other constant needs bumping.

## Not changed (intentional)
Already-published monthly reports keep their **historical** per-report counts (e.g. May 2026 = 33 services — LangSmith was added 2026-06). Only the **template** + **generator** that drive future reports are bumped — historical snapshots are not retroactively rewritten.

## Verification
- ✅ `scripts/*.test.js` — 215 pass (generate-charts 24)
- ✅ Jekyll build — home renders "covering **34** AI services"
- ✅ PR review — 0 Critical / 0 Important

## Coordination
Merge in step with main-repo #594 + the worker deploy so the site's "34 services" lines up with the dashboard going live with LangSmith data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)