### PR TITLE
docs: bump service count 39 → 40 (Black Forest Labs / FLUX) — refs aiwatch#756

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AIWatch Monthly Reports
 
-> Monthly AI service reliability reports covering uptime, incidents, and performance across 39 major AI services.
+> Monthly AI service reliability reports covering uptime, incidents, and performance across 40 major AI services.
 
 **Live site**: [ai-watch.dev/reports](https://ai-watch.dev/reports/) (served via Vercel rewrite; legacy `reports.ai-watch.dev` self-redirects to the canonical path — #264)
 **Data source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
@@ -30,7 +30,7 @@ Each monthly report includes:
 
 ## Methodology
 
-- **39 services monitored**: 15 LLM APIs, 14 voice & inference, 4 AI apps, 6 coding agents
+- **40 services monitored**: 15 LLM APIs, 15 voice & inference, 4 AI apps, 6 coding agents
 - **Data sources**: Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, AWS Health Dashboard, Azure Status RSS, OnlineOrNot
 - **AIWatch Score**: Weighted composite of uptime (40pts), incident affected days (25pts), recovery time (15pts), and probe-based responsiveness (20pts). Services without probe data use 80→100 score redistribution.
 - **Uptime figures**: Official status page metrics — single primary component basis where available, platform-wide average otherwise
@@ -74,7 +74,7 @@ After generation, fill in the narrative sections (`Summary`, `Recommendations`, 
 
 ## About AIWatch
 
-AIWatch is an AI service status monitoring dashboard that aggregates real-time status from 39 major AI services.
+AIWatch is an AI service status monitoring dashboard that aggregates real-time status from 40 major AI services.
 
 - **Live dashboard**: [ai-watch.dev](https://ai-watch.dev)
 - **Source code**: [github.com/bentleypark/aiwatch](https://github.com/bentleypark/aiwatch) (AGPL-3.0)

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: AIWatch Reports
-description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 39 AI services
+description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 40 AI services
 baseurl: "/reports"
 url: https://ai-watch.dev
 theme: minima

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "[MON] [YEAR] AI Reliability Report"
-description: "Monthly reliability report for 39 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
+description: "Monthly reliability report for 40 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
 date: [YYYY-MM-DD]
 published: true
 ---
@@ -9,7 +9,7 @@ published: true
 > **Source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
 > **Period**: [MONTH] 1–[LAST_DAY], [YEAR]
 > **Published**: [PUBLISH_MONTH] [YEAR]
-> **Services monitored**: 39 — 29 API services, 6 coding agents, 4 AI apps
+> **Services monitored**: 40 — 30 API services, 6 coding agents, 4 AI apps
 
 ## Summary
 
@@ -207,7 +207,7 @@ Actionable takeaways per service. Descriptive context for each event lives in ea
 ## About This Report
 
 * **Data Sources:** Real-time data is aggregated from official status pages via multiple frameworks, including Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, OnlineOrNot, and RSS feeds (Source: [ai-watch.dev](https://ai-watch.dev)).
-* **Monitoring Frequency:** All 39 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
+* **Monitoring Frequency:** All 40 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
 * **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). Services without probe data use 80→100 score redistribution **plus a 5% penalty** to reflect the missing responsiveness signal. Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
 * **Uptime Source:** *Official* = service publishes a rolling 30-day uptime metric AIWatch reads directly. *Estimate* = no official metric; AIWatch substitutes an industry-average assumption (99.5%) or its own poll-derived figure for the Score's Uptime input. *Partial (Nd)* = an official source exists but AIWatch's measurement window is shorter than the full month (e.g. service newly tracked mid-month). The label only describes the Uptime input quality — the Score itself is computed identically across all services.
 * **Incident Counting:** Incident counts reflect all affected components per service. Providers differ in reporting granularity — Anthropic reports per-model incidents (Opus/Sonnet/Haiku each counted separately), while others report at the service level.

--- a/index.md
+++ b/index.md
@@ -1,10 +1,10 @@
 ---
 layout: home
 title: AIWatch Monthly Reports
-description: "Monthly AI service incident reports covering 39 AI services — uptime, incidents, and reliability rankings."
+description: "Monthly AI service incident reports covering 40 AI services — uptime, incidents, and reliability rankings."
 ---
 
-Monthly AI service incident reports covering 39 AI services monitored by [AIWatch](https://ai-watch.dev).
+Monthly AI service incident reports covering 40 AI services monitored by [AIWatch](https://ai-watch.dev).
 
 ## Reports
 

--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -681,7 +681,7 @@ if (require.main === module) {
         if (history[key]) { lastDataDay = d; break }
       }
 
-      // Use all 39 services in category order (not just incident table)
+      // Use all 40 services in category order (not just incident table)
       const serviceNames = CATEGORY_ORDER.map(id => ID_TO_NAME[id]).filter(Boolean)
 
       const heatmapSvg = generateUptimeHeatmapSvg(serviceNames, history, daysInMonth, monthKey, monitoringStartDay, lastDataDay)


### PR DESCRIPTION
## Summary
Mirrors [aiwatch#756](https://github.com/bentleypark/aiwatch/issues/756), which adds **Black Forest Labs (FLUX)** as the 40th monitored AI service. Updates the reports site's live-count surfaces.

## Changes
- `README.md` — "39 → 40 major AI services" (×2); methodology breakdown "15 LLM APIs, **15** voice & inference, 4 AI apps, 6 coding agents"
- `_config.yml` — site description count
- `index.md` — home description + intro count
- `_templates/monthly-report.md` — description, "Services monitored: **40 — 30 API services**, 6 coding agents, 4 AI apps", "All 40 services are polled"
- `scripts/generate-charts.js` — comment count

Sub-counts reconcile to 40 (15 LLM + 15 voice&inference + 4 apps + 6 agents; and 30 API + 6 agents + 4 apps).

## Not changed (intentional)
- Historical month reports (`2026-03/04/05`) keep their period-accurate counts — those months did not include FLUX.

## Verification
Pure count-text edits; no Liquid/template logic touched. Diff is 10 single-line count bumps. GitHub Pages will rebuild on merge.

Refs aiwatch#756

🤖 Generated with [Claude Code](https://claude.com/claude-code)