### PR TITLE
fix(charts): scope uptime-heatmap roster to the report month (#63)

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -52,18 +52,22 @@ jobs:
           MONTH: ${{ steps.month.outputs.month }}
         run: node scripts/generate-report.js "$MONTH"
 
-      - name: Generate charts
-        env:
-          MONTH: ${{ steps.month.outputs.month }}
-        run: node scripts/generate-charts.js "${MONTH}/index.md"
-
       - name: Snapshot archive JSON to _data/ (#15)
         # Persists /api/report?month=YYYY-MM as _data/{MONTH}.json for long-term
         # git preservation alongside the KV archive — see _data/README.md for
         # provenance + rebuild caveats.
+        # MUST run BEFORE "Generate charts" (#63): the uptime-heatmap roster is filtered
+        # to this snapshot's service keys (existedInMonth) so services added AFTER the
+        # report month don't render as blank rows. If the snapshot isn't present yet the
+        # filter fails open to the full live roster and the post-month services leak back in.
         env:
           MONTH: ${{ steps.month.outputs.month }}
         run: bash scripts/fetch-archive.sh "$MONTH"
+
+      - name: Generate charts
+        env:
+          MONTH: ${{ steps.month.outputs.month }}
+        run: node scripts/generate-charts.js "${MONTH}/index.md"
 
       - name: Update top-level index.md (#15)
         # Inserts/refreshes the entry for $MONTH in the front-page Reports list

--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -272,6 +272,20 @@ function readDataArchive(month, dataDir) {
   }
 }
 
+// PURE. Filter the full category-ordered id list down to the roster that EXISTED in the
+// report month — the ids present in that month's `_data/{month}.json` archive (the #909
+// `existedInMonth` set). Drops services added AFTER the month (which would otherwise
+// render as blank "Added Later" heatmap rows, aiwatch-reports#63), while KEEPING
+// score-excluded-but-existed services (bedrock/azureopenai/characterai + the mid-month-
+// added ones) — they still have that month's uptime. Criterion is archive membership,
+// NOT "has a score". Fail-open: a null/empty roster (missing or corrupt snapshot) returns
+// the full list unchanged, so the chart never breaks on a bad snapshot.
+function rosterForMonth(categoryOrder, archiveServiceIds) {
+  if (!archiveServiceIds || archiveServiceIds.length === 0) return categoryOrder
+  const roster = new Set(archiveServiceIds)
+  return categoryOrder.filter(id => roster.has(id))
+}
+
 // Normalize an archive-like object into a trend month-entry. `daysCollected`
 // (when present) drives the partial-month flag; absent → assumed full.
 function toMonthEntry(month, archiveLike) {
@@ -580,7 +594,7 @@ ${partialNote}
 module.exports = {
   generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade,
   // trend (aiwatch-reports#41)
-  monthsBefore, daysInMonthOf, readDataArchive, toMonthEntry, monthEntryFromScoreRows,
+  monthsBefore, daysInMonthOf, readDataArchive, rosterForMonth, toMonthEntry, monthEntryFromScoreRows,
   buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta, loadTrendEntries,
   generateTrendSvg, nameToId, ID_TO_NAME, TREND_MONTHS,
 }
@@ -685,8 +699,17 @@ if (require.main === module) {
         if (history[key]) { lastDataDay = d; break }
       }
 
-      // Use all 43 services in category order (not just incident table)
-      const serviceNames = CATEGORY_ORDER.map(id => ID_TO_NAME[id]).filter(Boolean)
+      // Roster = services that EXISTED in the report month (that month's archive keys),
+      // not the current live CATEGORY_ORDER — otherwise services added AFTER the month
+      // (e.g. turbopuffer / Twelve Labs for a June report) render as blank "Added Later"
+      // rows (aiwatch-reports#63). Score-excluded-but-existed services stay (the criterion
+      // is archive membership, not "has a score"). Fail-open to the full list if absent.
+      const monthArchive = readDataArchive(monthKey, path.resolve('_data'))
+      const rosterIds = rosterForMonth(
+        CATEGORY_ORDER,
+        monthArchive && monthArchive.services ? Object.keys(monthArchive.services) : null,
+      )
+      const serviceNames = rosterIds.map(id => ID_TO_NAME[id]).filter(Boolean)
 
       const heatmapSvg = generateUptimeHeatmapSvg(serviceNames, history, daysInMonth, monthKey, monitoringStartDay, lastDataDay)
       const heatmapPath = path.join(outDir, 'uptime-heatmap.svg')

--- a/scripts/generate-charts.test.js
+++ b/scripts/generate-charts.test.js
@@ -1,7 +1,7 @@
 const {
   generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade,
   monthsBefore, buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta,
-  generateTrendSvg, toMonthEntry, monthEntryFromScoreRows,
+  generateTrendSvg, toMonthEntry, monthEntryFromScoreRows, rosterForMonth,
 } = require('./generate-charts')
 const assert = require('assert')
 
@@ -458,6 +458,35 @@ test('monthEntryFromScoreRows maps a parsed Score table to a current-month entry
 test('monthEntryFromScoreRows tolerates N/A scores', () => {
   const e = monthEntryFromScoreRows('2026-05', [{ Service: 'Voyage AI', Score: 'N/A', Grade: '' }])
   eq(e.services.voyageai.score, null)
+})
+
+// ── rosterForMonth (heatmap month-roster filter, aiwatch-reports#63) ──
+const CAT = ['claude', 'openai', 'bedrock', 'characterai', 'langfuse', 'turbopuffer', 'twelvelabs']
+
+test('rosterForMonth drops ids absent from the month archive (added after the month)', () => {
+  // archive = existed-in-month set (excludes July-added turbopuffer/twelvelabs)
+  const out = rosterForMonth(CAT, ['claude', 'openai', 'bedrock', 'characterai', 'langfuse'])
+  assert.deepStrictEqual(out, ['claude', 'openai', 'bedrock', 'characterai', 'langfuse'])
+  assert.ok(!out.includes('turbopuffer') && !out.includes('twelvelabs'))
+})
+
+test('rosterForMonth KEEPS score-excluded-but-existed services (bedrock/azure/characterai + mid-month)', () => {
+  // bedrock/characterai are score-withheld; langfuse is mid-month-added — all existed, all kept
+  const out = rosterForMonth(CAT, ['claude', 'bedrock', 'characterai', 'langfuse'])
+  assert.ok(out.includes('bedrock') && out.includes('characterai') && out.includes('langfuse'))
+})
+
+test('rosterForMonth preserves category order', () => {
+  const out = rosterForMonth(['a', 'b', 'c', 'd'], ['d', 'b', 'a'])
+  assert.deepStrictEqual(out, ['a', 'b', 'd']) // input order, filtered — not roster order
+})
+
+test('rosterForMonth fail-opens on null roster (missing/corrupt snapshot)', () => {
+  assert.deepStrictEqual(rosterForMonth(CAT, null), CAT)
+})
+
+test('rosterForMonth fail-opens on empty roster', () => {
+  assert.deepStrictEqual(rosterForMonth(CAT, []), CAT)
 })
 
 // ── Summary ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem
The monthly uptime heatmap (`assets/{YYYY-MM}/uptime-heatmap.svg`) rendered a row for **every service in the current live roster**, so services added **after** the report month appeared as blank "Added Later" rows. The June 2026 heatmap showed **turbopuffer** and **Twelve Labs** (both added in July) as empty rows — even though the header count (41), the `_data/2026-06.json` archive (41), and the Score section (30 of 38) are all correct. Only the chart was wrong; it affects **every historical month**.

## Root cause
`generate-charts.js` built the heatmap roster from the hardcoded `CATEGORY_ORDER` (current full roster), not the report month's archive. #909 fixed the archive + ranking (`existedInMonth`) but not this chart path.

## Fix
- **`generate-charts.js`** — pure `rosterForMonth(categoryOrder, archiveServiceIds)` filters the roster to the month's `_data/{month}.json` archive keys. Criterion is **archive membership (existedInMonth), NOT "has a score"** — so score-excluded-but-existed services stay (the 3 withheld `bedrock`/`azureopenai`/`characterai` + the 8 mid-month-added), and only truly post-month services drop. Fail-open on a missing/corrupt snapshot.
- **`generate-report.yml`** — the `_data` snapshot step (`fetch-archive.sh`) now runs **before** "Generate charts", so the archive exists when the heatmap is drawn. Found in review: otherwise the filter fails open on first-draft generation and the post-month services leak back in. Verified safe for the trend chart (it reads only months strictly before the current one + takes the current month from the parsed report).
- **5 unit tests** for `rosterForMonth`.

## Verification
- [x] `rosterForMonth` unit tests: drops post-month ids, keeps score-excluded-but-existed ids, preserves order, fail-open ×2 — all script tests pass (5/5 files)
- [x] regenerating the June heatmap with the fix drops turbopuffer / Twelve Labs and keeps bedrock/azureopenai/characterai + the 8 mid-month services
- [ ] **follow-up (delivery)**: regenerate the actual `2026-06` report heatmap on `report/2026-06` (hence `refs #63`, not `closes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
