### PR TITLE
refactor(summary): remove dead/broken standalone CLI, keep library exports (#52)

### DIFF
--- a/scripts/generate-summary.js
+++ b/scripts/generate-summary.js
@@ -1,9 +1,10 @@
-#!/usr/bin/env node
-// generate-summary.js — Parse monthly report tables and generate Opening + TL;DR
-// Usage: node scripts/generate-summary.js 2026-03/index.md
-
-const fs = require('fs')
-const path = require('path')
+// generate-summary.js — Library: table parser + monthly-report analyzer/narrative generators.
+// Consumed by generate-report.js (auto-draft narrative injection) and generate-charts.js
+// (parseTable for the Score table). NOT a CLI: the former standalone `node generate-summary.js
+// <report>.md` path was removed (#52) — it re-parsed the rendered markdown, but the Incident
+// Summary renders as an HTML <table> that parseTable (markdown pipe tables only) can't read, so
+// analyze() ran on mis-parsed rows. generate-report.js feeds analyze() correct rows built directly
+// from archive.services (archiveToAnalysisRows), superseding the CLI.
 
 // ── Table parser ──────────────────────────────────────────
 function parseTable(md, heading) {
@@ -172,41 +173,3 @@ function generateStats(a) {
 
 // ── Exports for testing ───────────────────────────────────
 module.exports = { parseTable, toMinutes, fmtDuration, analyze, generateOpening, generateTldr, generateStats }
-
-// ── CLI execution ─────────────────────────────────────────
-if (require.main === module) {
-  const file = process.argv[2]
-  if (!file) {
-    console.error('Usage: node scripts/generate-summary.js <report.md>')
-    process.exit(1)
-  }
-
-  const md = fs.readFileSync(path.resolve(file), 'utf-8')
-  const scores = parseTable(md, 'AIWatch Score')
-  const incidents = parseTable(md, 'Incident Summary')
-
-  if (scores.length === 0 || incidents.length === 0) {
-    console.error('Failed to parse tables. Check heading names match.')
-    process.exit(1)
-  }
-
-  const titleMatch = md.match(/^#\s+(\w+ \d{4})/m)
-  const monthYear = titleMatch ? titleMatch[1] : '[MONTH] [YEAR]'
-
-  const a = analyze(scores, incidents)
-
-  console.log('═══════════════════════════════════════════')
-  console.log('  OPENING NARRATIVE')
-  console.log('═══════════════════════════════════════════\n')
-  console.log(generateOpening(monthYear, a))
-
-  console.log('\n═══════════════════════════════════════════')
-  console.log('  TL;DR')
-  console.log('═══════════════════════════════════════════\n')
-  console.log(generateTldr(a, incidents))
-
-  console.log('\n═══════════════════════════════════════════')
-  console.log('  STATS')
-  console.log('═══════════════════════════════════════════\n')
-  console.log(generateStats(a))
-}


### PR DESCRIPTION
Closes #52. Follow-up to #49 (same root cause, different file).

## Problem

`generate-summary.js`'s standalone CLI (`if (require.main === module)`) had the **same `parseTable('Incident Summary')` mismatch fixed in #49**, but unlike generate-charts.js it fed the mis-parsed result into `analyze()`:

- Incident Summary renders as an HTML `<table>`; `parseTable` matches markdown pipe tables only, so its non-greedy scan skipped it and matched the next markdown table — the **Security Alerts** `By source` sub-table.
- `analyze()` then ran on Security-table rows → `withIncidents`/`totalDowntimeMins`/`totalServices` all wrong → **silently wrong Opening/TL;DR narrative** (or a hard abort on a zero-security month, the #49 failure in the summary CLI).

## Why delete (not repair)

- The CLI is invoked by **no workflow, doc, or test** (only the file's own usage string).
- The module is used **as a library** by `generate-report.js`, which feeds `analyze()` **correct rows built directly from `archive.services`** via `archiveToAnalysisRows` — bypassing `parseTable`. generate-report.js documents that this auto-draft injection closed the "operator runs a local script and copy-pastes output" gap the CLI once served, i.e. the CLI is superseded and its output is wrong anyway.

## Change

- Delete the `if (require.main === module)` CLI block.
- Remove now-dead `fs`/`path` requires and the `#!/usr/bin/env node` shebang (library-only module).
- Rewrite the header comment for the library role.
- `module.exports` + all analyzer/generator functions unchanged — still imported by `generate-report.js` (analyze/narrative) and `generate-charts.js` (parseTable for the Score table).

## Verification

- Full `scripts/*.test.js` suite green (tests import the exported functions).
- `generate-report.js` pipeline still injects the auto-draft narrative — library path untouched.
- Repo-wide grep confirms no remaining CLI / `fs` / `path` / shebang dependency on this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)