### PR TITLE
fix(ci): generate-report.yml no longer aborts re-running an existing month (closes #59)

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -82,14 +82,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Reset local state to remote branch when it exists, so re-runs for the same
-          # month start from a clean baseline instead of failing the push as non-fast-forward.
-          if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
-            git fetch origin "$BRANCH:$BRANCH"
-            git checkout "$BRANCH"
-          else
-            git checkout -b "$BRANCH"
-          fi
+          # The report files were generated onto the default (main) checkout ABOVE. Create/RESET
+          # the branch at that generated HEAD with `git checkout -B` — a plain `git checkout <branch>`
+          # aborts on an existing month because the untracked generated files (2026-06/index.md,
+          # assets/, _data/*.json) would be overwritten by the switch (#59). `-B` moves the branch
+          # pointer without touching the working tree, so the generated files survive and are committed.
+          # We still fetch the remote branch first — with an EXPLICIT refspec so the remote-tracking
+          # ref the force-with-lease below reads is always fresh (a bare `git fetch origin $BRANCH`
+          # only updates it opportunistically, so a re-run could otherwise be rejected as "stale info").
+          # First run (branch absent): fetch errors → `|| true` → force-with-lease creates the branch.
+          git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" 2>/dev/null || true
+          git checkout -B "$BRANCH"
 
           # _data/${MONTH}.json (snapshot) and index.md (Reports list entry) are added
           # alongside the report file + assets so the draft PR is self-contained — #15.


### PR DESCRIPTION
## Problem

The "Create branch + draft PR" step runs AFTER the report files are generated onto the default `main` checkout. On a **re-run for an existing month**, `git checkout report/${MONTH}` aborted because the untracked generated files (`{MONTH}/index.md`, `assets/{MONTH}/*`, `_data/{MONTH}.json`) + the modified top-level `index.md` would be overwritten by the switch:

```
error: The following untracked working tree files would be overwritten by checkout:
	2026-06/index.md ...
Aborting
```

First-time generation worked (`git checkout -b`), but **every re-run of an existing month failed** (hit 2026-07-06 regenerating June after an archive rebuild, run 28765833892). The abort is *before* the force-push → nothing clobbered, just a no-op red-X.

## Fix

Replace the `if remote-exists then fetch+checkout else checkout -b` block with a create-or-reset that keeps the working tree:

```bash
git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" 2>/dev/null || true
git checkout -B "$BRANCH"
```

- `git checkout -B` moves the branch pointer to the generated HEAD **without touching the working tree** → the untracked generated files survive and get committed. Handles both first-run and re-run in one path.
- The **explicit-refspec fetch** keeps `refs/remotes/origin/$BRANCH` fresh so the subsequent `git push --force-with-lease` isn't rejected as *"stale info"* on a re-run (a bare `git fetch origin $BRANCH` only updates that ref opportunistically, depending on checkout's refspec — flagged in review). First run: fetch errors → `|| true` → force-with-lease creates the branch.

**Behavioral note (intentional):** the branch is now one fresh commit off `main` (bot-owned, wholesale-regenerated) rather than stacked on the prior draft — cleaner for an auto-generated draft. The `git diff --cached --quiet` no-op guard now compares vs `main` (cosmetic; the "vs previous draft" wording is slightly stale but harmless). The reuse-existing-PR logic is unchanged.

## Acceptance (#59)
- [x] checkout logic fixed (first-run + existing-month re-run in one path)
- [ ] **verify**: re-run the Action for 2026-06 → succeeds, updates the open draft PR (#51)

Reviewed via `pr-review-toolkit:code-reviewer` — 0 Critical; 1 Important (force-with-lease baseline) applied; 1 cosmetic suggestion noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)