### PR TITLE
docs: bump service count 41 → 42 for turbopuffer (refs aiwatch#857)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Each monthly report includes:
 
 ## Methodology
 
-- **41 services monitored**: 15 LLM APIs, 16 voice & inference, 4 AI apps, 6 coding agents
+- **42 services monitored**: 15 LLM APIs, 17 voice & inference, 4 AI apps, 6 coding agents
 - **Data sources**: Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, AWS Health Dashboard, Azure Status RSS, OnlineOrNot
 - **AIWatch Score**: Weighted composite of uptime (40pts), incident affected days (25pts), recovery time (15pts), and probe-based responsiveness (20pts). Services without probe data use 80→100 score redistribution.
 - **Uptime figures**: Official status page metrics — single primary component basis where available, platform-wide average otherwise

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: AIWatch Reports
-description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 41 AI services
+description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 42 AI services
 baseurl: "/reports"
 url: https://ai-watch.dev
 theme: minima

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "[MON] [YEAR] AI Reliability Report"
-description: "Monthly reliability report for 41 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
+description: "Monthly reliability report for 42 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
 date: [YYYY-MM-DD]
 published: true
 ---
@@ -9,7 +9,7 @@ published: true
 > **Source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
 > **Period**: [MONTH] 1–[LAST_DAY], [YEAR]
 > **Published**: [PUBLISH_MONTH] [YEAR]
-> **Services monitored**: 41 — 31 API services, 6 coding agents, 4 AI apps
+> **Services monitored**: 42 — 32 API services, 6 coding agents, 4 AI apps
 
 ## Summary
 
@@ -207,7 +207,7 @@ Actionable takeaways per service. Descriptive context for each event lives in ea
 ## About This Report
 
 * **Data Sources:** Real-time data is aggregated from official status pages via multiple frameworks, including Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, OnlineOrNot, and RSS feeds (Source: [ai-watch.dev](https://ai-watch.dev)).
-* **Monitoring Frequency:** All 41 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
+* **Monitoring Frequency:** All 42 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
 * **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). Services without probe data use 80→100 score redistribution **plus a 5% penalty** to reflect the missing responsiveness signal. Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
 * **Uptime Source:** *Official* = service publishes a rolling 30-day uptime metric AIWatch reads directly. *Estimate* = no official metric; AIWatch substitutes an industry-average assumption (99.5%) or its own poll-derived figure for the Score's Uptime input. *Partial (Nd)* = an official source exists but AIWatch's measurement window is shorter than the full month (e.g. service newly tracked mid-month). The label only describes the Uptime input quality — the Score itself is computed identically across all services.
 * **Incident Counting:** Incident counts reflect all affected components per service. Providers differ in reporting granularity — Anthropic reports per-model incidents (Opus/Sonnet/Haiku each counted separately), while others report at the service level.

--- a/index.md
+++ b/index.md
@@ -1,10 +1,10 @@
 ---
 layout: home
 title: AIWatch Monthly Reports
-description: "Monthly AI service incident reports covering 41 AI services — uptime, incidents, and reliability rankings."
+description: "Monthly AI service incident reports covering 42 AI services — uptime, incidents, and reliability rankings."
 ---
 
-Monthly AI service incident reports covering 41 AI services monitored by [AIWatch](https://ai-watch.dev).
+Monthly AI service incident reports covering 42 AI services monitored by [AIWatch](https://ai-watch.dev).
 
 ## Reports
 

--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -681,7 +681,7 @@ if (require.main === module) {
         if (history[key]) { lastDataDay = d; break }
       }
 
-      // Use all 41 services in category order (not just incident table)
+      // Use all 42 services in category order (not just incident table)
       const serviceNames = CATEGORY_ORDER.map(id => ID_TO_NAME[id]).filter(Boolean)
 
       const heatmapSvg = generateUptimeHeatmapSvg(serviceNames, history, daysInMonth, monthKey, monitoringStartDay, lastDataDay)


### PR DESCRIPTION
## Summary
Bumps the service count **41 → 42** for **turbopuffer** (serverless vector DB), added as the 42nd monitored AIWatch service in bentleypark/aiwatch#857.

## Changes
- `README.md` — **42 services monitored**: 15 LLM APIs, **17** voice & inference, 4 AI apps, 6 coding agents (turbopuffer is inference; 15+17+4+6 = 42)
- `_config.yml`, `index.md` — description count 42
- `_templates/monthly-report.md` — **42 — 32 API services**, 6 coding agents, 4 AI apps + polling line
- `scripts/generate-charts.js` — comment

Historical month reports (2026-03/04/05) keep their as-published counts.

`refs bentleypark/aiwatch#857`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
