### PR TITLE
feat(report): 3-month trend + Notable Movers (Score/MTTR/downtime) (refs #41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 Each monthly report includes:
 
 - **AIWatch Score Rankings** — Composite reliability score (uptime + incidents + recovery time)
+- **3-Month Trend** — Score direction over the trailing 3 months (slope chart), plus **Notable Movers**: the services whose Score, recovery time (MTTR), or total downtime changed most, so a flat Score can't hide a recovery-time regression. Auto-rendered once ≥2 months of archive exist; omitted otherwise. (Uptime is intentionally not trended — see *Methodology*.)
 - **Incident Summary** — Total downtime and incident counts per service
 - **Official Uptime** — Provider-reported uptime figures
 - **Notable Incidents** — Top 5 incidents with root cause and impact
@@ -35,6 +36,7 @@ Each monthly report includes:
 - **Uptime figures**: Official status page metrics — single primary component basis where available, platform-wide average otherwise
 - **Incident counts**: Per-component aggregation — some providers (e.g., Anthropic) report per model, so counts may exceed distinct outages
 - **API probe**: Direct RTT measurement every 5 minutes to 20 services with public endpoints (supplementary monitoring data)
+- **3-Month Trend (Notable Movers)**: ranked by the largest single change across **Score / MTTR / total downtime** over the window — incident-feed *measured* metrics. Uptime is deliberately excluded: the archive's `uptime` field mixes per-service sources (status-page group aggregates, estimate/poll-derived figures) so a cross-service uptime delta is misleading (a 3-month official-uptime trend awaits aiwatch#586 + ≥3 months of the clean `officialUptime` field). Direction (🔺/🔻) follows the bold *headline* metric, not Score. Services the Score ranking excludes (no-incident-feed / stale source) are excluded from movers too. The first point is flagged when its month is partial (mid-month onboarding); MTTR/downtime are measured over the months that have incident data.
 
 Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
 
@@ -55,9 +57,11 @@ New monthly reports are generated from the permanent archive — no live-data fa
 
 **Local:**
 ```bash
-node scripts/generate-report.js 2026-04   # writes 2026-04/index.md with published: false
-node scripts/generate-charts.js 2026-04/index.md
+node scripts/generate-report.js 2026-04   # writes 2026-04/index.md (incl. the 3-Month Trend section)
+node scripts/generate-charts.js 2026-04/index.md   # writes score-chart.svg, uptime-heatmap.svg, trend-chart.svg
 ```
+
+The trend section + chart read the trailing months from `_data/` (prior months) plus the current report (this month), so they auto-populate once `_data/` holds ≥2 consecutive months; the first one or two reports render without the section. The first fully-comparable 3-month window is **2026-06** (Apr/May/Jun all full months).
 
 **GitHub Actions** (`.github/workflows/generate-report.yml`):
 1. Open the workflow's "Run workflow" page

--- a/_data/README.md
+++ b/_data/README.md
@@ -5,6 +5,21 @@ Stored alongside KV for long-term git preservation and trend analysis.
 
 Files are named `{YYYY-MM}.json` (e.g., `2026-03.json`).
 
+## Consumed by the 3-Month Trend section
+
+`generate-report.js` (`buildTrendSection`) and `generate-charts.js` (`generateTrendSvg`) read the
+**trailing months** here to render the report's *3-Month Trend* + *Notable Movers* (aiwatch-reports#41).
+The drift caveats below are handled, not ignored:
+- **Partial month** (e.g. `2026-03`, 12-day window): flagged on the trend's x-axis (`Mar*`) + a footnote;
+  MTTR / downtime are measured over the months that actually have incident data (first-present → last-present),
+  so a sparse partial month doesn't zero out the trend.
+- **Roster drift** (a service added mid-window appears with no score in earlier months): excluded from
+  *movers* — a service needs a Score at BOTH window ends to qualify, so a mid-window add never reads as a fake change.
+- **Excluded services**: no-incident-feed (`bedrock`, `azureopenai`) and stale-source services are kept out
+  of movers, mirroring the Score ranking's own exclusion.
+- **Uptime is NOT trended** from these files — the `uptime` field mixes per-service sources (group aggregates /
+  estimates), so only the incident-*measured* Score / MTTR / total-downtime fields feed the decomposition.
+
 ## Snapshot provenance
 
 Two paths produce these files:

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -69,6 +69,13 @@ published: true
 
 ---
 
+<!-- TREND_SECTION -->
+<!-- ^ Auto-rendered by generate-report.js (buildTrendSection) from the current archive +
+     committed _data/{YYYY-MM}.json snapshots of prior months (aiwatch-reports#41). Emits the
+     whole "## N-Month Trend" section (ending in its own `---`) when ≥2 months of history exist
+     and there's a Score mover, else nothing — the case for the first 1–2 reports. The slope-chart
+     SVG is written by generate-charts.js under the same gate. Do not hand-author. -->
+
 ## AIWatch Score — [MONTH] [YEAR] Reliability Rankings
 
 **AIWatch Score (0–100)** is designed to answer one question:

--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -228,8 +228,362 @@ ${footnote}
 </svg>`
 }
 
+// ── 3-Month Trend (aiwatch#637 quick-win / aiwatch-reports#41) ──────────
+//
+// Turns the single-month snapshot into a directional signal: "Claude API 71 → 68
+// → 63, down 3 months running". Score is the primary metric (uptime/MTTR can be
+// layered later). The multi-month core is PURE (buildTrendSeries / computeScoreMovers)
+// so it's unit-testable without filesystem or network; the IO wrappers are thin.
+//
+// Data sourcing (deliberate, see #41): PRIOR months come from the committed
+// `_data/{YYYY-MM}.json` snapshots (immutable history, no network); the CURRENT
+// month comes from the freshly-built report (its Score table / the archive the
+// report generator already fetched) — because in the CI pipeline `fetch-archive.sh`
+// writes `_data/{currentMonth}.json` AFTER generate-charts runs, so that file isn't
+// present yet when the chart is drawn.
+
+// Return the `count` month keys immediately BEFORE `month` (ascending), e.g.
+// monthsBefore('2026-06', 2) → ['2026-04', '2026-05']. UTC-based, no Date.now().
+function monthsBefore(month, count) {
+  const [y, m] = month.split('-').map(Number)
+  const out = []
+  for (let i = count; i >= 1; i--) {
+    // m is 1-based; Date(y, m-1 - i, 1) walks back i months, normalizing year.
+    const d = new Date(Date.UTC(y, m - 1 - i, 1))
+    out.push(`${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`)
+  }
+  return out
+}
+
+function daysInMonthOf(month) {
+  const [y, m] = month.split('-').map(Number)
+  return new Date(y, m, 0).getDate()
+}
+
+// Read a committed `_data/{month}.json` snapshot → archive-like object, or null if
+// absent/corrupt (a missing prior month must degrade gracefully, never throw).
+function readDataArchive(month, dataDir) {
+  try {
+    const raw = fs.readFileSync(path.join(dataDir, `${month}.json`), 'utf-8')
+    const d = JSON.parse(raw)
+    return d.archive || d
+  } catch {
+    return null
+  }
+}
+
+// Normalize an archive-like object into a trend month-entry. `daysCollected`
+// (when present) drives the partial-month flag; absent → assumed full.
+function toMonthEntry(month, archiveLike) {
+  if (!archiveLike || !archiveLike.services) return null
+  const services = {}
+  for (const [id, s] of Object.entries(archiveLike.services)) {
+    services[id] = {
+      score: s && typeof s.score === 'number' ? s.score : null,
+      grade: s && s.grade ? s.grade : null,
+      // MTTR + total downtime feed the Notable Movers decomposition — both incident-feed
+      // MEASURED values, consistent across services. The archive's `uptime` field is
+      // deliberately NOT used: it mixes per-service sources (group aggregates like ChatGPT's
+      // #586 over-count, estimate/poll-derived figures), so surfacing it as a reader-facing
+      // "uptime" produces contradictory score-up/uptime-down lines. The clean status-page field
+      // (`officialUptime`) is carried only in archives from 2026-06 onward (see officialUptimeFor
+      // in generate-report.js) and isn't in the trailing snapshots yet, so a 3-month official-uptime
+      // delta isn't available — add it once #586 lands AND officialUptime spans ≥3 archived months. (#41)
+      // mttr (avgResolutionMin) / downtime (totalDowntimeMin) are null in a zero-incident month.
+      mttr: s && typeof s.avgResolutionMin === 'number' ? s.avgResolutionMin : null,
+      downtime: s && typeof s.totalDowntimeMin === 'number' ? s.totalDowntimeMin : null,
+    }
+  }
+  return {
+    month,
+    daysInMonth: daysInMonthOf(month),
+    daysCollected: archiveLike && typeof archiveLike.daysCollected === 'number' ? archiveLike.daysCollected : null,
+    services,
+  }
+}
+
+// Build a CURRENT-month entry from a parsed AIWatch Score table (the report MD rows:
+// { Service, Score, Grade }). daysCollected is unknown here → treated as full; the
+// report-side section uses the real archive so its partial-flag is authoritative.
+function monthEntryFromScoreRows(month, rows) {
+  const services = {}
+  for (const r of rows || []) {
+    const id = nameToId(r.Service)
+    const score = parseInt(r.Score, 10)
+    services[id] = { score: Number.isNaN(score) ? null : score, grade: r.Grade || null }
+  }
+  return { month, daysInMonth: daysInMonthOf(month), daysCollected: daysInMonthOf(month), services }
+}
+
+// PURE. monthEntries: [{ month, daysInMonth, daysCollected, services:{ id:{score,grade} } }]
+// ascending by month. Returns { months, partialMonths:Set, series:{ id:{ id, points } } }
+// where points align 1:1 with months (score=null when the service is absent that month).
+function buildTrendSeries(monthEntries) {
+  const months = monthEntries.map(e => e.month)
+  const partialMonths = new Set(
+    monthEntries
+      .filter(e => typeof e.daysCollected === 'number' && e.daysCollected < e.daysInMonth)
+      .map(e => e.month),
+  )
+  const ids = new Set()
+  monthEntries.forEach(e => Object.keys(e.services || {}).forEach(id => ids.add(id)))
+
+  const series = {}
+  for (const id of ids) {
+    const points = monthEntries.map(e => {
+      const s = e.services && e.services[id]
+      return {
+        month: e.month,
+        score: s && typeof s.score === 'number' ? s.score : null,
+        grade: s && s.grade ? s.grade : null,
+        mttr: s && typeof s.mttr === 'number' ? s.mttr : null,
+        downtime: s && typeof s.downtime === 'number' ? s.downtime : null,
+        partial: partialMonths.has(e.month),
+      }
+    })
+    series[id] = { id, points }
+  }
+  return { months, partialMonths, series }
+}
+
+// PURE. Top decliners + improvers by Score delta across the window. Only services
+// with a numeric score in BOTH the first AND last month qualify (so a service added
+// mid-window isn't reported as a fake mover). `monoDown` flags a monotonic decline
+// across every present point (the "N months running" signal).
+function computeScoreMovers(trend, opts = {}) {
+  const { limit = 3, nameFor = id => id, exclude = new Set() } = opts
+  const { months, series } = trend
+  if (!months || months.length < 2) return { declining: [], improving: [], firstMonth: null, lastMonth: null }
+  const firstMonth = months[0]
+  const lastMonth = months[months.length - 1]
+
+  const rows = []
+  for (const id of Object.keys(series)) {
+    if (exclude.has(id)) continue // services the report doesn't rank (no-incident-feed / stale source)
+    const pts = series[id].points
+    const first = pts.find(p => p.month === firstMonth)
+    const last = pts.find(p => p.month === lastMonth)
+    if (!first || !last || first.score === null || last.score === null) continue
+    const delta = last.score - first.score
+    const present = pts.filter(p => p.score !== null)
+    // STRICT decrease at every step — a flat-then-drop (88 → 88 → 71) is a net decline
+    // but NOT "down every month", so it must not earn the ⚠︎ every-month label.
+    const monoDown = present.length >= 2 && delta < 0 && present.every((p, i) => i === 0 || p.score < present[i - 1].score)
+    rows.push({ id, name: nameFor(id), delta, first: first.score, last: last.score, points: pts, monoDown })
+  }
+
+  const declining = rows.filter(r => r.delta < 0).sort((a, b) => a.delta - b.delta).slice(0, limit)
+  const improving = rows.filter(r => r.delta > 0).sort((a, b) => b.delta - a.delta).slice(0, limit)
+  return { declining, improving, firstMonth, lastMonth }
+}
+
+// Delta of a sparse metric over the months that actually have data: first-present →
+// last-present. { first, last, delta } where delta is null for <2 present points (a value,
+// not a trend) and { null, null, null } when the metric is never present.
+function presentDelta(points, field) {
+  const present = points.filter(p => p[field] !== null && p[field] !== undefined)
+  if (present.length === 0) return { first: null, last: null, delta: null }
+  const first = present[0][field]
+  const last = present[present.length - 1][field]
+  return { first, last, delta: present.length >= 2 ? last - first : null }
+}
+
+// PURE. "Notable Movers" — the decision-grade list. Unlike computeScoreMovers (which ranks
+// by Score delta only, for the slope chart's emphasis), this ranks by the LARGEST move across
+// Score / MTTR / total-downtime — incident-feed MEASURED metrics — so a service with a FLAT
+// score but a big recovery-time regression (e.g. Gemini Score 64→64 but MTTR 2h→22h) still
+// surfaces; that's the "should I keep relying on this?" signal a composite score hides.
+// `uptime` is intentionally excluded (see toMonthEntry: mixed sources / #586 over-count make it
+// misleading and it hijacks the ranking). Each row carries all three deltas + which axis moved
+// most (`emphasize`) so the renderer can bold it. Magnitudes are normalized to comparable units:
+// 10 score pts ≈ 60 min MTTR ≈ 120 min downtime ≈ 1.0.
+function computeNotableMovers(trend, opts = {}) {
+  const { limit = 5, nameFor = id => id, exclude = new Set() } = opts
+  const { months, series } = trend
+  if (!months || months.length < 2) return []
+  const firstMonth = months[0]
+  const lastMonth = months[months.length - 1]
+
+  const rows = []
+  for (const id of Object.keys(series)) {
+    if (exclude.has(id)) continue // services the report doesn't rank (no-incident-feed / stale source)
+    const pts = series[id].points
+    const f = pts.find(p => p.month === firstMonth)
+    const l = pts.find(p => p.month === lastMonth)
+    // Require Score at both ends so a mid-window-added service isn't a fake mover.
+    if (!f || !l || f.score === null || l.score === null) continue
+
+    const scoreDelta = l.score - f.score
+    // MTTR / downtime are sparse (null in a zero-incident month — common in a partial month
+    // like a mid-month-onboarded March), so measure their delta over the months that HAVE
+    // data (first-present → last-present), not the strict window endpoints. A single present
+    // point → delta null (a value, not a trend). Score always uses the window endpoints.
+    const mttr = presentDelta(pts, 'mttr')
+    const downtime = presentDelta(pts, 'downtime')
+
+    const nScore = Math.abs(scoreDelta) / 10
+    const nMttr = mttr.delta !== null ? Math.abs(mttr.delta) / 60 : 0
+    const nDowntime = downtime.delta !== null ? Math.abs(downtime.delta) / 120 : 0
+    const notability = Math.max(nScore, nMttr, nDowntime)
+    if (notability === 0) continue // nothing moved meaningfully
+
+    let emphasize = 'score'
+    if (nMttr >= nScore && nMttr >= nDowntime) emphasize = 'mttr'
+    else if (nDowntime >= nScore && nDowntime >= nMttr) emphasize = 'downtime'
+
+    // Direction follows the EMPHASIZED (headline) axis so the 🔺/🔻 marker never contradicts
+    // the bolded metric — e.g. Mistral with Score +1 but downtime +36h is a 🔻 (the downtime
+    // regression is the story; the small score gain is shown transparently beside it). More
+    // downtime / slower recovery = worse = declining. Falls back through the other axes if the
+    // chosen one is exactly flat.
+    let sign = 0
+    if (emphasize === 'mttr') sign = -Math.sign(mttr.delta || 0)
+    else if (emphasize === 'downtime') sign = -Math.sign(downtime.delta || 0)
+    else sign = Math.sign(scoreDelta)
+    if (sign === 0) {
+      sign = scoreDelta !== 0 ? Math.sign(scoreDelta)
+        : downtime.delta ? -Math.sign(downtime.delta)
+        : mttr.delta ? -Math.sign(mttr.delta) : 0
+    }
+
+    rows.push({
+      id,
+      name: nameFor(id),
+      score: { first: f.score, last: l.score, delta: scoreDelta, points: pts },
+      mttr,
+      downtime,
+      notability,
+      emphasize,
+      declining: sign < 0,
+    })
+  }
+
+  rows.sort((a, b) => b.notability - a.notability || Math.abs(b.score.delta) - Math.abs(a.score.delta))
+  return rows.slice(0, limit)
+}
+
+// "71 → 68 → 63" from a series' points (skips months the service was absent).
+function formatTrendArrow(points) {
+  return points.filter(p => p.score !== null).map(p => p.score).join(' → ')
+}
+
+// "+8" / "−8" (real minus sign for typography).
+function fmtScoreDelta(delta) {
+  if (delta > 0) return `+${delta}`
+  if (delta < 0) return `−${Math.abs(delta)}`
+  return '±0'
+}
+
+// The trend window, in months — a ROLLING window: each report shows the latest TREND_MONTHS
+// (current + TREND_MONTHS-1 prior), not a cumulative all-history view. Single source of truth
+// for both consumers (the report section + the slope chart) so the window can be widened (e.g.
+// to 6) in ONE place once enough clean history (incl. the post-#586 officialUptime field)
+// accumulates. The "## N-Month Trend" heading derives N from the months actually present, so a
+// change here — or an early report with fewer months — relabels automatically. (aiwatch-reports#41)
+const TREND_MONTHS = 3
+
+// Assemble the trend month-entries for `month`: prior months from `_data/`, the
+// current month from `currentEntry` (built by the caller from the report/archive).
+// Filters out months with no snapshot so a gap degrades gracefully.
+function loadTrendEntries(month, currentEntry, opts = {}) {
+  const { months = TREND_MONTHS, dataDir = path.resolve('_data') } = opts
+  const entries = []
+  for (const pm of monthsBefore(month, months - 1)) {
+    const e = toMonthEntry(pm, readDataArchive(pm, dataDir))
+    if (e) entries.push(e)
+  }
+  if (currentEntry) entries.push(currentEntry)
+  return entries
+}
+
+// ── Trend slope chart ────────────────────────────────────
+// All services render as faint context lines; the movers (decliners red, improvers
+// green) are emphasized + end-labeled. Partial months get a "*" on the x-axis label.
+function generateTrendSvg(trend, opts = {}) {
+  const { nameFor = id => id, movers = computeScoreMovers(trend, { nameFor }) } = opts
+  const { months, partialMonths, series } = trend
+
+  const padding = { top: 50, right: 150, bottom: 40, left: 40 }
+  const plotW = 360
+  const plotH = 300
+  const width = padding.left + plotW + padding.right
+  const height = padding.top + plotH + padding.bottom
+
+  const n = months.length
+  const xFor = i => padding.left + (n === 1 ? plotW / 2 : (i / (n - 1)) * plotW)
+  const yFor = score => padding.top + plotH - (score / 100) * plotH
+
+  // y gridlines + labels (0/25/50/75/100)
+  const gridlines = [0, 25, 50, 75, 100].map(v => {
+    const y = yFor(v)
+    return [
+      `  <line x1="${padding.left}" y1="${y}" x2="${padding.left + plotW}" y2="${y}" stroke="${COLORS.border}" stroke-width="1" opacity="0.5"/>`,
+      `  <text x="${padding.left - 8}" y="${y + 4}" fill="${COLORS.textMuted}" font-size="10" font-family="ui-monospace,monospace" text-anchor="end">${v}</text>`,
+    ].join('\n')
+  }).join('\n')
+
+  // x labels (month short name + "*" when partial)
+  const xLabels = months.map((m, i) => {
+    const [yr, mo] = m.split('-').map(Number)
+    const name = new Date(yr, mo - 1).toLocaleString('en-US', { month: 'short' })
+    const star = partialMonths.has(m) ? '*' : ''
+    return `  <text x="${xFor(i)}" y="${padding.top + plotH + 20}" fill="${COLORS.textMuted}" font-size="11" font-family="ui-monospace,monospace" text-anchor="middle">${name}${star}</text>`
+  }).join('\n')
+
+  const moverIds = new Set([...movers.declining, ...movers.improving].map(m => m.id))
+  const polyFor = (pts, stroke, strokeWidth, opacity) => {
+    const drawn = pts.map((p, i) => ({ p, i })).filter(o => o.p.score !== null)
+    if (drawn.length < 2) return ''
+    const d = drawn.map(o => `${xFor(o.i).toFixed(1)},${yFor(o.p.score).toFixed(1)}`).join(' ')
+    return `  <polyline points="${d}" fill="none" stroke="${stroke}" stroke-width="${strokeWidth}" opacity="${opacity}"/>`
+  }
+
+  // context lines (non-movers, faint)
+  const contextLines = Object.values(series)
+    .filter(s => !moverIds.has(s.id))
+    .map(s => polyFor(s.points, COLORS.textMuted, 1, 0.18))
+    .filter(Boolean)
+    .join('\n')
+
+  // mover lines (emphasized) + end labels
+  const moverRows = [...movers.declining, ...movers.improving].map(m => {
+    const color = m.delta < 0 ? COLORS.down : COLORS.operational
+    const line = polyFor(m.points, color, 2.5, 0.95)
+    const drawn = m.points.map((p, i) => ({ p, i })).filter(o => o.p.score !== null)
+    const lastDrawn = drawn[drawn.length - 1]
+    const label = lastDrawn
+      ? `  <text x="${(xFor(lastDrawn.i) + 8).toFixed(1)}" y="${(yFor(lastDrawn.p.score) + 4).toFixed(1)}" fill="${color}" font-size="11" font-family="ui-monospace,monospace">${escapeXml(m.name)} ${fmtScoreDelta(m.delta)}</text>`
+      : ''
+    return [line, label].filter(Boolean).join('\n')
+  }).filter(Boolean).join('\n')
+
+  const partialNote = partialMonths.size
+    ? `  <text x="${padding.left}" y="${height - 6}" fill="${COLORS.textMuted}" font-size="9" font-family="ui-monospace,monospace" opacity="0.7">* partial month — fewer days monitored; indicative only</text>`
+    : ''
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">
+  <style>
+    .chart-bg { fill: ${COLORS.bg}; }
+    .chart-title { fill: ${COLORS.text}; }
+  </style>
+  <rect class="chart-bg" width="100%" height="100%" fill="${COLORS.bg}"/>
+  <text x="${padding.left}" y="28" fill="${COLORS.text}" font-size="14" font-weight="600" font-family="ui-monospace,monospace" class="chart-title">AIWatch Score — ${n}-Month Trend</text>
+${gridlines}
+${xLabels}
+${contextLines}
+${moverRows}
+${partialNote}
+</svg>`
+}
+
 // ── Exports ──────────────────────────────────────────────
-module.exports = { generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade }
+module.exports = {
+  generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade,
+  // trend (aiwatch-reports#41)
+  monthsBefore, daysInMonthOf, readDataArchive, toMonthEntry, monthEntryFromScoreRows,
+  buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta, loadTrendEntries,
+  generateTrendSvg, nameToId, ID_TO_NAME, TREND_MONTHS,
+}
 
 // ── CLI ──────────────────────────────────────────────────
 if (require.main === module) {
@@ -273,6 +627,29 @@ if (require.main === module) {
   const scorePath = path.join(outDir, 'score-chart.svg')
   fs.writeFileSync(scorePath, scoreSvg + '\n', 'utf-8')
   console.log(`✓ ${scorePath}`)
+
+  // 3-month trend chart (sync — prior months from committed _data/, current month
+  // from this report's parsed Score table). Written only when ≥2 months are available
+  // (a lone first month has no trend); the report's TREND_SECTION applies the same
+  // gate so the `![](trend-chart.svg)` ref never dangles.
+  const currentEntry = monthEntryFromScoreRows(monthKey, scores)
+  const trendEntries = loadTrendEntries(monthKey, currentEntry, { dataDir: path.resolve('_data') })
+  if (trendEntries.length >= 2) {
+    const trend = buildTrendSeries(trendEntries)
+    // No explicit `exclude` here (unlike the report-section path): the current-month entry is
+    // built from the parsed AIWatch Score table, and buildScoreTable already drops the services
+    // the report doesn't rank (NO_INCIDENT_FEED + stale), so an excluded service has a null
+    // current-month score and computeScoreMovers' "score at both ends" guard filters it from
+    // emphasis automatically — it can only ever appear as a faint context line. If the current
+    // month is ever sourced from the full archive instead, pass the same exclude set here too.
+    const movers = computeScoreMovers(trend, { nameFor: id => ID_TO_NAME[id] || id })
+    const trendSvg = generateTrendSvg(trend, { nameFor: id => ID_TO_NAME[id] || id, movers })
+    const trendPath = path.join(outDir, 'trend-chart.svg')
+    fs.writeFileSync(trendPath, trendSvg + '\n', 'utf-8')
+    console.log(`✓ ${trendPath} (${trendEntries.length} months: ${trend.months.join(', ')})`)
+  } else {
+    console.log(`• trend-chart.svg skipped — only ${trendEntries.length} month(s) of _data available (need ≥2)`)
+  }
 
   // Uptime heatmap — fetch real data from API
   const API_URL = 'https://aiwatch-worker.p2c2kbf.workers.dev/api/uptime?days=' + daysInMonth

--- a/scripts/generate-charts.test.js
+++ b/scripts/generate-charts.test.js
@@ -1,4 +1,8 @@
-const { generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade } = require('./generate-charts')
+const {
+  generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade,
+  monthsBefore, buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta,
+  generateTrendSvg, toMonthEntry, monthEntryFromScoreRows,
+} = require('./generate-charts')
 const assert = require('assert')
 
 let passed = 0
@@ -193,6 +197,267 @@ test('dark background, no light mode', () => {
 test('heatmap cells use rx=2', () => {
   const svg = generateUptimeHeatmapSvg(['Claude API'], MOCK_HISTORY, 31, '2026-03', 20, 20)
   assert.ok(svg.includes('rx="2"'), 'should use rx=2 for cells')
+})
+
+// ── 3-Month Trend (aiwatch-reports#41) ───────────────────
+
+console.log('\nmonthsBefore')
+
+test('returns the N months immediately before, ascending', () => {
+  assert.deepStrictEqual(monthsBefore('2026-06', 2), ['2026-04', '2026-05'])
+})
+
+test('wraps the year boundary', () => {
+  assert.deepStrictEqual(monthsBefore('2026-02', 3), ['2025-11', '2025-12', '2026-01'])
+})
+
+// Three months: March is PARTIAL (12/31 days). Claude declines every month;
+// Gemini improves; Newbie only appears in the last month (mid-window add).
+const TREND_ENTRIES = [
+  { month: '2026-03', daysInMonth: 31, daysCollected: 12, services: { claude: { score: 71, grade: 'Good' }, gemini: { score: 80, grade: 'Good' } } },
+  { month: '2026-04', daysInMonth: 30, daysCollected: 30, services: { claude: { score: 68, grade: 'Good' }, gemini: { score: 85, grade: 'Good' } } },
+  { month: '2026-05', daysInMonth: 31, daysCollected: 31, services: { claude: { score: 63, grade: 'Fair' }, gemini: { score: 90, grade: 'Excellent' }, newbie: { score: 50, grade: 'Fair' } } },
+]
+
+console.log('\nbuildTrendSeries')
+
+test('aligns points 1:1 with months', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  eq(t.months.length, 3)
+  eq(t.series.claude.points.length, 3)
+  assert.deepStrictEqual(t.series.claude.points.map(p => p.score), [71, 68, 63])
+})
+
+test('a service added mid-window gets null for the months it was absent', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  assert.deepStrictEqual(t.series.newbie.points.map(p => p.score), [null, null, 50])
+})
+
+test('flags the partial month (daysCollected < daysInMonth)', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  assert.ok(t.partialMonths.has('2026-03'), '2026-03 should be partial')
+  assert.ok(!t.partialMonths.has('2026-04'), '2026-04 (30/30) should be full')
+  assert.ok(!t.partialMonths.has('2026-05'), '2026-05 (31/31) should be full')
+})
+
+console.log('\ncomputeScoreMovers')
+
+test('ranks decliners and improvers by delta', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  const m = computeScoreMovers(t)
+  eq(m.declining[0].id, 'claude')
+  eq(m.declining[0].delta, -8)
+  eq(m.improving[0].id, 'gemini')
+  eq(m.improving[0].delta, 10)
+})
+
+test('flags a strictly monotonic decline (down every month)', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  const m = computeScoreMovers(t)
+  eq(m.declining[0].monoDown, true) // claude 71 → 68 → 63
+})
+
+test('does NOT flag a flat-then-drop as down-every-month', () => {
+  // 88 → 88 → 71: net decline (−17) but the first step is flat, not a decrease.
+  const flat = [
+    { month: '2026-03', daysInMonth: 31, daysCollected: 31, services: { svc: { score: 88, grade: 'Good' } } },
+    { month: '2026-04', daysInMonth: 30, daysCollected: 30, services: { svc: { score: 88, grade: 'Good' } } },
+    { month: '2026-05', daysInMonth: 31, daysCollected: 31, services: { svc: { score: 71, grade: 'Fair' } } },
+  ]
+  const m = computeScoreMovers(buildTrendSeries(flat))
+  eq(m.declining[0].id, 'svc')
+  eq(m.declining[0].delta, -17)
+  eq(m.declining[0].monoDown, false)
+})
+
+test('excludes a service missing in the first or last month (no fake mover)', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  const m = computeScoreMovers(t)
+  const ids = [...m.declining, ...m.improving].map(r => r.id)
+  assert.ok(!ids.includes('newbie'), 'mid-window-added service must not be a mover')
+})
+
+test('returns empty movers for a single month (no trend)', () => {
+  const t = buildTrendSeries([TREND_ENTRIES[2]])
+  const m = computeScoreMovers(t)
+  eq(m.declining.length, 0)
+  eq(m.improving.length, 0)
+})
+
+test('honors a nameFor mapping', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  const m = computeScoreMovers(t, { nameFor: id => (id === 'claude' ? 'Claude API' : id) })
+  eq(m.declining[0].name, 'Claude API')
+})
+
+console.log('\ncomputeNotableMovers')
+
+// Gemini: FLAT score (64→64) but MTTR spikes 2h→22h — the decision signal a composite
+// score hides. claude: score + MTTR + downtime all decline. steady: nothing moves.
+const NOTABLE_ENTRIES = [
+  { month: '2026-03', daysInMonth: 31, daysCollected: 31, services: {
+    gemini: { score: 64, grade: 'Fair', mttr: 120, downtime: 240 },
+    claude: { score: 71, grade: 'Good', mttr: 30, downtime: 60 },
+    steady: { score: 80, grade: 'Good', mttr: 10, downtime: 20 },
+  } },
+  { month: '2026-04', daysInMonth: 30, daysCollected: 30, services: {
+    gemini: { score: 64, grade: 'Fair', mttr: 600, downtime: 1200 },
+    claude: { score: 68, grade: 'Good', mttr: 90, downtime: 180 },
+    steady: { score: 80, grade: 'Good', mttr: 10, downtime: 20 },
+  } },
+  { month: '2026-05', daysInMonth: 31, daysCollected: 31, services: {
+    gemini: { score: 64, grade: 'Fair', mttr: 1320, downtime: 2640 },
+    claude: { score: 63, grade: 'Fair', mttr: 180, downtime: 360 },
+    steady: { score: 80, grade: 'Good', mttr: 10, downtime: 20 },
+  } },
+]
+
+test('surfaces a FLAT-score service whose MTTR spiked (the signal Score hides)', () => {
+  const n = computeNotableMovers(buildTrendSeries(NOTABLE_ENTRIES))
+  eq(n[0].id, 'gemini')          // biggest normalized move
+  eq(n[0].score.delta, 0)        // score is flat
+  eq(n[0].mttr.delta, 1200)
+  eq(n[0].downtime.delta, 2400)
+  assert.ok(n[0].emphasize === 'mttr' || n[0].emphasize === 'downtime', 'bolds a measured axis, not score')
+  eq(n[0].declining, true)       // MTTR / downtime up = worse
+})
+
+test('includes a service declining on all axes', () => {
+  const n = computeNotableMovers(buildTrendSeries(NOTABLE_ENTRIES))
+  const claude = n.find(m => m.id === 'claude')
+  assert.ok(claude, 'claude should be a notable mover')
+  eq(claude.score.delta, -8)
+  eq(claude.declining, true)
+})
+
+test('excludes a service that did not move on any axis', () => {
+  const n = computeNotableMovers(buildTrendSeries(NOTABLE_ENTRIES))
+  assert.ok(!n.some(m => m.id === 'steady'), 'a flat service is not notable')
+})
+
+test('direction follows the headline (emphasized) axis, not score', () => {
+  // Score +1 (slightly up) but downtime regresses 12h → 49h — the row must read 🔻 (declining),
+  // keying off the bolded downtime, not the small score gain.
+  const mistralish = [
+    { month: '2026-04', daysInMonth: 30, daysCollected: 30, services: { svc: { score: 77, grade: 'Good', mttr: 8, downtime: 735 } } },
+    { month: '2026-05', daysInMonth: 31, daysCollected: 31, services: { svc: { score: 78, grade: 'Good', mttr: 19, downtime: 2938 } } },
+  ]
+  const m = computeNotableMovers(buildTrendSeries(mistralish))[0]
+  eq(m.score.delta, 1)
+  eq(m.emphasize, 'downtime')
+  eq(m.declining, true) // headline = downtime regression
+})
+
+test('does NOT use the uptime field (the #586 / mixed-source trap)', () => {
+  // A service whose only "movement" is uptime must NOT surface — uptime is excluded.
+  const upOnly = [
+    { month: '2026-03', daysInMonth: 31, daysCollected: 31, services: { svc: { score: 70, grade: 'Good', uptime: 72.78, mttr: 30, downtime: 60 } } },
+    { month: '2026-04', daysInMonth: 30, daysCollected: 30, services: { svc: { score: 70, grade: 'Good', uptime: 99.9, mttr: 30, downtime: 60 } } },
+  ]
+  const n = computeNotableMovers(buildTrendSeries(upOnly))
+  eq(n.length, 0) // flat score + flat MTTR/downtime → not notable, despite a huge uptime swing
+})
+
+test('falls back to Score-only notability when MTTR/downtime are absent', () => {
+  const n = computeNotableMovers(buildTrendSeries(TREND_ENTRIES)) // no mttr/downtime fields
+  eq(n[0].id, 'gemini')          // +10 score is the largest move here
+  eq(n[0].emphasize, 'score')
+  eq(n[0].mttr.delta, null)
+  eq(n[0].downtime.delta, null)
+})
+
+test('honors nameFor + respects the limit', () => {
+  const n = computeNotableMovers(buildTrendSeries(NOTABLE_ENTRIES), { limit: 1, nameFor: id => id.toUpperCase() })
+  eq(n.length, 1)
+  eq(n[0].name, 'GEMINI')
+})
+
+test('returns [] for a single month', () => {
+  eq(computeNotableMovers(buildTrendSeries([NOTABLE_ENTRIES[2]])).length, 0)
+})
+
+test('excludes services the report does not rank (NO_INCIDENT_FEED / stale)', () => {
+  // bedrock moves hard on every axis but is in the exclude set → must never surface as a mover,
+  // mirroring the Score table's exclusion (else the trend contradicts the rest of the report).
+  const withBedrock = NOTABLE_ENTRIES.map((e, i) => ({
+    ...e,
+    services: { ...e.services, bedrock: { score: 90 - i * 10, grade: 'Good', mttr: 10 + i * 600, downtime: 20 + i * 1200 } },
+  }))
+  const t = buildTrendSeries(withBedrock)
+  const exclude = new Set(['bedrock'])
+  assert.ok(!computeNotableMovers(t, { exclude }).some(m => m.id === 'bedrock'), 'bedrock excluded from notable movers')
+  const sm = computeScoreMovers(t, { exclude })
+  assert.ok(![...sm.declining, ...sm.improving].some(m => m.id === 'bedrock'), 'bedrock excluded from score movers')
+  // without the exclude it WOULD appear (proves the guard is what suppresses it)
+  assert.ok(computeNotableMovers(t).some(m => m.id === 'bedrock'), 'bedrock surfaces when not excluded')
+})
+
+console.log('\nformatTrendArrow / fmtScoreDelta')
+
+test('formatTrendArrow joins present scores with arrows', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  eq(formatTrendArrow(t.series.claude.points), '71 → 68 → 63')
+})
+
+test('formatTrendArrow skips absent months', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  eq(formatTrendArrow(t.series.newbie.points), '50')
+})
+
+test('fmtScoreDelta signs the delta', () => {
+  eq(fmtScoreDelta(8), '+8')
+  eq(fmtScoreDelta(-8), '−8')
+  eq(fmtScoreDelta(0), '±0')
+})
+
+console.log('\ngenerateTrendSvg')
+
+test('renders without throwing and carries the title + mover label', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  const svg = generateTrendSvg(t, { nameFor: id => (id === 'claude' ? 'Claude API' : id) })
+  assert.ok(svg.includes('3-Month Trend'), 'has title')
+  assert.ok(svg.includes('Claude API'), 'labels the mover')
+  assert.ok(svg.includes('<polyline'), 'draws lines')
+})
+
+test('marks the partial month with a star on the axis', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  const svg = generateTrendSvg(t)
+  assert.ok(svg.includes('Mar*'), 'partial month axis label carries *')
+  assert.ok(svg.includes('partial month'), 'has the partial footnote')
+})
+
+test('dark background, no light mode', () => {
+  const t = buildTrendSeries(TREND_ENTRIES)
+  const svg = generateTrendSvg(t)
+  assert.ok(svg.includes('fill="#0d1117"'), 'dark bg')
+  assert.ok(!svg.includes('prefers-color-scheme'), 'no media query')
+})
+
+console.log('\ntoMonthEntry / monthEntryFromScoreRows')
+
+test('toMonthEntry computes daysInMonth + carries daysCollected', () => {
+  const e = toMonthEntry('2026-03', { daysCollected: 12, services: { claude: { score: 71, grade: 'Good' } } })
+  eq(e.daysInMonth, 31)
+  eq(e.daysCollected, 12)
+  eq(e.services.claude.score, 71)
+})
+
+test('toMonthEntry returns null when services are missing', () => {
+  eq(toMonthEntry('2026-03', null), null)
+  eq(toMonthEntry('2026-03', {}), null)
+})
+
+test('monthEntryFromScoreRows maps a parsed Score table to a current-month entry', () => {
+  const e = monthEntryFromScoreRows('2026-05', [{ Service: 'Claude API', Score: '63', Grade: 'Fair' }])
+  eq(e.services.claude.score, 63)
+  eq(e.services.claude.grade, 'Fair')
+  eq(e.daysCollected, e.daysInMonth) // current month treated as full
+})
+
+test('monthEntryFromScoreRows tolerates N/A scores', () => {
+  const e = monthEntryFromScoreRows('2026-05', [{ Service: 'Voyage AI', Score: 'N/A', Grade: '' }])
+  eq(e.services.voyageai.score, null)
 })
 
 // ── Summary ──────────────────────────────────────────────

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -26,6 +26,7 @@
 const fs = require('fs')
 const path = require('path')
 const summary = require('./generate-summary')
+const charts = require('./generate-charts')  // trend core (aiwatch-reports#41)
 
 const API_BASE = process.env.AIWATCH_API_BASE || 'https://aiwatch-worker.p2c2kbf.workers.dev'
 const TEMPLATE_PATH = path.join(__dirname, '..', '_templates', 'monthly-report.md')
@@ -592,6 +593,113 @@ function buildDetectionSection(archive, meta) {
   return parts.join('\n')
 }
 
+// Auto-renders the "## N-Month Trend" section (aiwatch#637 quick-win / aiwatch-reports#41).
+// Turns the snapshot into a directional signal. The CURRENT month comes from the
+// freshly-fetched `archive`; PRIOR months from the committed `_data/{YYYY-MM}.json`
+// snapshots (immutable history). Emits its own trailing `---` (like buildSecuritySection /
+// buildDetectionSection) when ≥2 months exist AND at least one mover is found; otherwise
+// returns '' (a lone first month, or a flat board, has no trend to show). The actual
+// slope chart SVG is written by generate-charts.js under the same ≥2-month gate, so the
+// `![](trend-chart.svg)` ref below never dangles. The multi-month math lives in
+// generate-charts.js (buildTrendSeries / computeScoreMovers) — pure + unit-tested there.
+function buildTrendSection(month, archive, meta, dataDir = path.join(__dirname, '..', '_data')) {
+  const currentEntry = charts.toMonthEntry(month, archive)
+  if (!currentEntry) return ''
+  const entries = charts.loadTrendEntries(month, currentEntry, { dataDir })
+  if (entries.length < 2) return ''
+
+  const trend = charts.buildTrendSeries(entries)
+  // Exclude the services the Score ranking itself excludes (NO_INCIDENT_FEED + stale source,
+  // per buildScoreTable / the #29 note) so a trend mover never contradicts a report that
+  // elsewhere states it does not rank that service. Estimate-only bedrock/azureopenai scores
+  // CAN move month-to-month, so this isn't hypothetical. Keyed off the CURRENT month's archive.
+  const exclude = new Set(
+    Object.entries(archive.services)
+      .map(([id, data]) => ({ id, data }))
+      .filter(s => NO_INCIDENT_FEED.has(s.id) || isStaleSource(s))
+      .map(s => s.id),
+  )
+
+  const movers = charts.computeScoreMovers(trend, { nameFor: id => serviceName(id, meta), exclude })
+  if (!movers.declining.length && !movers.improving.length) return ''
+
+  const notable = charts.computeNotableMovers(trend, { nameFor: id => serviceName(id, meta), exclude })
+
+  const span = entries.length
+  const parts = [
+    `## ${span}-Month Trend`,
+    '',
+    `AIWatch Score direction over the last ${span} months (${entries[0].month} → ${month}). The chart shows the composite-Score direction for every service; **Notable Movers** below decompose the biggest changes into the incident-measured metrics that actually drive a "keep relying on this?" decision — recovery time (MTTR) and total downtime — since a flat Score can hide a recovery-time regression.`,
+    '',
+    `![AIWatch Score ${span}-month trend](../assets/${month}/trend-chart.svg)`,
+    '',
+  ]
+
+  if (notable.length) {
+    parts.push('### Notable Movers', '')
+    // Make the selection rule + the arrow semantics explicit (readers shouldn't have to guess
+    // why these N appear): ranked by the single largest change across Score / MTTR / downtime,
+    // the bold metric is that change, and 🔺/🔻 track that headline metric — not Score.
+    parts.push(
+      `*The ${notable.length} services whose **Score, recovery time (MTTR), or total downtime** changed most over the window (ranked by the largest single change, not a fixed threshold). The metric in **bold** is the change that ranked each service here; 🔺 / 🔻 mark whether that headline metric improved or worsened — so a service can show a small Score gain yet land here, and read 🔻, because its downtime regressed.*`,
+      '',
+    )
+    parts.push(...notable.map(m => fmtMoverLine(m)))
+    parts.push('')
+  }
+
+  if (trend.partialMonths.size) {
+    parts.push(
+      `> **Partial month**: ${[...trend.partialMonths].join(', ')} had fewer than a full month of monitoring — its point is indicative, not a full-month comparison. MTTR / downtime show "—" for any month a service recorded zero incidents.`,
+      '',
+    )
+  }
+  parts.push('---', '')
+  return parts.join('\n')
+}
+
+// Signed duration delta (MTTR / downtime): "+5h 12m" / "−18m" / "±0".
+function fmtDurationDelta(mins) {
+  if (mins === null || mins === undefined || Number.isNaN(mins)) return ''
+  if (mins === 0) return '±0'
+  return `${mins > 0 ? '+' : '−'}${fmtDurationMin(Math.abs(mins))}`
+}
+
+// One Notable-Movers bullet: direction marker + name, then Score · MTTR · Downtime with the
+// axis that moved most bolded. A null endpoint (a zero-incident month has no MTTR/downtime)
+// renders the segment as "—". Uptime is intentionally absent (see computeNotableMovers).
+function fmtMoverLine(m) {
+  const arrow = m.declining ? '🔻' : '🔺'
+  const segs = []
+
+  let s = `Score ${m.score.first} → ${m.score.last} (${charts.fmtScoreDelta(m.score.delta)})`
+  if (m.emphasize === 'score') s = `**${s}**`
+  segs.push(s)
+
+  // MTTR / downtime measured over the months that have data (first-present → last-present):
+  //  • never recorded   → "—"
+  //  • one month of data → single value (no redundant arrow)
+  //  • ≥2 months        → "X → Y (Δ)"
+  // Assumes a zero-incident month is null (not 0) in the archive — per toMonthEntry, MTTR/downtime
+  // are read only when typeof === 'number', and the archive emits null (not 0) for no incidents. If
+  // a future archive ever emits a literal 0, fmtDurationMin maps it to "—" too, so it still reads as
+  // "no incidents" rather than a misleading "0m" — safe either way.
+  const span = (o) => {
+    if (o.first === null && o.last === null) return '—'
+    if (o.delta === null) return fmtDurationMin(o.last)
+    return `${fmtDurationMin(o.first)} → ${fmtDurationMin(o.last)} (${fmtDurationDelta(o.delta)})`
+  }
+  let t = `MTTR ${span(m.mttr)}`
+  if (m.emphasize === 'mttr') t = `**${t}**`
+  segs.push(t)
+
+  let d = `downtime ${span(m.downtime)}`
+  if (m.emphasize === 'downtime') d = `**${d}**`
+  segs.push(d)
+
+  return `- ${arrow} **${m.name}** — ${segs.join(' · ')}`
+}
+
 function buildLatencyTable(services, meta) {
   const withLatency = services.filter(s => s.data.avgLatencyMs !== null && !NO_PROBE.has(s.id))
   // Competition rank with ascending sort: negate avgLatencyMs so competitionRank's
@@ -759,6 +867,17 @@ function fillTemplate(template, month, archive, meta) {
     out = out.replace(/<!-- DETECTION_SECTION -->(?:\n*<!--[\s\S]*?-->)?/, detectionSection)
   } else {
     out = out.replace(/\n*<!-- DETECTION_SECTION -->(?:\n*<!--[\s\S]*?-->)?\n*(?:---\n*)?/, '\n\n')
+  }
+
+  // 3-Month Trend section (aiwatch-reports#41) — same marker pattern as security/detection:
+  // buildTrendSection emits the whole section (ending in its own `---`) when ≥2 months of
+  // archive history exist and there's a mover, else nothing. When omitted, strip the marker +
+  // its explainer comment AND the trailing `---` so the preceding `---` stays the single rule.
+  const trendSection = buildTrendSection(month, archive, meta)
+  if (trendSection) {
+    out = out.replace(/<!-- TREND_SECTION -->(?:\n*<!--[\s\S]*?-->)?/, trendSection)
+  } else {
+    out = out.replace(/\n*<!-- TREND_SECTION -->(?:\n*<!--[\s\S]*?-->)?\n*(?:---\n*)?/, '\n\n')
   }
 
   return out
@@ -1076,6 +1195,7 @@ module.exports = {
   buildTopFindings,
   buildSecuritySection,
   buildDetectionSection,
+  buildTrendSection,
   fmtLeadMin,
   fmtIso,
   monthName,

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -22,6 +22,7 @@ const {
   buildTopFindings,
   buildSecuritySection,
   buildDetectionSection,
+  buildTrendSection,
   fmtLeadMin,
   monthName,
   lastDayOfMonth,
@@ -1335,6 +1336,72 @@ test('buildNotableIncidentsDraft / buildObservationsDraft are fenced + carry the
   assert.ok(nb.includes('(sonnet)'))
   const ob = buildObservationsDraft(SAMPLE_NARRATIVE.observations, 'sonnet')
   assert.ok(ob.startsWith(OBSERVATIONS_OPEN_MARKER) && ob.endsWith(OBSERVATIONS_CLOSE_MARKER), 'observations draft fenced')
+})
+
+// ── buildTrendSection (aiwatch-reports#41) — exclusion wiring (round-2 fix) ──
+console.log('\nbuildTrendSection')
+
+const fsT = require('fs')
+const osT = require('os')
+const pathT = require('path')
+
+// Write two prior-month _data snapshots to a temp dir, then render the section for a current
+// month supplied via the archive arg. The archive carries a normal mover (codex, declining hard)
+// AND an excluded estimate-only mover (bedrock, NO_INCIDENT_FEED) that ALSO moves hard.
+function withTrendFixture(fn) {
+  const dir = fsT.mkdtempSync(pathT.join(osT.tmpdir(), 'trend-test-'))
+  try {
+    fsT.writeFileSync(pathT.join(dir, '2026-04.json'), JSON.stringify({
+      period: '2026-04', daysCollected: 30, services: {
+        codex: { score: 86, grade: 'Good', avgResolutionMin: 83, totalDowntimeMin: 578 },
+        bedrock: { score: 90, grade: 'Good', avgResolutionMin: null, totalDowntimeMin: null },
+      },
+    }))
+    fsT.writeFileSync(pathT.join(dir, '2026-05.json'), JSON.stringify({
+      period: '2026-05', daysCollected: 31, services: {
+        codex: { score: 82, grade: 'Good', avgResolutionMin: 468, totalDowntimeMin: 3277 },
+        bedrock: { score: 90, grade: 'Good', avgResolutionMin: null, totalDowntimeMin: null },
+      },
+    }))
+    return fn(dir)
+  } finally {
+    fsT.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+const TREND_META = { codex: { name: 'Codex' }, bedrock: { name: 'Amazon Bedrock' } }
+// Current month (2026-06): codex keeps declining; bedrock's estimate-only score swings hard.
+const TREND_ARCHIVE = {
+  period: '2026-06', daysCollected: 30, services: {
+    codex: { score: 70, grade: 'Fair', avgResolutionMin: 600, totalDowntimeMin: 5000 },
+    bedrock: { score: 55, grade: 'Fair', avgResolutionMin: null, totalDowntimeMin: null },
+  },
+}
+
+test('renders a ## 3-Month Trend section with the Notable Movers list', () => {
+  withTrendFixture(dir => {
+    const out = buildTrendSection('2026-06', TREND_ARCHIVE, TREND_META, dir)
+    assert.ok(out.includes('## 3-Month Trend'), 'has the section heading')
+    assert.ok(out.includes('### Notable Movers'), 'has the Notable Movers list')
+    assert.ok(out.includes('Codex'), 'normal mover present')
+  })
+})
+
+test('excludes a NO_INCIDENT_FEED service (bedrock) from the rendered movers — the round-2 fix', () => {
+  withTrendFixture(dir => {
+    const out = buildTrendSection('2026-06', TREND_ARCHIVE, TREND_META, dir)
+    assert.ok(!out.includes('Amazon Bedrock'), 'estimate-only bedrock must NOT surface as a trend mover')
+  })
+})
+
+test('returns empty when fewer than 2 months of data exist', () => {
+  const dir = fsT.mkdtempSync(pathT.join(osT.tmpdir(), 'trend-empty-'))
+  try {
+    // No prior _data files in dir → only the current (archive) month → <2 months.
+    eq(buildTrendSection('2026-06', TREND_ARCHIVE, TREND_META, dir), '')
+  } finally {
+    fsT.rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 console.log(`\n${passed} passed, ${failed} failed`)


### PR DESCRIPTION
Implements **aiwatch-reports#41** — a rolling 3-month trend in the monthly report, turning the single-month snapshot into a directional signal.

## What ships
- **Score slope chart** (`generateTrendSvg`) — every service a faint context line; the biggest Score movers emphasized + end-labeled.
- **`### Notable Movers`** — decomposes the biggest changes into **incident-MEASURED** metrics: **Score + MTTR + total downtime**. Ranked by the largest single normalized change; direction (🔺/🔻) follows the **bold headline metric, not Score**, so a flat Score can't hide a recovery-time regression (e.g. Gemini Score +2 but downtime −306h; Mistral Score +1 but downtime +36h → 🔻).
- A one-line **selection-criterion caption** (no guessing why these N appear) + **partial-month** flag.

## Key design decision — uptime is intentionally NOT trended
The archive's `uptime` field mixes per-service sources (ChatGPT's #586 group-aggregate over-count, estimate/poll-derived figures), so a cross-service uptime delta renders **contradictory** score-up/uptime-down lines. The decomposition uses only the incident-feed *measured* fields. A clean 3-month **official-uptime** trend awaits **aiwatch#586** + the `officialUptime` field spanning ≥3 archived months — which also makes this the free-report preview of the paid SLA-verification data (**aiwatch#637**).

## Robustness
- Excludes the services the Score ranking excludes (`NO_INCIDENT_FEED` + stale source) from movers — no self-contradiction with the rest of the report.
- Sparse incident metrics use first-present→last-present deltas (a partial month doesn't zero the trend).
- Marker-based wiring (`<!-- TREND_SECTION -->`) mirroring SECURITY/DETECTION; `TREND_MONTHS` single source of truth for the rolling window. Dependency-free (node + assert).

## Tests
+24 tests (pure trend core + `buildTrendSection` integration incl. the exclusion guard). All suites green: charts 54 · report 144 · summary 32 · update-index 18.

## Review
3 rounds via code-reviewer → converged (1 Important [mover exclusion] fixed + verified; all Suggestions addressed).

## Scope / not-closing
**Published reports, assets, and `_data` snapshots are untouched** — the section auto-debuts in the **2026-06 report** (first all-full 04/05/06 window). The "generated into the 2026-06 report" acceptance item is time-gated (report runs ~2026-07-01), so this is **`refs #41`**, not `closes` — the issue stays open with a verify-after for that generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)