### PR TITLE
fix(charts): drop false-positive Incident Summary guard aborting on zero-security months (#49)

### DIFF
--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -604,10 +604,14 @@ if (require.main === module) {
   }
 
   const scores = parseTable(md, 'AIWatch Score')
-  const incidents = parseTable(md, 'Incident Summary')
 
   if (scores.length === 0) { console.error('Failed to parse AIWatch Score table. Check "## AIWatch Score" heading exists.'); process.exit(1) }
-  if (incidents.length === 0) { console.error('Failed to parse Incident Summary table. Check "## Incident Summary" heading exists.'); process.exit(1) }
+  // The Incident Summary renders as an HTML <table> (not a markdown pipe table), so parseTable()
+  // can't read it and charts don't consume incident data anyway — the scores guard above is the
+  // report-well-formedness check. A markdown-table guard here false-failed on zero-security months:
+  // parseTable's non-greedy scan skipped the HTML table and matched the next markdown table further
+  // down — the Security Alerts section, which is conditionally omitted (buildSecuritySection returns
+  // '' when totalAlerts <= 0) — so the guard aborted the whole pipeline when it was absent (#49).
 
   const relDir = path.dirname(file)
   const monthMatch = relDir.match(/(\d{4}-\d{2})/)


### PR DESCRIPTION
Closes #49.

## Problem

The `Generate charts` step of `generate-report.yml` (`node scripts/generate-charts.js "${MONTH}/index.md"`) aborts with:

```
Failed to parse Incident Summary table. Check "## Incident Summary" heading exists.
Error: Process completed with exit code 1.
```

…even though the `## Incident Summary` heading **is** present and all charts generate fine. It's a false failure that blocks the entire monthly report draft pipeline (observed on the 2026-06 draft run).

## Root cause

1. The Incident Summary is rendered as an **HTML `<table>`** (`generate-report.js` → `buildIncidentTable` emits `<tr><td>…` rows), not a markdown pipe table.
2. `parseTable()` (`generate-summary.js`) only matches **markdown pipe tables**; its non-greedy scan skips the HTML table and matches the *next* markdown table below — the **Security Alerts** section.
3. `buildSecuritySection` returns `''` when `totalAlerts <= 0`, so a **zero-security month** has no markdown table after the heading → `parseTable` returns `[]` → `process.exit(1)`.
4. `incidents` was **never consumed** elsewhere in `generate-charts.js`. The `scores` parse/guard is the real report-well-formedness check (it feeds `generateScoreBarSvg`).

Intermittent by design: success depended on whether that month happened to render a Security Alerts markdown table.

## Fix

Remove the dead `incidents` parse + its guard, with an explanatory comment. No HTML-aware replacement guard is added — it would still false-fail on a genuinely incident-free month (a legitimate outcome).

## Verification

- Reproduced: a 2026-06 report with the Security section stripped (zero-security simulation) has no markdown table after `## Incident Summary`; **before** → `exit 1`, **after** → all three SVGs generate, `exit 0`.
- `scripts/*.test.js` full suite green.

## Out of scope (noted for follow-up)

The standalone `generate-summary.js` CLI has the same `parseTable('Incident Summary')` mismatch, but the **CI report pipeline is unaffected**: `generate-report.js` builds analyzer rows directly from `archive.services` via `archiveToAnalysisRows` (bypassing the markdown re-parse). Only manual `node scripts/generate-summary.js <report>.md` invocation is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)