### PR TITLE
feat(report): add Twelve Labs (43 services) + backfill fal/bfl/turbopuffer roster (refs aiwatch#839)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Each monthly report includes:
 
 ## Methodology
 
-- **42 services monitored**: 15 LLM APIs, 17 voice & inference, 4 AI apps, 6 coding agents
+- **43 services monitored**: 15 LLM APIs, 18 voice & inference, 4 AI apps, 6 coding agents
 - **Data sources**: Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, AWS Health Dashboard, Azure Status RSS, OnlineOrNot
 - **AIWatch Score**: Weighted composite of uptime (40pts), incident affected days (25pts), recovery time (15pts), and probe-based responsiveness (20pts). Services without probe data use 80→100 score redistribution.
 - **Uptime figures**: Official status page metrics — single primary component basis where available, platform-wide average otherwise

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: AIWatch Reports
-description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 42 AI services
+description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 43 AI services
 baseurl: "/reports"
 url: https://ai-watch.dev
 theme: minima

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "[MON] [YEAR] AI Reliability Report"
-description: "Monthly reliability report for 42 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
+description: "Monthly reliability report for 43 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
 date: [YYYY-MM-DD]
 published: true
 ---
@@ -9,7 +9,7 @@ published: true
 > **Source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
 > **Period**: [MONTH] 1–[LAST_DAY], [YEAR]
 > **Published**: [PUBLISH_MONTH] [YEAR]
-> **Services monitored**: 42 — 32 API services, 6 coding agents, 4 AI apps
+> **Services monitored**: 43 — 33 API services, 6 coding agents, 4 AI apps
 
 ## Summary
 
@@ -207,7 +207,7 @@ Actionable takeaways per service. Descriptive context for each event lives in ea
 ## About This Report
 
 * **Data Sources:** Real-time data is aggregated from official status pages via multiple frameworks, including Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, OnlineOrNot, and RSS feeds (Source: [ai-watch.dev](https://ai-watch.dev)).
-* **Monitoring Frequency:** All 42 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
+* **Monitoring Frequency:** All 43 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
 * **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). Services without probe data use 80→100 score redistribution **plus a 5% penalty** to reflect the missing responsiveness signal. Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
 * **Uptime Source:** *Official* = service publishes a rolling 30-day uptime metric AIWatch reads directly. *Estimate* = no official metric; AIWatch substitutes an industry-average assumption (99.5%) or its own poll-derived figure for the Score's Uptime input. *Partial (Nd)* = an official source exists but AIWatch's measurement window is shorter than the full month (e.g. service newly tracked mid-month). The label only describes the Uptime input quality — the Score itself is computed identically across all services.
 * **Incident Counting:** Incident counts reflect all affected components per service. Providers differ in reporting granularity — Anthropic reports per-model incidents (Opus/Sonnet/Haiku each counted separately), while others report at the service level.

--- a/index.md
+++ b/index.md
@@ -1,10 +1,10 @@
 ---
 layout: home
 title: AIWatch Monthly Reports
-description: "Monthly AI service incident reports covering 42 AI services — uptime, incidents, and reliability rankings."
+description: "Monthly AI service incident reports covering 43 AI services — uptime, incidents, and reliability rankings."
 ---
 
-Monthly AI service incident reports covering 42 AI services monitored by [AIWatch](https://ai-watch.dev).
+Monthly AI service incident reports covering 43 AI services monitored by [AIWatch](https://ai-watch.dev).
 
 ## Reports
 

--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -49,10 +49,10 @@ const ID_TO_NAME = {
   mistral: 'Mistral API', cohere: 'Cohere API', groq: 'Groq Cloud',
   together: 'Together AI', fireworks: 'Fireworks AI', cerebras: 'Cerebras Inference',
   perplexity: 'Perplexity', huggingface: 'Hugging Face',
-  replicate: 'Replicate', elevenlabs: 'ElevenLabs', xai: 'xAI (Grok)',
+  replicate: 'Replicate', fal: 'fal.ai', elevenlabs: 'ElevenLabs', xai: 'xAI (Grok)',
   deepseek: 'DeepSeek API', openrouter: 'OpenRouter', bedrock: 'Amazon Bedrock',
-  azureopenai: 'Azure OpenAI', pinecone: 'Pinecone', stability: 'Stability AI',
-  voyageai: 'Voyage AI', modal: 'Modal', langsmith: 'LangChain (LangSmith)', helicone: 'Helicone', langfuse: 'Langfuse', runway: 'Runway', luma: 'Luma (Dream Machine)',
+  azureopenai: 'Azure OpenAI', pinecone: 'Pinecone', turbopuffer: 'turbopuffer', stability: 'Stability AI', bfl: 'Black Forest Labs (FLUX)',
+  voyageai: 'Voyage AI', modal: 'Modal', twelvelabs: 'Twelve Labs', langsmith: 'LangChain (LangSmith)', helicone: 'Helicone', langfuse: 'Langfuse', runway: 'Runway', luma: 'Luma (Dream Machine)',
   claudeai: 'claude.ai', chatgpt: 'ChatGPT', characterai: 'Character.AI', deepseekapp: 'DeepSeek App',
   claudecode: 'Claude Code', codex: 'Codex', cursor: 'Cursor',
   copilot: 'GitHub Copilot', windsurf: 'Windsurf', junie: 'Junie',
@@ -67,8 +67,8 @@ const CATEGORY_ORDER = [
   'claude', 'openai', 'gemini', 'bedrock', 'azureopenai', 'mistral', 'cohere', 'groq',
   'together', 'fireworks', 'cerebras', 'perplexity', 'xai', 'deepseek', 'openrouter',
   // Voice & Inference (incl. observability — langsmith/helicone/langfuse — and video; coarse grouping)
-  'elevenlabs', 'assemblyai', 'deepgram', 'huggingface', 'replicate', 'pinecone',
-  'stability', 'voyageai', 'modal', 'langsmith', 'helicone', 'langfuse', 'runway', 'luma',
+  'elevenlabs', 'assemblyai', 'deepgram', 'huggingface', 'replicate', 'fal', 'pinecone', 'turbopuffer',
+  'stability', 'bfl', 'voyageai', 'modal', 'twelvelabs', 'langsmith', 'helicone', 'langfuse', 'runway', 'luma',
   // Coding Agents
   'claudecode', 'codex', 'cursor', 'copilot', 'windsurf', 'junie',
 ]
@@ -681,7 +681,7 @@ if (require.main === module) {
         if (history[key]) { lastDataDay = d; break }
       }
 
-      // Use all 42 services in category order (not just incident table)
+      // Use all 43 services in category order (not just incident table)
       const serviceNames = CATEGORY_ORDER.map(id => ID_TO_NAME[id]).filter(Boolean)
 
       const heatmapSvg = generateUptimeHeatmapSvg(serviceNames, history, daysInMonth, monthKey, monitoringStartDay, lastDataDay)


### PR DESCRIPTION
Sibling of aiwatch PR #871 (Twelve Labs, service #43). Brings the reports site + generator from 42 → 43 monitored services.

## Changes
- **Count bump 42 → 43** across doc/chrome: `README.md` (17→18 voice & inference), `_config.yml`, `index.md` (×2), `_templates/monthly-report.md` (×3, incl. 32→33 API services). Sub-counts verified: 15 LLM + 18 voice&inference + 4 apps + 6 agents = 43; 33 API + 6 agents + 4 apps = 43.
- **Generator roster** (`scripts/generate-charts.js`): added `twelvelabs` (Twelve Labs) — and backfilled `fal` (fal.ai), `bfl` (Black Forest Labs (FLUX)), `turbopuffer`, which were previously missing from `ID_TO_NAME` / `CATEGORY_ORDER` and would otherwise render as raw ids in the monthly heatmap. Both maps now hold all 43 ids in dashboard order.

## Verification
- `ID_TO_NAME` (43) ↔ `CATEGORY_ORDER` (43) in sync, identical id set, no dups.
- `node --test scripts/*.test.js` → fail 0.
- Local Jekyll: homepage renders "43 AI services".
- `y="42"` SVG coordinate untouched; only the line-684 comment bumped.

## Notes
- The 03/04/05 archives have no data for the new services, so historical report charts are unaffected — the roster change is forward-looking.
- `README.md:38` probe-target count is unchanged: aiwatch #871 has not (yet) added a probe endpoint for Twelve Labs (requested in that PR's review); bump the reports probe count only if/when it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)