### PR TITLE
feat(generator): generate-time RECURRENCE CHECK block + MoM-framed auto-draft (closes #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The trend section + chart read the trailing months from `_data/` (prior months) 
 
 After generation, fill in the narrative sections (`Summary`, `Recommendations`, `Key Insight`, `Notable Incidents`, `Observations`), flip `published: false` → `true`, and merge.
 
+**Narrative recurrence check** (aiwatch-reports#54): when a likely narrative subject (a top-incident service, the slowest-recovery service, or a Notable Mover) also filled the **same slot** — the Summary "High incident count" bullet, a Key Insight pattern, or Notable Incidents — in ≥2 of the last 3 published months, the generator injects a `RECURRENCE CHECK` block above `## Summary` (e.g. *"Together AI led the Summary 'High incident count' bullet in 2 of the last 2 published months … (last month 133 → this month 85)"*). It has no memory of prior months otherwise, so the same framing recurred unnoticed (Together AI three months running). **Reframe around the month-over-month change, then delete the block** — it uses the same delete-before-merge fence as AUTO-DRAFT, and a leaked fence hard-fails the pre-publish lint. The auto-drafted "Most incidents" bullet is also MoM-framed by default (`155 incidents … — 97 last month (+58)`).
+
 ---
 
 ## About AIWatch

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -1012,7 +1012,7 @@ function injectAutoDraft(filled, opening, tldr) {
 // (by passing a stub `summaryMod` whose `analyze` throws). main() routes through
 // this so the failure-isolation contract — "narrative-generation failure never
 // blocks the deterministic data pipeline" — is testable, not just documented.
-function applyAutoDraft(filled, archive, meta, month, summaryMod = summary) {
+function applyAutoDraft(filled, archive, meta, month, summaryMod = summary, momByService = {}) {
   try {
     const { scores, incidents } = archiveToAnalysisRows(archive, meta)
     if (scores.length === 0 || incidents.length === 0) {
@@ -1021,7 +1021,7 @@ function applyAutoDraft(filled, archive, meta, month, summaryMod = summary) {
     }
     const a = summaryMod.analyze(scores, incidents)
     const opening = summaryMod.generateOpening(`${monthName(month)} ${month.split('-')[0]}`, a)
-    const tldr = summaryMod.generateTldr(a, incidents)
+    const tldr = summaryMod.generateTldr(a, incidents, momByService)
     return injectAutoDraft(filled, opening, tldr)
   } catch (err) {
     console.warn('[generate-report] Auto-draft injection failed (continuing with un-injected draft):', err instanceof Error ? err.message : err)
@@ -1145,10 +1145,21 @@ async function main() {
   }
   const filled = fillTemplate(template, month, archive, meta)
 
+  // aiwatch-reports#54 — month-over-month incident-count deltas, used to MoM-frame the
+  // auto-draft "Most incidents" bullet AND the recurrence block's "133 → 85" hint.
+  // Best-effort: an absent prior-month _data archive yields an empty map (no MoM tails).
+  const dataDir = path.join(__dirname, '..', '_data')
+  let momByService = {}
+  try {
+    momByService = buildMomIncidentDeltas(archive, meta, month, { dataDir })
+  } catch (err) {
+    console.warn('[generate-report] MoM delta computation failed (continuing without deltas):', err instanceof Error ? err.message : err)
+  }
+
   // Auto-draft narrative is best-effort — never blocks the deterministic data pipeline.
   // applyAutoDraft swallows analyzer/parsing failures (logs `console.warn`, returns
   // `filled` unchanged); see its docstring above for the contract.
-  let withDraft = applyAutoDraft(filled, archive, meta, month)
+  let withDraft = applyAutoDraft(filled, archive, meta, month, summary, momByService)
   if (withDraft !== filled) {
     console.log('[generate-report] Injected auto-draft narrative (Opening → Key Insight; TL;DR → Summary).')
   }
@@ -1174,6 +1185,24 @@ async function main() {
     console.warn('[generate-report] Narrative injection failed (continuing without it):', err instanceof Error ? err.message : err)
   }
 
+  // aiwatch-reports#54 — flag narrative subjects repeated across prior months. Best-effort:
+  // a missing/corrupt prior month degrades (loadPriorNarrative skips it), never throws.
+  try {
+    const currentSubjects = computeCurrentSubjects(archive, meta, month, { dataDir })
+    const priorMonths = loadPriorNarrative(month, { rootDir: OUT_DIR_ROOT })
+    const flags = detectRecurrence(currentSubjects, priorMonths)
+    const block = buildRecurrenceBlock(flags, { currentMonth: month, priorCount: priorMonths.length, momByService })
+    const beforeRecurrence = withDraft
+    withDraft = injectRecurrenceCheck(withDraft, block)
+    if (withDraft !== beforeRecurrence) {
+      console.log(`[generate-report] Injected RECURRENCE CHECK — ${flags.length} repeated subject${flags.length === 1 ? '' : 's'} (review, then DELETE the block before merge).`)
+    } else if (flags.length === 0) {
+      console.log('[generate-report] No narrative recurrence vs prior months.')
+    }
+  } catch (err) {
+    console.warn('[generate-report] Recurrence check failed (continuing without it):', err instanceof Error ? err.message : err)
+  }
+
   const outDir = path.join(OUT_DIR_ROOT, month)
   fs.mkdirSync(outDir, { recursive: true })
   const outPath = path.join(outDir, 'index.md')
@@ -1181,6 +1210,296 @@ async function main() {
 
   console.log(`[generate-report] ✓ Wrote ${month}/index.md (published: false)`)
   console.log(`[generate-report]   Review narrative sections (including AUTO-DRAFT), then flip published: true and merge.`)
+}
+
+// ── Narrative recurrence check (aiwatch-reports#54) ──────────────────
+//
+// The hand-authored narrative slots (Summary "High incident count" bullet, Key
+// Insight patterns, Notable Incidents) have no memory of prior months, so the same
+// framing recurs (Together AI led the "High incident count" bullet Apr/May/Jun) and
+// is only caught by a human at edit time. This injects a generate-time RECURRENCE
+// CHECK block — the same class of mechanical gate #415 was on the aiwatch side:
+// a passive "compare against last month" rule gets only probabilistic compliance.
+//
+// Two pure cores (unit-tested, no I/O): `extractNarrativeSubjects` reads the subject
+// services out of a prior month's published index.md per slot; `detectRecurrence`
+// flags any current-month subject that also filled the SAME slot in ≥2 of the last 3
+// months. The I/O wrappers read the prior months + inject the block behind the same
+// delete-before-merge fence as AUTO-DRAFT, and degrade gracefully (a missing/corrupt
+// prior month is skipped, never thrown — same contract as the charts prior-month read).
+
+// Slots we track. Keyed the same on the current-subject side (computeCurrentSubjects)
+// and the prior-month side (extractNarrativeSubjects) so detectRecurrence can pair them.
+const RECURRENCE_SLOTS = ['summary', 'keyInsight', 'notable']
+const RECURRENCE_WINDOW = 3 // look back this many published months
+const RECURRENCE_MIN = 2    // flag a subject repeated in ≥ this many of the window
+
+const RECURRENCE_OPEN_MARKER = '<!-- BEGIN RECURRENCE CHECK — review, reframe around the change, then DELETE this entire block before merge -->'
+const RECURRENCE_CLOSE_MARKER = '<!-- END RECURRENCE CHECK -->'
+
+// Human label per slot for the injected block.
+const RECURRENCE_SLOT_LABEL = {
+  summary: "the Summary 'High incident count' bullet",
+  keyInsight: 'a Key Insight pattern',
+  notable: 'Notable Incidents',
+}
+
+// Case/spacing-insensitive service-name key for cross-month matching. Prior-month
+// names are read from rendered markdown (author-typed) so exact equality is unsafe.
+function normSubject(s) {
+  return String(s || '').trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+// Text of a `## <heading>` section up to (excluding) the next top-level `## ` or EOF.
+// Returns '' when the heading is absent. The Score heading carries a "— Month Year"
+// suffix, so callers pass a prefix and we match `## <prefix>` to end-of-line. No `m`
+// flag: the terminating `$` must mean end-of-STRING (EOF fallback), not end-of-line.
+function sectionText(md, headingPrefix) {
+  const esc = headingPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`\\n##\\s+${esc}[^\\n]*\\n([\\s\\S]*?)(?=\\n##\\s|$)`)
+  const m = ('\n' + String(md)).match(re)
+  return m ? m[1] : ''
+}
+
+// Service display-names the report names in its own AIWatch Score table — a
+// self-contained lexicon so the prose slots can be scanned without external meta.
+function serviceNameLexicon(md) {
+  return summary.parseTable(md, 'AIWatch Score')
+    .map(r => r.Service)
+    .filter(Boolean)
+}
+
+// Fold an author-typed name variant onto its canonical Score-table name so cross-month
+// matching survives spelling drift — the "High incident count" bullet says "Mistral" one
+// month and "Mistral API" the next, but both are the same "Mistral API" Score row. Exact
+// match wins; else a UNIQUE prefix-word-run resolve ("mistral" → "Mistral API"); an
+// ambiguous or absent match keeps the raw token (never a wrong canonicalization).
+function canonicalizeToLexicon(name, lexicon) {
+  const key = normSubject(name)
+  if (!key) return name
+  const exact = lexicon.find(l => normSubject(l) === key)
+  if (exact) return exact
+  const startsWithToken = lexicon.filter(l => normSubject(l).startsWith(key + ' '))
+  if (startsWithToken.length === 1) return startsWithToken[0]
+  const tokenStartsWith = lexicon.filter(l => key.startsWith(normSubject(l) + ' '))
+  if (tokenStartsWith.length === 1) return tokenStartsWith[0]
+  return name
+}
+
+// Which lexicon names appear in `text` (whole-name, boundary-guarded so "Codex"
+// doesn't match inside another word). Order-preserving, de-duplicated.
+function subjectsInText(text, lexicon) {
+  const seen = new Set()
+  const out = []
+  for (const name of lexicon) {
+    const key = normSubject(name)
+    if (seen.has(key)) continue
+    const re = new RegExp(`(?<![\\w])${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![\\w])`, 'i')
+    if (re.test(text)) { seen.add(key); out.push(name) }
+  }
+  return out
+}
+
+// Subjects of the Summary "High incident count" bullet — the proven recurrence.
+// Matches the bullet by its bold label (hand-authored "High incident count…" or the
+// auto-draft's "Most incidents"), then pulls each service name that precedes a `(`
+// stat group ("Mistral API (155 incidents…) and Together AI (133…)"). Each name is
+// canonicalized to the report's own lexicon so "Mistral" and "Mistral API" fold together
+// across months (the false-negative this feature exists to prevent).
+function highIncidentBulletSubjects(summaryTxt, lexicon) {
+  const bulletRe = /^[-*]\s*\*\*(?:high incident|most incidents)[^*]*\*\*:?\s*(.+)$/im
+  const m = summaryTxt.match(bulletRe)
+  if (!m) return []
+  const out = []
+  const seen = new Set()
+  for (const nm of m[1].matchAll(/([A-Z][A-Za-z0-9.&()/-]*(?:\s+[A-Z0-9][A-Za-z0-9.&()/-]*)*)\s*\(/g)) {
+    const name = canonicalizeToLexicon(nm[1].trim(), lexicon)
+    const key = normSubject(name)
+    if (name && !seen.has(key)) { seen.add(key); out.push(name) }
+  }
+  return out
+}
+
+// Key Insight subjects = services named in the section's BOLD-LEAD bullets (`- **…**: …`)
+// ONLY, not its prose — the bold-lead bullets ARE the recurring framings. Scanning the full
+// ~200-line section pulls every incidentally-mentioned service (noisy flags); requiring the
+// literal word "Pattern" is too strict (real months use free-form labels like "Single-month
+// deltas…" / "…two months running"), so we scope to any bold-lead bullet then filter to the
+// report's own lexicon — precision without depending on a label convention.
+function keyInsightSubjects(keyInsightTxt, lexicon) {
+  const boldBullets = (keyInsightTxt.match(/^[-*]\s*\*\*[^\n]*$/gim) || []).join('\n')
+  return boldBullets ? subjectsInText(boldBullets, lexicon) : []
+}
+
+// Service subjects named on `**Affected**:` lines in the Notable Incidents section.
+// "(also Claude Code, claude.ai)" is expanded to its service list; every other
+// parenthetical is descriptive prose and dropped. Results are filtered to the report's
+// own service lexicon so incident-description noise ("newly-created keys") never leaks
+// in as a subject.
+function affectedSubjects(notableTxt, lexicon) {
+  const known = new Map(lexicon.map(n => [normSubject(n), n]))
+  const out = []
+  const seen = new Set()
+  for (const m of notableTxt.matchAll(/^\s*\*\*Affected:?\*\*:?\s*(.+)$/gim)) {
+    const expanded = m[1].replace(/\(also\s+([^)]*)\)/gi, ', $1').replace(/\([^)]*\)/g, '')
+    for (const part of expanded.split(/\s*(?:&|,|\band\b)\s*/i)) {
+      const canon = known.get(normSubject(part))
+      if (canon && !seen.has(normSubject(canon))) { seen.add(normSubject(canon)); out.push(canon) }
+    }
+  }
+  return out
+}
+
+// PURE. Extract the subject services of each tracked narrative slot from a prior
+// month's published index.md. Never throws — an absent/odd section yields []. The
+// lexicon is derived from the same document's Score table (self-contained).
+function extractNarrativeSubjects(indexMd) {
+  const md = String(indexMd || '')
+  const lexicon = serviceNameLexicon(md)
+  return {
+    summary: highIncidentBulletSubjects(sectionText(md, 'Summary'), lexicon),
+    keyInsight: keyInsightSubjects(sectionText(md, 'Key Insight'), lexicon),
+    notable: affectedSubjects(sectionText(md, 'Notable Incidents'), lexicon),
+  }
+}
+
+// PURE. Flag each current-month subject that also filled the SAME slot in ≥ `min` of
+// the (up to `window`) prior months.
+//   currentSubjectsBySlot: { slot -> [name] }
+//   priorMonths:           [{ month, subjects: { slot -> [name] } }]
+// Returns [{ service, slot, monthsSeen: [YYYY-MM,…] }], one per (service, slot).
+function detectRecurrence(currentSubjectsBySlot, priorMonths, opts = {}) {
+  const { window = RECURRENCE_WINDOW, min = RECURRENCE_MIN } = opts
+  const recent = (priorMonths || []).slice(0, window)
+  const flags = []
+  for (const slot of RECURRENCE_SLOTS) {
+    const current = currentSubjectsBySlot?.[slot] || []
+    const emitted = new Set()
+    for (const svc of current) {
+      const key = normSubject(svc)
+      if (!key || emitted.has(key)) continue
+      emitted.add(key)
+      const monthsSeen = recent
+        .filter(pm => (pm.subjects?.[slot] || []).some(n => normSubject(n) === key))
+        .map(pm => pm.month)
+      if (monthsSeen.length >= min) flags.push({ service: svc, slot, monthsSeen })
+    }
+  }
+  return flags
+}
+
+// ── Recurrence I/O wrappers ──────────────────────────────────────────
+
+// Read the last `window` published months' narrative subjects. Graceful: a month
+// with no `index.md` (or an unreadable one) is skipped, matching the charts
+// prior-month contract (a partial history degrades, never throws).
+function loadPriorNarrative(month, opts = {}) {
+  const { rootDir = OUT_DIR_ROOT, window = RECURRENCE_WINDOW } = opts
+  const prior = []
+  for (const pm of charts.monthsBefore(month, window)) {
+    let md
+    try {
+      md = fs.readFileSync(path.join(rootDir, pm, 'index.md'), 'utf-8')
+    } catch {
+      continue // month never published / unreadable → skip
+    }
+    try {
+      prior.push({ month: pm, subjects: extractNarrativeSubjects(md) })
+    } catch (err) {
+      console.warn(`[generate-report] recurrence: could not parse ${pm}/index.md — skipping (${err instanceof Error ? err.message : err})`)
+    }
+  }
+  return prior
+}
+
+// Month-over-month incident-count deltas, keyed by service display name, for every
+// service with a count this month AND last month. Feeds both the RECURRENCE block's
+// "133 → 85" hint and the auto-draft's MoM-framed "Most incidents" bullet (#54 bonus).
+function buildMomIncidentDeltas(archive, meta, month, opts = {}) {
+  const { dataDir = path.join(__dirname, '..', '_data') } = opts
+  const map = {}
+  const prevMonth = charts.monthsBefore(month, 1)[0]
+  const prev = charts.readDataArchive(prevMonth, dataDir)
+  if (!prev || !prev.services) return map
+  const { incidents } = archiveToAnalysisRows(archive, meta)
+  for (const r of incidents) {
+    const curr = parseInt(r.Incidents, 10)
+    if (Number.isNaN(curr)) continue
+    const id = charts.nameToId(r.Service)
+    const p = prev.services[id]?.incidents
+    if (typeof p !== 'number') continue
+    map[r.Service] = { curr, prev: p }
+  }
+  return map
+}
+
+// Current-month likely narrative subjects per slot, derived from the archive data
+// already computed for the report — top incident-count services (drive the Summary
+// bullet + Key Insight Pattern-1), the slowest-recovery service (Pattern-2), and the
+// Notable Movers (Key Insight turnaround + Notable Incidents). Best-effort: a trend
+// gap (fewer than 2 months of _data) just drops the movers.
+function computeCurrentSubjects(archive, meta, month, opts = {}) {
+  const { dataDir = path.join(__dirname, '..', '_data') } = opts
+  const { scores, incidents } = archiveToAnalysisRows(archive, meta)
+  if (scores.length === 0 || incidents.length === 0) return { summary: [], keyInsight: [], notable: [] }
+  const a = summary.analyze(scores, incidents)
+  const topIncident = [...incidents]
+    .filter(r => parseInt(r.Incidents, 10) > 0)
+    .sort((x, y) => parseInt(y.Incidents, 10) - parseInt(x.Incidents, 10))
+    .slice(0, 2)
+    .map(r => r.Service)
+  const slowest = a.slowestRecovery?.Service ? [a.slowestRecovery.Service] : []
+  let movers = []
+  try {
+    const cur = charts.toMonthEntry(month, archive)
+    const entries = charts.loadTrendEntries(month, cur, { dataDir })
+    if (entries.length >= 2) {
+      const trend = charts.buildTrendSeries(entries)
+      movers = charts.computeNotableMovers(trend, { nameFor: id => serviceName(id, meta) }).map(m => m.name)
+    }
+  } catch { /* movers are optional context */ }
+  const uniq = arr => [...new Set(arr.filter(Boolean))]
+  return {
+    summary: uniq(topIncident),
+    keyInsight: uniq([...topIncident, ...slowest, ...movers]),
+    notable: uniq([...topIncident, ...movers]),
+  }
+}
+
+// Render the RECURRENCE CHECK block for the flags (or '' when none). Behind the same
+// delete-before-merge fence as AUTO-DRAFT so #55's lint + the "no fence in output"
+// sanity check catch a leak. `priorCount` = months actually available (the /N).
+function buildRecurrenceBlock(flags, opts = {}) {
+  if (!flags || flags.length === 0) return ''
+  const { currentMonth = '', priorCount = RECURRENCE_WINDOW, momByService = {} } = opts
+  const lines = [
+    RECURRENCE_OPEN_MARKER,
+    '_Narrative repeated vs prior months — lead with the month-over-month change or a fresh lens, then delete this block._',
+    '',
+  ]
+  for (const f of flags) {
+    const label = RECURRENCE_SLOT_LABEL[f.slot] || f.slot
+    const priors = f.monthsSeen.join(', ')
+    const nMonths = Math.max(priorCount, f.monthsSeen.length)
+    const thisMonth = currentMonth ? ` + this month (${currentMonth})` : ''
+    const mom = momByService[f.service]
+    const momHint = mom && typeof mom.prev === 'number' && typeof mom.curr === 'number'
+      ? ` (last month ${mom.prev} → this month ${mom.curr})`
+      : ''
+    lines.push(`- ⚠️ **${f.service}** — led ${label} in ${f.monthsSeen.length} of the last ${nMonths} published month${nMonths === 1 ? '' : 's'} (${priors})${thisMonth}.${momHint} → Reframe around the change or pick a fresh lens.`)
+  }
+  lines.push('', RECURRENCE_CLOSE_MARKER)
+  return lines.join('\n')
+}
+
+// Insert the block directly above `## Summary` (near the top, next to the narrative
+// work). Idempotent — a document already carrying the open marker is returned as-is.
+function injectRecurrenceCheck(filled, block) {
+  if (!block) return filled
+  if (filled.includes(RECURRENCE_OPEN_MARKER)) return filled
+  // Function replacer — `block` is a literal, so a `$`-sequence in a service name / hint
+  // can't be misread as a replacement pattern ($&, $1, …).
+  return filled.replace(/^## Summary$/m, () => `${block}\n\n## Summary`)
 }
 
 if (require.main === module) {
@@ -1236,4 +1555,15 @@ module.exports = {
   NOTABLE_CLOSE_MARKER,
   OBSERVATIONS_OPEN_MARKER,
   OBSERVATIONS_CLOSE_MARKER,
+  // Narrative recurrence check (aiwatch-reports#54) — pure cores reused by #55's lint.
+  extractNarrativeSubjects,
+  detectRecurrence,
+  buildRecurrenceBlock,
+  injectRecurrenceCheck,
+  buildMomIncidentDeltas,
+  computeCurrentSubjects,
+  loadPriorNarrative,
+  RECURRENCE_OPEN_MARKER,
+  RECURRENCE_CLOSE_MARKER,
+  RECURRENCE_SLOTS,
 }

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -1455,5 +1455,261 @@ test('returns empty when fewer than 2 months of data exist', () => {
   }
 })
 
+// ── Narrative recurrence check (aiwatch-reports#54) ──────────────────
+const {
+  extractNarrativeSubjects,
+  detectRecurrence,
+  buildRecurrenceBlock,
+  injectRecurrenceCheck,
+  buildMomIncidentDeltas,
+  loadPriorNarrative,
+  RECURRENCE_OPEN_MARKER,
+  RECURRENCE_CLOSE_MARKER,
+} = require('./generate-report')
+const osR = require('os')
+const chartsR = require('./generate-charts')
+const { computeCurrentSubjects } = require('./generate-report')
+
+// A minimal published-report fixture: a Score table (the self-contained lexicon) plus
+// the three narrative slots, mirroring the real report structure.
+function sampleReport({ highIncident, keyInsight, affected }) {
+  return [
+    '# Report',
+    '',
+    '## Summary',
+    '',
+    '- **Most reliable**: Modal (97/100)',
+    `- **High incident count, fast recovery**: ${highIncident}`,
+    '',
+    '## Key Insight',
+    '',
+    keyInsight,
+    '',
+    '## AIWatch Score — Test 2026 Rankings',
+    '',
+    '| Rank | Service | Score | Grade |',
+    '|------|---------|-------|-------|',
+    '| 1 | Modal | 97 | Excellent |',
+    '| 2 | Together AI | 84 | Good |',
+    '| 3 | Mistral API | 78 | Good |',
+    '| 4 | ChatGPT | 70 | Good |',
+    '| 5 | Gemini API | 64 | Fair |',
+    '',
+    '## Notable Incidents',
+    '',
+    '### 1. Something broke',
+    `**Affected**: ${affected}`,
+    '**Duration**: 2h',
+    '',
+    '## Observations',
+    '',
+    '- done',
+  ].join('\n')
+}
+
+console.log('\nextractNarrativeSubjects (aiwatch-reports#54)')
+
+test('pulls the High-incident bullet subjects (name-before-stats)', () => {
+  const md = sampleReport({
+    highIncident: 'Together AI (85 incidents, 43m avg) and Mistral API (78 incidents, 19m avg)',
+    keyInsight: '- **Pattern 1**: nothing',
+    affected: 'Gemini API',
+  })
+  const s = extractNarrativeSubjects(md)
+  eq(s.summary.join('|'), 'Together AI|Mistral API')
+})
+
+test('High-incident subjects are canonicalized to the lexicon (Mistral → Mistral API)', () => {
+  // The flagship false-negative: a bare "Mistral" one month must fold onto "Mistral API"
+  // so it matches a "Mistral API" subject next month (both are the same Score row).
+  const md = sampleReport({
+    highIncident: 'Mistral (97 incidents) and Together AI (139 incidents)',
+    keyInsight: '- x',
+    affected: 'Gemini API',
+  })
+  const s = extractNarrativeSubjects(md)
+  eq(s.summary.join('|'), 'Mistral API|Together AI')
+})
+
+test('Key Insight subjects come from bold-lead bullets (Pattern OR free-form label), not prose', () => {
+  const md = sampleReport({
+    highIncident: 'Together AI (85 incidents)',
+    keyInsight: [
+      'Prose mentioning ChatGPT that must NOT count as a subject.',
+      '',
+      '- **Pattern 1 — counts**: Gemini API drove the month; unrelated Foobar ignored.',
+      '- **Major-LLM concentration risk, two months running**: Mistral API stayed elevated.',
+    ].join('\n'),
+    affected: 'Gemini API',
+  })
+  const s = extractNarrativeSubjects(md)
+  assert.ok(s.keyInsight.includes('Gemini API'), 'Pattern-labelled bullet subject found')
+  assert.ok(s.keyInsight.includes('Mistral API'), 'free-form bold-label bullet subject found (not just "Pattern N")')
+  assert.ok(!s.keyInsight.includes('ChatGPT'), 'prose-only mention excluded (scoped to bold-lead bullets)')
+  assert.ok(!s.keyInsight.includes('Foobar'), 'non-lexicon token excluded')
+})
+
+test('Notable Affected expands "(also …)" and filters description noise to the lexicon', () => {
+  const md = sampleReport({
+    highIncident: 'Together AI (85 incidents)',
+    keyInsight: '- x',
+    affected: 'Gemini API (newly-created keys), Mistral API (also ChatGPT)',
+  })
+  const s = extractNarrativeSubjects(md)
+  eq(s.notable.join('|'), 'Gemini API|Mistral API|ChatGPT')
+})
+
+test('missing sections and garbage input degrade to [] without throwing', () => {
+  const empty = extractNarrativeSubjects('## Nothing here')
+  eq(`${empty.summary.length}${empty.keyInsight.length}${empty.notable.length}`, '000')
+  const junk = extractNarrativeSubjects(null)
+  eq(`${junk.summary.length}${junk.keyInsight.length}${junk.notable.length}`, '000')
+})
+
+console.log('\ndetectRecurrence (aiwatch-reports#54)')
+
+const PRIORS_3 = [
+  { month: '2026-03', subjects: { summary: ['Together AI'], keyInsight: [], notable: [] } },
+  { month: '2026-04', subjects: { summary: ['Together AI', 'Mistral API'], keyInsight: [], notable: [] } },
+  { month: '2026-05', subjects: { summary: ['together ai'], keyInsight: ['ChatGPT'], notable: [] } },
+]
+
+test('flags a subject that filled the same slot in ≥2 of the last 3 months', () => {
+  const flags = detectRecurrence({ summary: ['Together AI'], keyInsight: [], notable: [] }, PRIORS_3)
+  eq(flags.length, 1)
+  eq(flags[0].service, 'Together AI')
+  eq(flags[0].slot, 'summary')
+  eq(flags[0].monthsSeen.join(','), '2026-03,2026-04,2026-05') // case-insensitive match on 05
+})
+
+test('does NOT flag a subject seen in only 1 month', () => {
+  const flags = detectRecurrence({ summary: ['Mistral API'], keyInsight: [], notable: [] }, PRIORS_3)
+  eq(flags.length, 0)
+})
+
+test('slots are isolated — a summary repeat does not flag the notable slot', () => {
+  const flags = detectRecurrence({ notable: ['Together AI'], summary: [], keyInsight: [] }, PRIORS_3)
+  eq(flags.length, 0)
+})
+
+test('window caps the look-back — a 4th-oldest month is ignored', () => {
+  const priors = [
+    ...PRIORS_3,
+    { month: '2026-02', subjects: { summary: ['Cohere API'], keyInsight: [], notable: [] } },
+  ]
+  // 'Cohere API' only in the 2026-02 entry, which is the 4th → outside the window of 3.
+  eq(detectRecurrence({ summary: ['Cohere API'], keyInsight: [], notable: [] }, priors).length, 0)
+})
+
+test('empty prior history yields no flags', () => {
+  eq(detectRecurrence({ summary: ['Together AI'] }, []).length, 0)
+})
+
+console.log('\nbuildRecurrenceBlock / injectRecurrenceCheck (aiwatch-reports#54)')
+
+test('no flags → empty block (clean omission)', () => {
+  eq(buildRecurrenceBlock([]), '')
+  eq(buildRecurrenceBlock([], { currentMonth: '2026-06' }), '')
+})
+
+test('block carries the delete-before-merge fence + MoM hint', () => {
+  const block = buildRecurrenceBlock(
+    [{ service: 'Together AI', slot: 'summary', monthsSeen: ['2026-04', '2026-05'] }],
+    { currentMonth: '2026-06', priorCount: 2, momByService: { 'Together AI': { prev: 133, curr: 85 } } },
+  )
+  assert.ok(block.startsWith(RECURRENCE_OPEN_MARKER), 'opens with fence marker')
+  assert.ok(block.includes('DELETE this entire block before merge'), 'delete-before-merge instruction present')
+  assert.ok(block.trim().endsWith(RECURRENCE_CLOSE_MARKER), 'closes with fence marker')
+  assert.ok(block.includes('Together AI'), 'names the subject')
+  assert.ok(block.includes('133 → this month 85'), 'MoM delta rendered')
+})
+
+test('injects the block above "## Summary" and is idempotent', () => {
+  const block = buildRecurrenceBlock(
+    [{ service: 'Together AI', slot: 'summary', monthsSeen: ['2026-04', '2026-05'] }],
+    { currentMonth: '2026-06', priorCount: 2 },
+  )
+  const once = injectRecurrenceCheck('intro\n\n## Summary\n\n- bullet', block)
+  assert.ok(once.indexOf(RECURRENCE_OPEN_MARKER) < once.indexOf('## Summary'), 'block sits above Summary')
+  const twice = injectRecurrenceCheck(once, block)
+  eq(twice, once) // idempotent — open marker already present
+  const markerCount = (twice.match(new RegExp(RECURRENCE_OPEN_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length
+  eq(markerCount, 1)
+})
+
+test('empty block is a no-op injection', () => {
+  eq(injectRecurrenceCheck('## Summary\n\n- x', ''), '## Summary\n\n- x')
+})
+
+console.log('\nbuildMomIncidentDeltas + loadPriorNarrative (aiwatch-reports#54)')
+
+test('buildMomIncidentDeltas pairs this-month vs last-month incident counts', () => {
+  const dir = fsT.mkdtempSync(pathT.join(osR.tmpdir(), 'mom-'))
+  try {
+    const togetherId = chartsR.nameToId('Together AI')
+    // prev month for '2026-06' is '2026-05'
+    fsT.writeFileSync(pathT.join(dir, '2026-05.json'), JSON.stringify({
+      archive: { services: { [togetherId]: { incidents: 133 } } },
+    }))
+    const archive = { services: { [togetherId]: { score: 84, grade: 'good', incidents: 85, totalDowntimeMin: 60, avgResolutionMin: 40 } } }
+    const meta = { [togetherId]: { name: 'Together AI' } }
+    const map = buildMomIncidentDeltas(archive, meta, '2026-06', { dataDir: dir })
+    eq(map['Together AI'].curr, 85)
+    eq(map['Together AI'].prev, 133)
+  } finally {
+    fsT.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('buildMomIncidentDeltas returns {} when the prior _data archive is absent (graceful)', () => {
+  const dir = fsT.mkdtempSync(pathT.join(osR.tmpdir(), 'mom-empty-'))
+  try {
+    const archive = { services: { together: { score: 84, incidents: 85 } } }
+    eq(Object.keys(buildMomIncidentDeltas(archive, { together: { name: 'Together AI' } }, '2026-06', { dataDir: dir })).length, 0)
+  } finally {
+    fsT.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('computeCurrentSubjects derives slots from archive data (top-incident → summary)', () => {
+  const dir = fsT.mkdtempSync(pathT.join(osR.tmpdir(), 'cur-'))
+  try {
+    const mid = chartsR.nameToId('Mistral API')
+    const tid = chartsR.nameToId('Together AI')
+    const archive = { services: {
+      [mid]: { score: 78, grade: 'good', incidents: 155, totalDowntimeMin: 60, avgResolutionMin: 19 },
+      [tid]: { score: 84, grade: 'good', incidents: 133, totalDowntimeMin: 90, avgResolutionMin: 43 },
+    } }
+    const meta = { [mid]: { name: 'Mistral API' }, [tid]: { name: 'Together AI' } }
+    const s = computeCurrentSubjects(archive, meta, '2026-06', { dataDir: dir }) // no _data → movers drop
+    eq(s.summary.slice().sort().join('|'), 'Mistral API|Together AI') // top-2 incident counts
+    assert.ok(s.keyInsight.includes('Mistral API'), 'top-incident feeds keyInsight too')
+  } finally {
+    fsT.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('computeCurrentSubjects returns empty slots for an empty archive (no throw)', () => {
+  const s = computeCurrentSubjects({ services: {} }, {}, '2026-06', { dataDir: fsT.mkdtempSync(pathT.join(osR.tmpdir(), 'cur-empty-')) })
+  eq(`${s.summary.length}${s.keyInsight.length}${s.notable.length}`, '000')
+})
+
+test('loadPriorNarrative skips months with no index.md (never throws)', () => {
+  const root = fsT.mkdtempSync(pathT.join(osR.tmpdir(), 'prior-'))
+  try {
+    // Only 2026-05 exists; 2026-03/04 are absent → skipped, not thrown.
+    fsT.mkdirSync(pathT.join(root, '2026-05'))
+    fsT.writeFileSync(pathT.join(root, '2026-05', 'index.md'), sampleReport({
+      highIncident: 'Together AI (133 incidents)', keyInsight: '- x', affected: 'Gemini API',
+    }))
+    const prior = loadPriorNarrative('2026-06', { rootDir: root })
+    eq(prior.length, 1)
+    eq(prior[0].month, '2026-05')
+    eq(prior[0].subjects.summary.join('|'), 'Together AI')
+  } finally {
+    fsT.rmSync(root, { recursive: true, force: true })
+  }
+})
+
 console.log(`\n${passed} passed, ${failed} failed`)
 process.exit(failed > 0 ? 1 : 0)

--- a/scripts/generate-summary.js
+++ b/scripts/generate-summary.js
@@ -107,7 +107,11 @@ function generateOpening(monthYear, a) {
   return `${monthYear} showed a clear divide: ${topStable} remained highly stable, while ${worstSvc?.Service} (${worstSvc?.Score}/100) experienced the most challenges. ${a.withIncidents.length} out of ${a.totalServices} services recorded at least one incident, with a combined downtime of ${fmtDuration(a.totalDowntimeMins)}.`
 }
 
-function generateTldr(a, incidents) {
+// `momByService` (aiwatch-reports#54 bonus) maps a service display name → { curr, prev }
+// incident counts. When present for the "Most incidents" subject, the bullet is
+// MoM-framed ("85 incidents … — 133 last month (−48)") so the default draft leads with
+// the change a human otherwise adds by hand. Default {} → unchanged snapshot wording.
+function generateTldr(a, incidents, momByService = {}) {
   const lines = []
 
   // Most reliable
@@ -130,9 +134,16 @@ function generateTldr(a, incidents) {
     lines.push(`- **Riskiest this month**: ${a.bottom[0].Service} (${a.bottom[0].Score}/100${riskRow ? `, ${riskRow['Total Downtime']} total downtime` : ''})`)
   }
 
-  // Most incidents
+  // Most incidents (MoM-framed when a prior-month count is available — #54 bonus)
   if (a.mostIncidents) {
-    lines.push(`- **Most incidents**: ${a.mostIncidents.Service} (${a.mostIncidents.Incidents} incidents, ${a.mostIncidents['Total Downtime']} downtime)`)
+    const mom = momByService[a.mostIncidents.Service]
+    let momTail = ''
+    if (mom && typeof mom.prev === 'number' && typeof mom.curr === 'number') {
+      const d = mom.curr - mom.prev
+      const delta = d === 0 ? '±0' : `${d > 0 ? '+' : '−'}${Math.abs(d)}`
+      momTail = ` — ${mom.prev} last month (${delta})`
+    }
+    lines.push(`- **Most incidents**: ${a.mostIncidents.Service} (${a.mostIncidents.Incidents} incidents, ${a.mostIncidents['Total Downtime']} downtime${momTail})`)
   }
 
   // Recommendations

--- a/scripts/generate-summary.test.js
+++ b/scripts/generate-summary.test.js
@@ -244,6 +244,19 @@ test('most reliable shows perfect services', () => {
   assert(text.includes('ServiceA (100/100'), 'should show perfect score service')
 })
 
+test('MoM-frames the Most-incidents bullet when a prior count is provided (aiwatch-reports#54)', () => {
+  const a = analyze(MOCK_SCORES, MOCK_INCIDENTS)
+  const curr = parseInt(a.mostIncidents.Incidents, 10)
+  const text = generateTldr(a, MOCK_INCIDENTS, { [a.mostIncidents.Service]: { prev: curr + 40, curr } })
+  assert(text.includes(`${curr + 40} last month`), 'shows prior-month count')
+  assert(text.includes('(−40)'), 'shows signed delta')
+})
+
+test('omits the MoM tail when no prior count is provided (backward-compat)', () => {
+  const a = analyze(MOCK_SCORES, MOCK_INCIDENTS)
+  assert(!generateTldr(a, MOCK_INCIDENTS).includes('last month'), 'no MoM tail by default')
+})
+
 // ── generateStats ─────────────────────────────────────────
 console.log('\ngenerateStats')
 


### PR DESCRIPTION
## What

Injects a **generate-time `RECURRENCE CHECK`** block flagging narrative subjects (services) repeated in the same slot across months, so the same framing can't recur unnoticed — Together AI led the Summary "High incident count" bullet Apr/May/Jun. Same class of gap #415 closed on the aiwatch side: a passive "compare against last month" rule gets only probabilistic compliance.

## How

Two pure, unit-tested cores (no I/O):
- **`extractNarrativeSubjects(indexMd)`** → `{ summary, keyInsight, notable }` — subject services per slot, read from a prior month's published `index.md`. The report's own AIWatch Score table is the lexicon (self-contained): high-incident bullet names are canonicalized to it (`"Mistral"` ↔ `"Mistral API"` fold across months), Key Insight scoped to bold-lead bullets (not prose), Notable from `**Affected**` lines.
- **`detectRecurrence(currentSubjectsBySlot, priorMonths)`** → flags a subject that filled the **same slot** in ≥2 of the last 3 months.

I/O wrappers read the prior months + inject the block above `## Summary` behind the **same delete-before-merge fence as AUTO-DRAFT** (so #55's lint + the no-fence-in-output check catch a leak). Best-effort throughout — a missing/corrupt prior month or `_data` archive is skipped, never thrown (same contract as the charts prior-month read).

**Bonus (#54):** month-over-month incident-count deltas — the auto-draft "Most incidents" bullet is change-framed by default (`155 incidents … — 97 last month (+58)`), and the recurrence block carries the same `133 → 85` hint.

## Acceptance (#54)
- [x] Pure, unit-tested `detectRecurrence` + `extractNarrativeSubjects` (no I/O) in `generate-report.js` / `generate-report.test.js`.
- [x] Generator injects the block when ≥1 recurrence is flagged; omits it cleanly when none; missing/corrupt prior month degrades gracefully (never throws).
- [x] Block uses the AUTO-DRAFT delete-before-merge fence.
- [x] (Bonus) auto-draft bullets carry MoM deltas for repeated subjects.

## Verification
- All suites green: `generate-report` **170/0**, `generate-summary` **34/0**, `generate-charts` 54/0, `update-index` 18/0 (+21 new tests).
- Real Apr/May reports → a June run flags **both** Together AI and Mistral API in the summary slot (was only Together AI before lexicon canonicalization), each with its MoM delta. 2026-04 `keyInsight` extracts correctly (bold-lead bullet scoping, not the literal word "Pattern").
- Reviewed via `pr-review-toolkit:code-reviewer` — 1 Important (name-variant false-negative) + 3 suggestions, all fixed; re-review 0 Critical/Important.

## Companions (reuse these cores)
- #55 — pre-publish CI recurrence lint (publish-time backstop).
- bentleypark/aiwatch#881 — `write-monthly-report` skill (authoring runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)