### PR TITLE
feat(report): gate the monthly Score ranking + Notable Movers on full-month coverage (closes #45)

### DIFF
--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -79,6 +79,18 @@ function isStaleSource(s) {
   return !!(s.data.incidentSourceStale ?? STALE_SOURCE.has(s.id))
 }
 
+// reports#45 — a service added DURING (or after) the report month lacked full-month coverage, so its
+// partial-month Score must not be ranked or featured in Notable Movers against full-month services
+// (the report-side equivalent of aiwatch#802's <30d-coverage dashboard gate). Reads the static
+// `addedAt` the monthly archive now exposes (aiwatch#809). `addedAt` absent = established service =
+// full coverage. Compares YYYY-MM prefixes: addedAt in a PRIOR month → ranked; in the report month
+// (or later) → excluded. `period` = the report month 'YYYY-MM'.
+function isRecentlyAdded(s, period) {
+  const addedAt = s && s.data && s.data.addedAt
+  if (!addedAt || !period) return false
+  return addedAt.slice(0, 7) >= period.slice(0, 7)
+}
+
 // Services without direct probe coverage (excluded from API Response Time ranking).
 // Archive.avgLatencyMs will be null for these — tracked for explicit messaging.
 const NO_PROBE = new Set(['bedrock', 'azureopenai', 'pinecone'])
@@ -243,13 +255,15 @@ function joinNames(svcs, meta) {
   return names.length === 2 ? names.join(' and ') : names.join(', ')
 }
 
-function buildRankingNote(services, meta) {
+function buildRankingNote(services, meta, period) {
   const scored = services.filter(s => s.data.score !== null)
   const noFeed = scored.filter(s => NO_INCIDENT_FEED.has(s.id))
   // STALE_SOURCE that isn't already a no-feed service (avoid double-listing) — #591.
   const stale = scored.filter(s => isStaleSource(s) && !NO_INCIDENT_FEED.has(s.id))
-  if (noFeed.length === 0 && stale.length === 0) return ''
-  const ranked = scored.length - noFeed.length - stale.length
+  // reports#45 — recently-added (partial-month) services, excluding any already covered above.
+  const recent = scored.filter(s => isRecentlyAdded(s, period) && !NO_INCIDENT_FEED.has(s.id) && !isStaleSource(s))
+  if (noFeed.length === 0 && stale.length === 0 && recent.length === 0) return ''
+  const ranked = scored.length - noFeed.length - stale.length - recent.length
   const clauses = []
   if (noFeed.length) {
     const verb = noFeed.length === 1 ? 'is' : 'are'
@@ -260,15 +274,21 @@ function buildRankingNote(services, meta) {
     const poss = stale.length === 1 ? 'its' : 'their'
     clauses.push(`**${joinNames(stale, meta)} ${verb} excluded from this ranking** — ${poss} status source migrated to a platform AIWatch can't reach, so the incident feed is frozen and the Score would be inflated by an empty 30-day window (see "Stale source" under [Incident Summary](#incident-summary))`)
   }
+  if (recent.length) {
+    const verb = recent.length === 1 ? 'is' : 'are'
+    const poss = recent.length === 1 ? 'it was' : 'they were'
+    clauses.push(`**${joinNames(recent, meta)} ${verb} excluded from this ranking** — ${poss} added to AIWatch mid-month, so the partial-month Score rests on insufficient coverage; ${recent.length === 1 ? 'it rejoins' : 'they rejoin'} once a full month of data accrues`)
+  }
   return `*${ranked} of ${scored.length} services ranked. ${clauses.join('. ')}.*`
 }
 
 // ── Table builders ───────────────────────────────────────────────────
-function buildScoreTable(services, meta) {
-  // Drop NO_INCIDENT_FEED services (no uptime metric + no reliable incidents) and STALE_SOURCE
-  // services (#591 — frozen feed inflates the Score from an empty window) from the ranking; both are
+function buildScoreTable(services, meta, period) {
+  // Drop NO_INCIDENT_FEED services (no uptime metric + no reliable incidents), STALE_SOURCE services
+  // (#591 — frozen feed inflates the Score from an empty window), and recently-added services
+  // (reports#45 — partial-month coverage would rank off insufficient data) from the ranking; all are
   // surfaced in the ranking-exclusion note + the Incident Summary ("No incident feed" / "Stale source").
-  const withScore = services.filter(s => s.data.score !== null && !NO_INCIDENT_FEED.has(s.id) && !isStaleSource(s))
+  const withScore = services.filter(s => s.data.score !== null && !NO_INCIDENT_FEED.has(s.id) && !isStaleSource(s) && !isRecentlyAdded(s, period))
   const ranked = competitionRank(withScore, s => s.data.score)
   const rows = ranked.map(r => {
     const s = r.item
@@ -616,7 +636,7 @@ function buildTrendSection(month, archive, meta, dataDir = path.join(__dirname, 
   const exclude = new Set(
     Object.entries(archive.services)
       .map(([id, data]) => ({ id, data }))
-      .filter(s => NO_INCIDENT_FEED.has(s.id) || isStaleSource(s))
+      .filter(s => NO_INCIDENT_FEED.has(s.id) || isStaleSource(s) || isRecentlyAdded(s, month)) // reports#45 — partial-month delta is not a real mover
       .map(s => s.id),
   )
 
@@ -803,8 +823,8 @@ function fillTemplate(template, month, archive, meta) {
   const services = Object.entries(archive.services).map(([id, data]) => ({ id, data }))
 
   // Build tables
-  const scoreTable = buildScoreTable(services, meta)
-  const rankingNote = buildRankingNote(services, meta)
+  const scoreTable = buildScoreTable(services, meta, month)
+  const rankingNote = buildRankingNote(services, meta, month)
   const { tableRows: incidentRows, zeroIncLine } = buildIncidentTable(services, meta)
   const uptimeRows = buildUptimeTable(services, meta)
   const latencyTable = buildLatencyTable(services, meta)
@@ -1183,6 +1203,7 @@ module.exports = {
   buildRankingNote,
   buildScoreTable,
   isStaleSource,
+  isRecentlyAdded,
   buildIncidentTable,
   officialUptimeFor,
   buildStaleSourceCaveat,

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -9,6 +9,7 @@ const {
   uptimeSourceLabel,
   buildRankingNote,
   isStaleSource,
+  isRecentlyAdded,
   buildScoreTable,
   buildIncidentTable,
   officialUptimeFor,
@@ -185,6 +186,56 @@ test('buildRankingNote names stale + no-feed in separate clauses with distinct r
   assert.ok(/no reliable incident feed/.test(note), `no-feed reason: ${note}`)
   assert.ok(/DeepSeek API is excluded from this ranking/.test(note), `stale clause: ${note}`)
   assert.ok(/incident feed is frozen/.test(note), `stale reason: ${note}`)
+})
+
+// ── reports#45 — full-month coverage gate (consumes aiwatch#809 addedAt) ──
+console.log('\nisRecentlyAdded (#45)')
+test('added in the report month → recently added (excluded)', () => {
+  eq(isRecentlyAdded({ id: 'fal', data: { addedAt: '2026-06-24' } }, '2026-06'), true)
+})
+test('added in a PRIOR month → established (ranked)', () => {
+  eq(isRecentlyAdded({ id: 'fal', data: { addedAt: '2026-06-24' } }, '2026-07'), false)
+})
+test('addedAt absent → established (ranked, no regression for old archives)', () => {
+  eq(isRecentlyAdded({ id: 'claude', data: { score: 90 } }, '2026-06'), false)
+})
+test('no period → not gated (fail-open)', () => {
+  eq(isRecentlyAdded({ id: 'fal', data: { addedAt: '2026-06-24' } }, undefined), false)
+})
+
+console.log('\nbuildScoreTable + buildRankingNote — coverage gate (#45)')
+test('buildScoreTable drops a mid-month-added service for that month, keeps it the next', () => {
+  const services = [
+    { id: 'cohere', data: { score: 89, grade: 'good', uptime: 100, incidents: 0, avgResolutionMin: null } },
+    { id: 'fal', data: { score: 95, grade: 'excellent', uptime: 100, incidents: 0, avgResolutionMin: null, addedAt: '2026-06-24' } },
+  ]
+  const meta = { cohere: { name: 'Cohere API' }, fal: { name: 'fal.ai' } }
+  const june = buildScoreTable(services, meta, '2026-06')
+  assert.ok(june.includes('Cohere API'), 'established service ranked')
+  assert.ok(!june.includes('fal.ai'), 'mid-month-added service dropped for its first (partial) month')
+  const july = buildScoreTable(services, meta, '2026-07')
+  assert.ok(july.includes('fal.ai'), 'service rejoins the ranking once a full month accrues')
+})
+test('buildRankingNote flags the recently-added exclusion with a distinct reason', () => {
+  const services = [
+    { id: 'cohere', data: { score: 89 } },
+    { id: 'fal', data: { score: 95, addedAt: '2026-06-24' } },
+  ]
+  const meta = { cohere: { name: 'Cohere API' }, fal: { name: 'fal.ai' } }
+  const note = buildRankingNote(services, meta, '2026-06')
+  assert.ok(note.includes('1 of 2 services ranked'), `got: ${note}`)
+  assert.ok(/fal\.ai is excluded from this ranking/.test(note), `recent clause: ${note}`)
+  assert.ok(/added to AIWatch mid-month/.test(note), `recent reason: ${note}`)
+})
+test('full-month services are unaffected — no note, all ranked (no regression)', () => {
+  const services = [
+    { id: 'cohere', data: { score: 89, grade: 'good', uptime: 100, incidents: 0, avgResolutionMin: null, addedAt: '2026-04-01' } },
+    { id: 'claude', data: { score: 90, grade: 'excellent', uptime: 100, incidents: 0, avgResolutionMin: null } },
+  ]
+  const meta = { cohere: { name: 'Cohere API' }, claude: { name: 'Claude API' } }
+  eq(buildRankingNote(services, meta, '2026-06'), '')
+  const table = buildScoreTable(services, meta, '2026-06')
+  assert.ok(table.includes('Cohere API') && table.includes('Claude API'), 'both full-month services ranked')
 })
 
 // ── Date helpers ─────────────────────────────────────────


### PR DESCRIPTION
Closes #45.

## What

A service added mid-month got a partial-month Score yet was ranked + featured in **Notable Movers** identically to full-month services — the report-side equivalent of aiwatch#802 (the dashboard's <30d-coverage gate).

New `isRecentlyAdded(s, period)` consumes the static per-service `addedAt` the monthly archive now exposes (**aiwatch#809**): a service whose `addedAt` YYYY-MM is `>=` the report month is
- excluded from the **Score ranking** (`buildScoreTable`), flagged in the ranking note ("excluded — added to AIWatch mid-month; rejoins once a full month accrues"), and
- added to the **Notable Movers** `exclude` set (a partial-month delta is not a real mover).

`addedAt` absent = established service = full coverage → **no regression** for pre-#809 archives.

## Verification
- `node scripts/generate-report.js` tests: **151 pass** (new: predicate edge cases, table exclusion + rejoin-next-month, ranking-note clause, full-month no-regression). `generate-charts.js` tests: 54 pass.
- **Live smoke** (`generate-report.js 2026-05` against the live `/api/report`): the gate fired correctly — June-added services (`addedAt` ≥ 2026-05) were excluded from the ranking with the "added mid-month" note, confirming end-to-end consumption of `addedAt`. (Regenerated file reverted — not committing over the published report.)
- PR review: 0 Critical / 0 Important (YYYY-MM comparison, disjoint ranked-count math, movers keying, and SVG-chart consistency all verified).

## Notes
- Chart consistency: a gated service has no Score-table row, so it's auto-excluded from the SVG chart emphasis too (same mechanism as NO_INCIDENT_FEED/stale) — no divergence.
- Depends on **aiwatch#809** (now merged + deployed), which adds `addedAt` to `/api/report`. Past months archived before that deploy lack `addedAt` (benign — they didn't monitor the recently-added services); the 2026-06 report (generated ~2026-07-01) is the first to apply the gate against real mid-month additions.
