### PR TITLE
feat(ci): pre-publish recurrence lint (closes #55)

### DIFF
--- a/.github/workflows/lint-recurrence.yml
+++ b/.github/workflows/lint-recurrence.yml
@@ -1,0 +1,50 @@
+name: Recurrence Lint
+
+# Pre-publish backstop (aiwatch-reports#55) for narrative recurrence, the second layer
+# behind the generate-time RECURRENCE CHECK block (#54). Runs on any PR that touches a
+# report's index.md and lints ONLY the changed report(s):
+#   • FAIL — a leaked AUTO-DRAFT / RECURRENCE CHECK fence in a `published: true` report.
+#   • WARN — a service named in the same narrative slot as the immediately prior month.
+# A `published: false` draft is exempt (the fences are expected there).
+
+on:
+  pull_request:
+    paths:
+      - '[0-9][0-9][0-9][0-9]-[0-9][0-9]/index.md'
+
+# Read-only: `::error`/`::warning` workflow commands need no elevated token.
+permissions:
+  contents: read
+
+concurrency:
+  group: recurrence-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: pre-publish recurrence lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so we can diff against the PR base to find the changed reports.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Determine changed report index.md files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # --diff-filter=ACMR: added/copied/modified/renamed-to only — exclude a DELETED
+          # or renamed-away report path (it's gone from HEAD, so linting it would ENOENT-fail CI).
+          files=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA"...HEAD -- '[0-9][0-9][0-9][0-9]-[0-9][0-9]/index.md' | tr '\n' ' ')
+          echo "Changed reports: ${files:-<none>}"
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+
+      - name: Recurrence lint
+        if: steps.changed.outputs.files != ''
+        run: node scripts/lint-recurrence.js ${{ steps.changed.outputs.files }}

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ After generation, fill in the narrative sections (`Summary`, `Recommendations`, 
 
 **Narrative recurrence check** (aiwatch-reports#54): when a likely narrative subject (a top-incident service, the slowest-recovery service, or a Notable Mover) also filled the **same slot** — the Summary "High incident count" bullet, a Key Insight pattern, or Notable Incidents — in ≥2 of the last 3 published months, the generator injects a `RECURRENCE CHECK` block above `## Summary` (e.g. *"Together AI led the Summary 'High incident count' bullet in 2 of the last 2 published months … (last month 133 → this month 85)"*). It has no memory of prior months otherwise, so the same framing recurred unnoticed (Together AI three months running). **Reframe around the month-over-month change, then delete the block** — it uses the same delete-before-merge fence as AUTO-DRAFT, and a leaked fence hard-fails the pre-publish lint. The auto-drafted "Most incidents" bullet is also MoM-framed by default (`155 incidents … — 97 last month (+58)`).
 
+**Pre-publish recurrence lint** (aiwatch-reports#55): the publish-time enforcement of the same signal. `.github/workflows/lint-recurrence.yml` runs `scripts/lint-recurrence.js` on any PR that changes a `NNNN-NN/index.md`, reusing #54's `extractNarrativeSubjects`/`detectRecurrence` (single source of truth). On a `published: true` report it **fails** if any AUTO-DRAFT / RECURRENCE CHECK fence survived (draft scaffolding must never publish) and **warns** (PR annotation) when a service fills the same narrative slot as the immediately prior month — so a genuine recurrence can proceed after the author acknowledges it, but never *silently*. A `published: false` draft is exempt.
+
 ---
 
 ## About AIWatch

--- a/scripts/lint-recurrence.js
+++ b/scripts/lint-recurrence.js
@@ -1,0 +1,167 @@
+// lint-recurrence.js — pre-publish CI backstop for narrative recurrence (aiwatch-reports#55).
+//
+// Second layer behind the generate-time RECURRENCE CHECK block (#54): that block is
+// advisory and DELETED before merge, so nothing stops a `published: true` report from
+// still naming the same service in the same narrative slot as the prior month, or from
+// leaking a draft fence. This lint enforces at the point of no return (the publish PR):
+//
+//   • FAIL  — any AUTO-DRAFT / RECURRENCE CHECK fence survived into a `published: true`
+//             report (unambiguous defect: draft scaffolding must never publish).
+//   • WARN  — a service named in the same slot as the immediately prior month (a genuine
+//             recurring pattern is sometimes legitimately the story, so it warns rather
+//             than fails — but it can never pass SILENTLY).
+//
+// Extraction is the SINGLE SOURCE OF TRUTH from #54 — `extractNarrativeSubjects` /
+// `detectRecurrence` are imported, never re-implemented. Pure decision logic
+// (`parseFrontmatter`, `findLeakedFences`, `lintReport`) is unit-tested in
+// lint-recurrence.test.js; only the file I/O + annotation printing lives in the CLI.
+
+const fs = require('fs')
+const path = require('path')
+const {
+  extractNarrativeSubjects,
+  detectRecurrence,
+  SUMMARY_OPEN_MARKER,
+  NOTABLE_OPEN_MARKER,
+  OBSERVATIONS_OPEN_MARKER,
+  RECURRENCE_OPEN_MARKER,
+} = require('./generate-report')
+const { monthsBefore } = require('./generate-charts')
+
+// Human labels per slot for the warn annotation (mirrors #54's block wording).
+const SLOT_LABEL = {
+  summary: "the Summary 'High incident count' bullet",
+  keyInsight: 'a Key Insight pattern',
+  notable: 'Notable Incidents',
+}
+
+// The exact fence markers we ship (kept for reference/coupling); the detector below is a
+// keyword check so a hand-edited/close marker or a future fence variant is still caught.
+const KNOWN_FENCE_MARKERS = [SUMMARY_OPEN_MARKER, NOTABLE_OPEN_MARKER, OBSERVATIONS_OPEN_MARKER, RECURRENCE_OPEN_MARKER]
+// Match each HTML comment INDIVIDUALLY (lazy to the first `-->`) — a keyword regex spanning
+// `[^]*?` across comments would swallow a benign comment up to a downstream fence and
+// mis-locate it. We then keyword-check the comment's own body.
+const COMMENT_RE = /<!--([\s\S]*?)-->/g
+const FENCE_KEYWORD_RE = /\b(?:AUTO-DRAFT|RECURRENCE CHECK)\b/i
+
+// PURE. Read the leading `---` YAML frontmatter into a shallow key→string map. Only the
+// scalar fields we need (`published`) matter; missing frontmatter → {}.
+function parseFrontmatter(md) {
+  const m = String(md).match(/^﻿?---\r?\n([\s\S]*?)\r?\n---/)
+  if (!m) return {}
+  const out = {}
+  for (const line of m[1].split(/\r?\n/)) {
+    const kv = line.match(/^\s*([A-Za-z0-9_-]+):\s*(.*)$/)
+    if (!kv) continue
+    let v = kv[2].trim()
+    // YAML: an UNQUOTED value ends at an inline ` # comment`; a quoted value keeps its content.
+    if (!/^['"]/.test(v)) v = v.replace(/\s+#.*$/, '').trim()
+    v = v.replace(/^(['"])(.*)\1$/, '$2') // strip surrounding quotes
+    out[kv[1]] = v
+  }
+  return out
+}
+
+// PURE. Is this report marked `published: true`? Case-insensitive so a `published: True`
+// (still truthy to Jekyll) can't silently slip the lint.
+function isPublished(md) {
+  return String(parseFrontmatter(md).published).toLowerCase() === 'true'
+}
+
+// PURE. Every AUTO-DRAFT / RECURRENCE CHECK fence (BEGIN or END) present in the document,
+// with a 1-based line number for the annotation. Empty when clean.
+function findLeakedFences(md) {
+  const text = String(md)
+  const out = []
+  for (const m of text.matchAll(COMMENT_RE)) {
+    if (!FENCE_KEYWORD_RE.test(m[1])) continue // benign comment (e.g. "Generate with: …")
+    const line = text.slice(0, m.index).split('\n').length
+    out.push({ line, snippet: m[0].split('\n')[0].slice(0, 120) })
+  }
+  return out
+}
+
+// PURE. Decide the lint result for one report against its prior month. Reuses #54's
+// extraction verbatim. A `published: false` draft is exempt (fences are expected there).
+//   { md, priorMd?, month?, priorMonth? } → { published, errors:[{line,message}], warnings:[{message}] }
+function lintReport({ md, priorMd = null, month = '', priorMonth = '' }) {
+  const published = isPublished(md)
+  const errors = []
+  const warnings = []
+  if (!published) return { published, errors, warnings } // draft — nothing to enforce
+
+  for (const f of findLeakedFences(md)) {
+    errors.push({ line: f.line, message: `Draft scaffolding leaked into a published report — remove this fence before publishing: ${f.snippet}` })
+  }
+
+  if (priorMd) {
+    const current = extractNarrativeSubjects(md)
+    const prior = [{ month: priorMonth, subjects: extractNarrativeSubjects(priorMd) }]
+    // window/min = 1: warn when a subject fills the same slot in the ONE immediately prior month.
+    for (const f of detectRecurrence(current, prior, { window: 1, min: 1 })) {
+      const label = SLOT_LABEL[f.slot] || f.slot
+      warnings.push({ message: `"${f.service}" led ${label} in ${priorMonth || 'the prior month'} too — reframe around the month-over-month change or confirm the repeat is intentional.` })
+    }
+  }
+
+  return { published, errors, warnings }
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────
+// Usage: node scripts/lint-recurrence.js <report/index.md> [<report/index.md> …]
+// Emits GitHub Actions annotations; exits non-zero iff any report has a fence error.
+
+// Resolve the prior month's report path relative to a `NNNN-NN/index.md` report path.
+function priorReportPath(reportPath) {
+  const month = path.basename(path.dirname(reportPath)) // "2026-06"
+  if (!/^\d{4}-\d{2}$/.test(month)) return { month: '', priorMonth: '', priorPath: null }
+  const priorMonth = monthsBefore(month, 1)[0]
+  const priorPath = path.join(path.dirname(reportPath), '..', priorMonth, 'index.md')
+  return { month, priorMonth, priorPath }
+}
+
+function lintFile(reportPath) {
+  let md
+  try {
+    md = fs.readFileSync(reportPath, 'utf-8')
+  } catch (err) {
+    console.log(`::error file=${reportPath}::Could not read report (${err instanceof Error ? err.message : err})`)
+    return 1
+  }
+  const { month, priorMonth, priorPath } = priorReportPath(reportPath)
+  let priorMd = null
+  if (priorPath) {
+    try { priorMd = fs.readFileSync(priorPath, 'utf-8') } catch { priorMd = null /* prior month absent → skip warn */ }
+  }
+
+  const { published, errors, warnings } = lintReport({ md, priorMd, month, priorMonth })
+  if (!published) {
+    console.log(`[lint-recurrence] ${reportPath}: draft (published: false) — skipped.`)
+    return 0
+  }
+  for (const e of errors) console.log(`::error file=${reportPath},line=${e.line}::${e.message}`)
+  for (const w of warnings) console.log(`::warning file=${reportPath}::${w.message}`)
+  const verdict = errors.length ? `FAIL (${errors.length} leaked fence${errors.length === 1 ? '' : 's'})` : warnings.length ? `pass with ${warnings.length} warning${warnings.length === 1 ? '' : 's'}` : 'clean'
+  console.log(`[lint-recurrence] ${reportPath}: ${verdict}.`)
+  return errors.length ? 1 : 0
+}
+
+if (require.main === module) {
+  const files = process.argv.slice(2).filter(Boolean)
+  if (files.length === 0) {
+    console.log('[lint-recurrence] No report files passed — nothing to lint.')
+    process.exit(0)
+  }
+  let worst = 0
+  for (const f of files) worst = Math.max(worst, lintFile(f))
+  process.exit(worst)
+}
+
+module.exports = {
+  parseFrontmatter,
+  isPublished,
+  findLeakedFences,
+  lintReport,
+  priorReportPath,
+  KNOWN_FENCE_MARKERS,
+}

--- a/scripts/lint-recurrence.test.js
+++ b/scripts/lint-recurrence.test.js
@@ -1,0 +1,246 @@
+// Tests for lint-recurrence.js (aiwatch-reports#55). Pure Node + assert, no deps —
+// run: node scripts/lint-recurrence.test.js
+const assert = require('assert')
+const {
+  parseFrontmatter,
+  isPublished,
+  findLeakedFences,
+  lintReport,
+  priorReportPath,
+} = require('./lint-recurrence')
+const { RECURRENCE_OPEN_MARKER, SUMMARY_OPEN_MARKER } = require('./generate-report')
+
+let passed = 0
+let failed = 0
+function test(name, fn) {
+  try { fn(); passed++; console.log(`  ✓ ${name}`) }
+  catch (err) { failed++; console.log(`  ✗ ${name}`); console.log(`    ${err.message}`) }
+}
+function eq(actual, expected, msg) {
+  assert.strictEqual(actual, expected, msg || `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+}
+
+// A minimal report fixture: frontmatter + Score table (the self-contained lexicon that
+// #54's extractor reads) + the three narrative slots.
+function report({ published = true, highIncident = 'Together AI (85 incidents)', keyInsight = '- x', affected = 'Gemini API', extra = '' } = {}) {
+  return [
+    '---',
+    'layout: page',
+    'title: "Test Report"',
+    `published: ${published}`,
+    '---',
+    '',
+    '## Summary',
+    '',
+    `- **High incident count, fast recovery**: ${highIncident}`,
+    extra,
+    '',
+    '## Key Insight',
+    '',
+    keyInsight,
+    '',
+    '## AIWatch Score — Test Rankings',
+    '',
+    '| Rank | Service | Score | Grade |',
+    '|------|---------|-------|-------|',
+    '| 1 | Together AI | 84 | Good |',
+    '| 2 | Mistral API | 78 | Good |',
+    '| 3 | Gemini API | 64 | Fair |',
+    '',
+    '## Notable Incidents',
+    '',
+    '### 1. Thing',
+    `**Affected**: ${affected}`,
+    '',
+    '## Observations',
+    '',
+    '- ok',
+  ].join('\n')
+}
+
+console.log('\nparseFrontmatter / isPublished')
+
+test('parses published: true', () => {
+  eq(parseFrontmatter(report({ published: true })).published, 'true')
+  eq(isPublished(report({ published: true })), true)
+})
+
+test('parses published: false', () => {
+  eq(isPublished(report({ published: false })), false)
+})
+
+test('missing frontmatter → {} → not published', () => {
+  eq(Object.keys(parseFrontmatter('## No frontmatter')).length, 0)
+  eq(isPublished('## No frontmatter'), false)
+})
+
+test('handles a BOM-prefixed frontmatter', () => {
+  eq(isPublished('﻿---\npublished: true\n---\n# body'), true)
+})
+
+test('handles CRLF line endings', () => {
+  eq(isPublished('---\r\npublished: true\r\n---\r\nbody'), true)
+})
+
+test('normalizes an inline #-comment on the value', () => {
+  eq(isPublished('---\npublished: true # ready to ship\n---'), true)
+})
+
+test('normalizes a quoted value and mixed case', () => {
+  eq(isPublished('---\npublished: "true"\n---'), true)
+  eq(isPublished('---\npublished: True\n---'), true)
+})
+
+console.log('\nfindLeakedFences')
+
+test('detects an AUTO-DRAFT fence', () => {
+  const fences = findLeakedFences(`intro\n${SUMMARY_OPEN_MARKER}\nbody`)
+  eq(fences.length, 1)
+  eq(fences[0].line, 2)
+})
+
+test('detects a RECURRENCE CHECK fence', () => {
+  eq(findLeakedFences(`a\nb\n${RECURRENCE_OPEN_MARKER}`).length, 1)
+})
+
+test('detects both BEGIN and END markers', () => {
+  const md = `${SUMMARY_OPEN_MARKER}\ndraft\n<!-- END AUTO-DRAFT -->`
+  eq(findLeakedFences(md).length, 2)
+})
+
+test('clean document → no fences', () => {
+  eq(findLeakedFences(report()).length, 0)
+})
+
+test('a benign comment before a real fence is NOT mis-flagged (no cross-comment span)', () => {
+  // Regression: a keyword regex using [^]*? across comments swallowed the benign
+  // "Generate with:" comment up to the downstream fence and mis-located it.
+  const md = [
+    'line1',
+    '<!-- Generate with: node scripts/generate-charts.js 2026-05/index.md -->',
+    'line3',
+    RECURRENCE_OPEN_MARKER,
+  ].join('\n')
+  const fences = findLeakedFences(md)
+  eq(fences.length, 1)
+  eq(fences[0].line, 4) // the real fence, at its own line — not line 2
+})
+
+console.log('\nlintReport')
+
+test('a draft (published: false) is exempt — fences do NOT fail', () => {
+  const md = report({ published: false, extra: SUMMARY_OPEN_MARKER })
+  const r = lintReport({ md })
+  eq(r.published, false)
+  eq(r.errors.length, 0)
+})
+
+test('a published report with a leaked AUTO-DRAFT fence FAILS', () => {
+  const md = report({ published: true, extra: SUMMARY_OPEN_MARKER })
+  const r = lintReport({ md })
+  eq(r.errors.length, 1)
+  assert.ok(r.errors[0].message.includes('Draft scaffolding leaked'), 'error message names the defect')
+})
+
+test('a published report with a leaked RECURRENCE CHECK fence FAILS', () => {
+  const md = report({ published: true, extra: RECURRENCE_OPEN_MARKER })
+  eq(lintReport({ md }).errors.length, 1)
+})
+
+test('a clean published report with no prior month → no errors, no warnings', () => {
+  const r = lintReport({ md: report() })
+  eq(r.errors.length, 0)
+  eq(r.warnings.length, 0)
+})
+
+test('WARNS on a same-slot recurrence vs the prior month (reuses #54 extraction)', () => {
+  // Overlap ONLY the summary slot (Together AI); differ in notable so exactly one warning.
+  const md = report({ highIncident: 'Together AI (85 incidents)', affected: 'Gemini API' })
+  const priorMd = report({ highIncident: 'Together AI (133 incidents)', affected: 'Mistral API' })
+  const r = lintReport({ md, priorMd, month: '2026-06', priorMonth: '2026-05' })
+  eq(r.errors.length, 0)
+  eq(r.warnings.length, 1)
+  assert.ok(r.warnings[0].message.includes('Together AI'), 'names the repeated service')
+  assert.ok(r.warnings[0].message.includes('2026-05'), 'names the prior month')
+})
+
+test('does NOT warn when every slot names a different service than the prior month', () => {
+  const md = report({ highIncident: 'Together AI (85 incidents)', affected: 'Gemini API' })
+  const priorMd = report({ highIncident: 'Mistral API (140 incidents)', affected: 'Mistral API' })
+  eq(lintReport({ md, priorMd, month: '2026-06', priorMonth: '2026-05' }).warnings.length, 0)
+})
+
+test('fence FAIL and recurrence WARN co-exist on one published report', () => {
+  const md = report({ highIncident: 'Together AI (85 incidents)', affected: 'Gemini API', extra: RECURRENCE_OPEN_MARKER })
+  const priorMd = report({ highIncident: 'Together AI (133 incidents)', affected: 'Mistral API' })
+  const r = lintReport({ md, priorMd, month: '2026-06', priorMonth: '2026-05' })
+  eq(r.errors.length, 1)
+  eq(r.warnings.length, 1)
+})
+
+console.log('\npriorReportPath')
+
+test('resolves the prior month report path from a NNNN-NN/index.md path', () => {
+  const { month, priorMonth, priorPath } = priorReportPath('2026-06/index.md')
+  eq(month, '2026-06')
+  eq(priorMonth, '2026-05')
+  assert.ok(priorPath.endsWith('2026-05/index.md'), `prior path resolves to 2026-05, got ${priorPath}`)
+})
+
+test('a non-report path yields no month (graceful)', () => {
+  const { month, priorPath } = priorReportPath('scripts/thing.js')
+  eq(month, '')
+  eq(priorPath, null)
+})
+
+console.log('\nCLI (exit-code contract)')
+
+const cp = require('child_process')
+const fsC = require('fs')
+const osC = require('os')
+const pathC = require('path')
+const CLI = pathC.join(__dirname, 'lint-recurrence.js')
+
+// Run the CLI as a subprocess; returns { code, out }.
+function runCli(args) {
+  const r = cp.spawnSync('node', [CLI, ...args], { encoding: 'utf-8' })
+  return { code: r.status, out: (r.stdout || '') + (r.stderr || '') }
+}
+
+test('no args → exit 0 (nothing to lint)', () => {
+  eq(runCli([]).code, 0)
+})
+
+test('a published report with a leaked fence → exit 1 with ::error', () => {
+  const dir = fsC.mkdtempSync(pathC.join(osC.tmpdir(), 'cli-'))
+  try {
+    const p = pathC.join(dir, '2099-03', 'index.md')
+    fsC.mkdirSync(pathC.dirname(p), { recursive: true })
+    fsC.writeFileSync(p, report({ published: true, extra: RECURRENCE_OPEN_MARKER }))
+    const r = runCli([p])
+    eq(r.code, 1)
+    assert.ok(r.out.includes('::error'), 'emits an error annotation')
+  } finally { fsC.rmSync(dir, { recursive: true, force: true }) }
+})
+
+test('multi-file: one clean + one leaked → exit 1 (worst-of aggregation)', () => {
+  const dir = fsC.mkdtempSync(pathC.join(osC.tmpdir(), 'cli-multi-'))
+  try {
+    const clean = pathC.join(dir, '2099-04', 'index.md')
+    const bad = pathC.join(dir, '2099-05', 'index.md')
+    fsC.mkdirSync(pathC.dirname(clean), { recursive: true })
+    fsC.mkdirSync(pathC.dirname(bad), { recursive: true })
+    fsC.writeFileSync(clean, report({ published: true }))
+    fsC.writeFileSync(bad, report({ published: true, extra: SUMMARY_OPEN_MARKER }))
+    eq(runCli([clean, bad]).code, 1)
+  } finally { fsC.rmSync(dir, { recursive: true, force: true }) }
+})
+
+test('an unreadable file → exit 1 (surfaced, not silently skipped)', () => {
+  const r = runCli([pathC.join(osC.tmpdir(), 'does-not-exist-2099-01', 'index.md')])
+  eq(r.code, 1)
+  assert.ok(r.out.includes('::error'), 'read failure is an annotation')
+})
+
+console.log(`\n${passed} passed, ${failed} failed`)
+process.exit(failed > 0 ? 1 : 0)


### PR DESCRIPTION
## What

Publish-time backstop behind the merged generate-time RECURRENCE CHECK block (#54). That block is advisory and deleted before merge, so nothing stops a `published: true` report from still naming the same service in the same narrative slot as the prior month, or from leaking a draft fence. This **enforces at the point of no return** (the publish PR), mirroring the aiwatch #415 hard-gate philosophy.

## How

`scripts/lint-recurrence.js` **reuses** `extractNarrativeSubjects` / `detectRecurrence` imported from `generate-report.js` (single source of truth — not re-implemented):
- **FAIL** (exit 1, `::error`) on any surviving AUTO-DRAFT / RECURRENCE CHECK fence in a `published: true` report — draft scaffolding must never publish.
- **WARN** (`::warning`, never fails) when a service fills the same narrative slot as the immediately prior month — a genuine recurrence can proceed after the author acknowledges it, but never *silently*.
- A `published: false` draft is **exempt**.

`.github/workflows/lint-recurrence.yml` runs it on any PR touching a `NNNN-NN/index.md`, scoping to the changed report(s) via `git diff --diff-filter=ACMR` (excludes deletions/renames → no ENOENT false-fail).

## Acceptance (#55)
- [x] CI workflow runs the lint on report `index.md` changes.
- [x] Reuses `extractNarrativeSubjects`/`detectRecurrence` from #54 (imported, not duplicated).
- [x] Hard-fails on any surviving AUTO-DRAFT / RECURRENCE fence in a `published: true` report.
- [x] Emits a PR annotation listing same-slot recurrences vs the prior month (warn).

## Verification
- **25** lint tests (pure decision logic + `spawnSync` CLI exit-code contract); full suite green (301 total).
- Real reports: 2026-05 → pass with same-slot warnings (Together AI / Mistral API summary recurrence vs April); a leaked-fence published report → **exit 1** with fences reported at their real lines; a draft with a fence → exempt (exit 0).
- Reviewed via `pr-review-toolkit:code-reviewer` — 0 Critical, 1 Important (deleted-report false-fail) + 2 suggestions, all fixed; re-review confirmed 0 remaining. The real-artifact run caught + fixed a cross-comment fence-regex bug before commit.

## Companions
- #54 — generate-time RECURRENCE CHECK block (merged). This is the publish-time enforcement.
- bentleypark/aiwatch#881 — `write-monthly-report` skill (runbook referencing both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)