### PR TITLE
chore: service count 37 + DeepSeek May correction & stale-source retire (aiwatch#618/#619)

### DIFF
--- a/2026-05/index.md
+++ b/2026-05/index.md
@@ -95,7 +95,7 @@ Combines four components — Uptime (40%), Incident affected days (25%), Recover
 | 12 | Voyage AI | 86 | Good | Official | Zero incidents, 100.00% uptime |
 | 13 | ChatGPT | 85 | Good | Estimate | 11 incidents, avg 4h 38m |
 | 14 | Together AI | 84 | Good | Official | 133 incidents, avg 43m |
-| 15= | DeepSeek API | 82 | Good | Official | 3 incidents through ~May 8 — partial month, see Stale-source caveat |
+| 15= | DeepSeek API | 82 | Good | Official | 3 incidents through ~May 8 — partial month, see DeepSeek correction note below |
 | 15= | Codex | 82 | Good | Official | 7 incidents, avg 7h 48m |
 | 17 | OpenAI API | 80 | Good | Official | 7 incidents, avg 1h 36m |
 | 18 | Mistral API | 78 | Good | Estimate | 155 incidents, fast recovery (avg 19m) |
@@ -239,7 +239,12 @@ These p75 figures are the input to the **Responsiveness** component (20% weight)
 
 **No incident feed (2 services):** Amazon Bedrock, Azure OpenAI — AIWatch has no reliable incident feed for these (RSS / estimate-only), so a blank incident count reflects monitoring coverage, not verified incident-free operation.
 
-**Stale source (1 service):** DeepSeek API — its status page migrated from Atlassian Statuspage to Flashduty mid-month, and Flashduty blocks AIWatch's server-side fetches (Cloudflare Workers / Vercel Edge), so the feed froze at **2026-05-08**. The 3 incidents, 99.92% uptime, and Score (82) above therefore reflect only ~May 1–8 — later incidents (5/21, 5/24, 5/28) are not captured. Treat DeepSeek's May figures as a floor, not a verified month.
+**Correction — DeepSeek now fully recoverable (June 2026 update):** When this report was published, DeepSeek's status page had migrated from Atlassian Statuspage to Flashduty mid-month and Flashduty blocked AIWatch's server-side fetches, freezing the feed at **2026-05-08**. So the figures in the tables above — **3 incidents, 99.92% uptime, Score 82** — reflect only ~May 1–8. AIWatch can now read the full Flashduty feed via a browser-rendered fetch, so the complete month is recoverable:
+
+- **DeepSeek API — 7 incidents** (May 6, 6, 8, 21, 24, 28, 28): total **2h 8m**, longest **33m**, median recovery **18m**, ≈**99.78%** uptime (Atlassian-weighted). The four later incidents (5/21, 5/24, 5/28×2) the frozen feed missed are all short API degradations.
+- DeepSeek's consumer **Web Chat** surface — now tracked separately as **DeepSeek App** (from June 2026) — saw **6 incidents** over the same period (median recovery 19m).
+
+The ranking, uptime, and incident tables above were **not** retroactively regenerated (the monthly archive's daily counters are immutable once written), so they remain the captured-window snapshot; treat these corrected figures as the verified month. DeepSeek returns to a fully-monitored month from June 2026 onward.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AIWatch Monthly Reports
 
-> Monthly AI service reliability reports covering uptime, incidents, and performance across 36 major AI services.
+> Monthly AI service reliability reports covering uptime, incidents, and performance across 37 major AI services.
 
 **Live site**: [ai-watch.dev/reports](https://ai-watch.dev/reports/) (served via Vercel rewrite; legacy `reports.ai-watch.dev` self-redirects to the canonical path — #264)
 **Data source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
@@ -29,7 +29,7 @@ Each monthly report includes:
 
 ## Methodology
 
-- **36 services monitored**: 15 LLM APIs, 12 voice & inference, 3 AI apps, 6 coding agents
+- **37 services monitored**: 15 LLM APIs, 12 voice & inference, 4 AI apps, 6 coding agents
 - **Data sources**: Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, AWS Health Dashboard, Azure Status RSS, OnlineOrNot
 - **AIWatch Score**: Weighted composite of uptime (40pts), incident affected days (25pts), recovery time (15pts), and probe-based responsiveness (20pts). Services without probe data use 80→100 score redistribution.
 - **Uptime figures**: Official status page metrics — single primary component basis where available, platform-wide average otherwise
@@ -70,7 +70,7 @@ After generation, fill in the narrative sections (`Summary`, `Recommendations`, 
 
 ## About AIWatch
 
-AIWatch is an AI service status monitoring dashboard that aggregates real-time status from 36 major AI services.
+AIWatch is an AI service status monitoring dashboard that aggregates real-time status from 37 major AI services.
 
 - **Live dashboard**: [ai-watch.dev](https://ai-watch.dev)
 - **Source code**: [github.com/bentleypark/aiwatch](https://github.com/bentleypark/aiwatch) (AGPL-3.0)

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: AIWatch Reports
-description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 36 AI services
+description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 37 AI services
 baseurl: "/reports"
 url: https://ai-watch.dev
 theme: minima

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "[MON] [YEAR] AI Reliability Report"
-description: "Monthly reliability report for 36 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
+description: "Monthly reliability report for 37 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
 date: [YYYY-MM-DD]
 published: true
 ---
@@ -9,7 +9,7 @@ published: true
 > **Source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
 > **Period**: [MONTH] 1–[LAST_DAY], [YEAR]
 > **Published**: [PUBLISH_MONTH] [YEAR]
-> **Services monitored**: 36 — 27 API services, 6 coding agents, 3 AI apps
+> **Services monitored**: 37 — 27 API services, 6 coding agents, 4 AI apps
 
 ## Summary
 
@@ -200,7 +200,7 @@ Actionable takeaways per service. Descriptive context for each event lives in ea
 ## About This Report
 
 * **Data Sources:** Real-time data is aggregated from official status pages via multiple frameworks, including Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, OnlineOrNot, and RSS feeds (Source: [ai-watch.dev](https://ai-watch.dev)).
-* **Monitoring Frequency:** All 36 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
+* **Monitoring Frequency:** All 37 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
 * **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). Services without probe data use 80→100 score redistribution **plus a 5% penalty** to reflect the missing responsiveness signal. Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
 * **Uptime Source:** *Official* = service publishes a rolling 30-day uptime metric AIWatch reads directly. *Estimate* = no official metric; AIWatch substitutes an industry-average assumption (99.5%) or its own poll-derived figure for the Score's Uptime input. *Partial (Nd)* = an official source exists but AIWatch's measurement window is shorter than the full month (e.g. service newly tracked mid-month). The label only describes the Uptime input quality — the Score itself is computed identically across all services.
 * **Incident Counting:** Incident counts reflect all affected components per service. Providers differ in reporting granularity — Anthropic reports per-model incidents (Opus/Sonnet/Haiku each counted separately), while others report at the service level.

--- a/index.md
+++ b/index.md
@@ -1,10 +1,10 @@
 ---
 layout: home
 title: AIWatch Monthly Reports
-description: "Monthly AI service incident reports covering 36 AI services — uptime, incidents, and reliability rankings."
+description: "Monthly AI service incident reports covering 37 AI services — uptime, incidents, and reliability rankings."
 ---
 
-Monthly AI service incident reports covering 36 AI services monitored by [AIWatch](https://ai-watch.dev).
+Monthly AI service incident reports covering 37 AI services monitored by [AIWatch](https://ai-watch.dev).
 
 ## Reports
 

--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -304,7 +304,7 @@ if (require.main === module) {
         if (history[key]) { lastDataDay = d; break }
       }
 
-      // Use all 36 services in category order (not just incident table)
+      // Use all 37 services in category order (not just incident table)
       const serviceNames = CATEGORY_ORDER.map(id => ID_TO_NAME[id]).filter(Boolean)
 
       const heatmapSvg = generateUptimeHeatmapSvg(serviceNames, history, daysInMonth, monthKey, monitoringStartDay, lastDataDay)

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -60,11 +60,14 @@ const NO_INCIDENT_FEED = new Set(['bedrock', 'azureopenai'])
 // uptime + an incident history, but both are STALE, which is more insidious: a partial-month count
 // reads as a verified low number and the frozen uptime reads as current. The guard surfaces a
 // caveat every report and stops a frozen zero-count from being labelled a "confirmed zero".
-//   • deepseek — migrated Atlassian Statuspage → Flashduty (~May 2026); the old mirror froze at
-//     2026-05-08 and Flashduty blocks AIWatch's server-side fetches (Workers/Edge), so 5/21+
-//     incidents are unreachable.
+//   • deepseek — migrated Atlassian Statuspage → Flashduty (~May 2026). REMOVED here as of June
+//     2026: AIWatch now reads the full Flashduty feed via a browser-rendered fetch (aiwatch#618),
+//     so DeepSeek (and the new DeepSeek App, aiwatch#619) are no longer frozen. From the June 2026
+//     archive onward their incidentSourceStale flag is absent → not stale; the May 2026 archive
+//     still carries the flag, so a May regeneration stays correctly stale (flag-driven, below).
 // Maintained constant — REMOVE a service here once its feed is reachable again (aiwatch#507).
-const STALE_SOURCE = new Set(['deepseek'])
+// Empty today; reserved for a future status-page migration that re-freezes a feed.
+const STALE_SOURCE = new Set([])
 
 // aiwatch#591 — is a service's incident source stale this month? PRIMARY signal is the archive's
 // per-service `incidentSourceStale` flag (the deployed Worker sets it from ServiceConfig; absent ⇒
@@ -304,15 +307,17 @@ function buildIncidentTable(services, meta) {
   // a blank count reflects what AIWatch can see, not verified incident-free operation. STALE_SOURCE
   // services (aiwatch#507) are also excluded from "confirmed": their feed is frozen, so a zero count
   // is "nothing since the cutoff," not a verified incident-free month.
+  // Use isStaleSource (flag-OR-constant) — not the raw STALE_SOURCE constant — so a service marked
+  // stale by the archive's incidentSourceStale flag is handled even though the constant is now empty
+  // (aiwatch#618 emptied it; the May 2026 archive still carries the flag).
   const zero = services.filter(s => s.data.incidents === 0)
   const confirmed = zero
-    .filter(s => !NO_PUBLIC_UPTIME.has(s.id) && !STALE_SOURCE.has(s.id))
+    .filter(s => !NO_PUBLIC_UPTIME.has(s.id) && !isStaleSource(s))
     .map(s => serviceName(s.id, meta))
-  // STALE_SOURCE is excluded from noFeed too (defensive — deepseek ∉ NO_PUBLIC_UPTIME today, but
-  // both sets are hand-maintained; a future stale service that also lacks a public uptime feed must
-  // get the more-specific Stale-source line, not a double caveat).
+  // Stale sources are excluded from noFeed too (defensive — a future stale service that also lacks a
+  // public uptime feed must get the more-specific Stale-source line, not a double caveat).
   const noFeed = zero
-    .filter(s => NO_PUBLIC_UPTIME.has(s.id) && !STALE_SOURCE.has(s.id))
+    .filter(s => NO_PUBLIC_UPTIME.has(s.id) && !isStaleSource(s))
     .map(s => serviceName(s.id, meta))
   const zeroLines = []
   if (confirmed.length) {
@@ -321,10 +326,11 @@ function buildIncidentTable(services, meta) {
   if (noFeed.length) {
     zeroLines.push(`**No incident feed (${noFeed.length} services):** ${noFeed.join(', ')} — AIWatch has no reliable incident feed for these (RSS / estimate-only), so a blank incident count reflects monitoring coverage, not verified incident-free operation.`)
   }
-  // Stale-source caveat (aiwatch#507) — rendered whenever a STALE_SOURCE service is in the report,
-  // regardless of its incident count (DeepSeek's May count is 3 but partial; its June count is 0 but
-  // not verified). Frozen feed → count + uptime + Score are not current.
-  const staleLine = buildStaleSourceCaveat(services.filter(s => STALE_SOURCE.has(s.id)).map(s => serviceName(s.id, meta)))
+  // Stale-source caveat (aiwatch#507) — rendered whenever a stale service is in the report (by the
+  // archive's incidentSourceStale flag or the STALE_SOURCE constant), regardless of incident count:
+  // a frozen feed means count + uptime + Score are not current. Driven by isStaleSource, not the raw
+  // constant, so it survives the aiwatch#618 emptying of STALE_SOURCE (the May archive's flag still fires).
+  const staleLine = buildStaleSourceCaveat(services.filter(s => isStaleSource(s)).map(s => serviceName(s.id, meta)))
   if (staleLine) zeroLines.push(staleLine)
   const zeroIncLine = zeroLines.join('\n\n')
 

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -153,9 +153,10 @@ test('returns empty string when nothing is excluded', () => {
 
 // #591 — stale-source services are excluded from the Score ranking (frozen feed inflates the Score).
 console.log('\nisStaleSource (#591)')
-test('archive flag true → stale; absent falls back to the STALE_SOURCE constant', () => {
-  eq(isStaleSource({ id: 'openai', data: { incidentSourceStale: true } }), true)   // new archive flag
-  eq(isStaleSource({ id: 'deepseek', data: {} }), true)                            // legacy archive → constant
+test('archive flag drives staleness; STALE_SOURCE constant is empty since aiwatch#618', () => {
+  eq(isStaleSource({ id: 'openai', data: { incidentSourceStale: true } }), true)   // archive flag
+  eq(isStaleSource({ id: 'deepseek', data: { incidentSourceStale: true } }), true) // May archive: flag still set → stale
+  eq(isStaleSource({ id: 'deepseek', data: {} }), false)                           // #618 — removed from STALE_SOURCE; absent flag ⇒ not stale (June+)
   eq(isStaleSource({ id: 'cohere', data: {} }), false)                             // neither
 })
 
@@ -282,11 +283,13 @@ test('splits zero-incident services into confirmed vs no-feed (estimate) (#29)',
   assert.ok(/\*\*No incident feed \(1 services\):\*\* Amazon Bedrock/.test(zeroIncLine), `no-feed line: ${zeroIncLine}`)
 })
 
-// aiwatch#507 — DeepSeek status page migrated to Flashduty (unreachable server-side); its feed
-// is frozen, so neither a partial nonzero count nor a frozen zero is a verified picture.
-test('STALE_SOURCE: caveat renders with a NONZERO count (deepseek 3 partial-month incidents)', () => {
+// aiwatch#507 — a status page that migrated to an unreachable platform freezes its feed, so neither
+// a partial nonzero count nor a frozen zero is a verified picture. Since aiwatch#618 the STALE_SOURCE
+// constant is empty (DeepSeek is readable again), so staleness is driven by the archive's
+// `incidentSourceStale` flag — these tests set it explicitly (e.g. the frozen May 2026 archive).
+test('STALE_SOURCE: caveat renders with a NONZERO count (3 partial-month incidents, flag set)', () => {
   const services = [
-    { id: 'deepseek', data: { score: 82, incidents: 3, uptime: 99.92, avgResolutionMin: 18, totalDowntimeMin: 53, longestIncidentMin: 34 } },
+    { id: 'deepseek', data: { score: 82, incidents: 3, uptime: 99.92, avgResolutionMin: 18, totalDowntimeMin: 53, longestIncidentMin: 34, incidentSourceStale: true } },
   ]
   const meta = { deepseek: { name: 'DeepSeek API' } }
   const { tableRows, zeroIncLine } = buildIncidentTable(services, meta)
@@ -295,10 +298,10 @@ test('STALE_SOURCE: caveat renders with a NONZERO count (deepseek 3 partial-mont
   assert.ok(/floor, not a verified picture\./.test(zeroIncLine), 'self-contained caveat')
   assert.ok(!/#\d+/.test(zeroIncLine), 'no reader-facing internal issue number')
 })
-test('STALE_SOURCE: a frozen ZERO count is NOT labelled "confirmed zero"', () => {
+test('STALE_SOURCE: a frozen ZERO count is NOT labelled "confirmed zero" (flag set)', () => {
   const services = [
     { id: 'cohere', data: { score: 89, incidents: 0, uptime: 100, avgResolutionMin: null } },
-    { id: 'deepseek', data: { score: 82, incidents: 0, uptime: 99.92, avgResolutionMin: null } },
+    { id: 'deepseek', data: { score: 82, incidents: 0, uptime: 99.92, avgResolutionMin: null, incidentSourceStale: true } },
   ]
   const meta = { cohere: { name: 'Cohere API' }, deepseek: { name: 'DeepSeek API' } }
   const { zeroIncLine } = buildIncidentTable(services, meta)


### PR DESCRIPTION
Follows the main-repo DeepSeek work (aiwatch#618 browser-rendered Flashduty feed, aiwatch#619 DeepSeek App).

- **Service count 36 → 37** (4 AI apps) across README, _config.yml, _templates/monthly-report.md, index.md, generate-charts.js (current-site-wide only; historical monthly counts untouched).
- **2026-05 report** — replace the DeepSeek "Stale source" caveat with a dated **Correction**: the complete month is 7 DeepSeek API incidents (total 2h 8m, longest 33m, median 18m, ~99.78%) + 6 Web Chat incidents (now the separate DeepSeek App). Month-end ranking/uptime/incident tables are an immutable archive snapshot, intentionally not regenerated (the note says so).
- **Generator** — empty the `STALE_SOURCE` constant (DeepSeek is readable again) and drive the stale caveat off `isStaleSource()` (flag-OR-constant) so June+ DeepSeek is not stale while the May archive's flag still fires. Generator tests **141 pass**.

Verified: Jekyll renders 2026-05 with the Correction; generator tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)