### PR TITLE
docs: fix stale probe-target count (→31) + non-probe list (Pinecone→Modal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Each monthly report includes:
 - **AIWatch Score**: Weighted composite of uptime (40pts), incident affected days (25pts), recovery time (15pts), and probe-based responsiveness (20pts). Services without probe data use 80→100 score redistribution.
 - **Uptime figures**: Official status page metrics — single primary component basis where available, platform-wide average otherwise
 - **Incident counts**: Per-component aggregation — some providers (e.g., Anthropic) report per model, so counts may exceed distinct outages
-- **API probe**: Direct RTT measurement every 5 minutes to 20 services with public endpoints (supplementary monitoring data)
+- **API probe**: Direct RTT measurement every 5 minutes to 31 probe targets with public endpoints (supplementary monitoring data)
 - **3-Month Trend (Notable Movers)**: ranked by the largest single change across **Score / MTTR / total downtime** over the window — incident-feed *measured* metrics. Uptime is deliberately excluded: the archive's `uptime` field mixes per-service sources (status-page group aggregates, estimate/poll-derived figures) so a cross-service uptime delta is misleading (a 3-month official-uptime trend awaits aiwatch#586 + ≥3 months of the clean `officialUptime` field). Direction (🔺/🔻) follows the bold *headline* metric, not Score. Services the Score ranking excludes (no-incident-feed / stale source) are excluded from movers too. The first point is flagged when its month is partial (mid-month onboarding); MTTR/downtime are measured over the months that have incident data.
 
 Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -123,7 +123,7 @@ Combines four components — Uptime (40%), Incident affected days (25%), Recover
 These p75 figures are the input to the **Responsiveness** component (20% weight) of [AIWatch Score](#aiwatch-score--[month]-[year]-reliability-rankings). Lower is better. The two tables answer different questions: Score Rankings sorts by *which service is safest to rely on* (combining uptime, incidents, recovery, and responsiveness); this table sorts by *which service is fastest at the network layer*.
 
 <!-- Data source: curl https://api.ai-watch.dev/api/probe/history?days=30 -->
-<!-- 20 probe-covered API services. Non-probe services (Bedrock, Azure OpenAI, Pinecone) excluded. -->
+<!-- 31 probe targets (30 API services incl. twelvelabs + cursor). Non-probe API services (Bedrock, Azure OpenAI, Modal) excluded. -->
 <!-- p95 + Spikes are present in probe:daily:{date} (CLAUDE.md KV schema) but not yet
      surfaced by /api/report. vs-Last-Month additionally requires reading the previous
      month's archive:monthly:* and computing deltas. Re-add the columns once the
@@ -133,7 +133,7 @@ These p75 figures are the input to the **Responsiveness** component (20% weight)
 |---|---|---|
 | 1 | | |
 
-> **Note**: Probe RTT measures direct API endpoint response time from Cloudflare Workers edge (5-min intervals). Values reflect network round-trip time, not inference latency. Services without probe coverage (Bedrock, Azure OpenAI, Pinecone) are excluded from rankings.
+> **Note**: Probe RTT measures direct API endpoint response time from Cloudflare Workers edge (5-min intervals). Values reflect network round-trip time, not inference latency. Services without probe coverage (Bedrock, Azure OpenAI, Modal) are excluded from rankings.
 
 ---
 


### PR DESCRIPTION
## Summary
Fixes stale probe-monitoring counts + the non-probe service list in the reports docs. These predated the recent aiwatch probe additions and were never bumped.

## Changes
- **`README.md:38`** — "20 services" → **31 probe targets** with public endpoints
- **`_templates/monthly-report.md:126`** (HTML comment) — "20 probe-covered API services … (Bedrock, Azure OpenAI, **Pinecone**)" → "31 probe targets (30 API services incl. twelvelabs + cursor) … (Bedrock, Azure OpenAI, **Modal**)"
- **`_templates/monthly-report.md:136`** (rendered Note) — non-probe list "(… **Pinecone**)" → "(… **Modal**)"

## Why these numbers
Authoritative source = aiwatch `PROBE_TARGETS` + `/methodology`:
- **31 probe targets** = 30 API services (incl. Twelve Labs, aiwatch#871) + `cursor` (coding agent, aiwatch#885). Mirrors aiwatch's own "31 probe targets" phrasing (dropped strict "API services" since cursor is an agent).
- **Pinecone is probed** since aiwatch#857 → the 3 non-probed API services are now **Bedrock · Azure OpenAI · Modal**.

## Scope / verification
- Doc + comment only — README isn't site-rendered; line 126 is an HTML comment; line 136 renders only on monthly-report generation. No live browser surface.
- Generator tests unaffected (`node --test scripts/*.test.js` → pass 4 / fail 0).
- Residual-stale grep clean (no `20 services` / `Pinecone` non-probe left).

## ⚠️ Merge dependency
The **31** count assumes **aiwatch#885** (adds `cursor` probe) is merged — it's currently OPEN. **Merge this PR after aiwatch#885 lands** so the count matches production. (If #885 is dropped, this should be 30.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)