### PR TITLE
fix(charts): de-collide 3-Month Trend mover end-labels (#65)

### DIFF
--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -510,6 +510,26 @@ function loadTrendEntries(month, currentEntry, opts = {}) {
   return entries
 }
 
+// PURE. De-collide a set of label y-anchors so none overlap: sort by y, greedily push
+// any label closer than `minGap` to the previous one down to `prev + minGap`, then
+// restore the input order. Returns a new array of adjusted ys (same order/length as
+// input). Two labels at the same y separate by exactly `minGap`; already-spaced labels
+// are untouched. Used for the trend chart's mover end-labels (aiwatch-reports#65).
+// Greedy push-DOWN (never centers): safe because movers cap at 3+3=6, so the worst-case
+// 72px spread fits the ~300px plot for realistic scores; only a pathological cluster of
+// near-0 decliners could reach the plot bottom.
+function spreadLabelYs(ys, minGap) {
+  const order = ys.map((y, i) => ({ y, i })).sort((a, b) => a.y - b.y)
+  let prev = -Infinity
+  for (const o of order) {
+    if (o.y < prev + minGap) o.y = prev + minGap
+    prev = o.y
+  }
+  const out = new Array(ys.length)
+  for (const o of order) out[o.i] = o.y
+  return out
+}
+
 // ── Trend slope chart ────────────────────────────────────
 // All services render as faint context lines; the movers (decliners red, improvers
 // green) are emphasized + end-labeled. Partial months get a "*" on the x-axis label.
@@ -559,16 +579,30 @@ function generateTrendSvg(trend, opts = {}) {
     .filter(Boolean)
     .join('\n')
 
-  // mover lines (emphasized) + end labels
-  const moverRows = [...movers.declining, ...movers.improving].map(m => {
+  // mover lines (emphasized) + end labels. Labels anchor at the mover's final-score y;
+  // two movers finishing at the same Score would collide, so the label y-positions are
+  // de-collided (spreadLabelYs) — pushed apart to a minimum gap while the line still
+  // ties each label to its series by colour/endpoint (aiwatch-reports#65).
+  const moverList = [...movers.declining, ...movers.improving].map(m => {
     const color = m.delta < 0 ? COLORS.down : COLORS.operational
-    const line = polyFor(m.points, color, 2.5, 0.95)
     const drawn = m.points.map((p, i) => ({ p, i })).filter(o => o.p.score !== null)
     const lastDrawn = drawn[drawn.length - 1]
-    const label = lastDrawn
-      ? `  <text x="${(xFor(lastDrawn.i) + 8).toFixed(1)}" y="${(yFor(lastDrawn.p.score) + 4).toFixed(1)}" fill="${color}" font-size="11" font-family="ui-monospace,monospace">${escapeXml(m.name)} ${fmtScoreDelta(m.delta)}</text>`
+    return {
+      color,
+      line: polyFor(m.points, color, 2.5, 0.95),
+      labelX: lastDrawn ? xFor(lastDrawn.i) + 8 : null,
+      labelYNatural: lastDrawn ? yFor(lastDrawn.p.score) + 4 : null,
+      text: `${escapeXml(m.name)} ${fmtScoreDelta(m.delta)}`,
+    }
+  })
+  const labeled = moverList.filter(o => o.labelYNatural !== null)
+  const spreadYs = spreadLabelYs(labeled.map(o => o.labelYNatural), 12)
+  labeled.forEach((o, k) => { o.labelY = spreadYs[k] })
+  const moverRows = moverList.map(o => {
+    const label = o.labelX !== null
+      ? `  <text x="${o.labelX.toFixed(1)}" y="${o.labelY.toFixed(1)}" fill="${o.color}" font-size="11" font-family="ui-monospace,monospace">${o.text}</text>`
       : ''
-    return [line, label].filter(Boolean).join('\n')
+    return [o.line, label].filter(Boolean).join('\n')
   }).filter(Boolean).join('\n')
 
   const partialNote = partialMonths.size
@@ -596,7 +630,7 @@ module.exports = {
   // trend (aiwatch-reports#41)
   monthsBefore, daysInMonthOf, readDataArchive, rosterForMonth, toMonthEntry, monthEntryFromScoreRows,
   buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta, loadTrendEntries,
-  generateTrendSvg, nameToId, ID_TO_NAME, TREND_MONTHS,
+  generateTrendSvg, spreadLabelYs, nameToId, ID_TO_NAME, TREND_MONTHS,
 }
 
 // ── CLI ──────────────────────────────────────────────────

--- a/scripts/generate-charts.test.js
+++ b/scripts/generate-charts.test.js
@@ -1,7 +1,7 @@
 const {
   generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade,
   monthsBefore, buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta,
-  generateTrendSvg, toMonthEntry, monthEntryFromScoreRows, rosterForMonth,
+  generateTrendSvg, toMonthEntry, monthEntryFromScoreRows, rosterForMonth, spreadLabelYs,
 } = require('./generate-charts')
 const assert = require('assert')
 
@@ -487,6 +487,48 @@ test('rosterForMonth fail-opens on null roster (missing/corrupt snapshot)', () =
 
 test('rosterForMonth fail-opens on empty roster', () => {
   assert.deepStrictEqual(rosterForMonth(CAT, []), CAT)
+})
+
+// ── spreadLabelYs (trend end-label de-collision, aiwatch-reports#65) ──
+test('spreadLabelYs separates two labels at the same y by minGap', () => {
+  // Copilot(88)/Perplexity(88) both anchor at y=90 → must split
+  assert.deepStrictEqual(spreadLabelYs([90, 90], 12), [90, 102])
+})
+
+test('spreadLabelYs leaves already-spaced labels untouched', () => {
+  assert.deepStrictEqual(spreadLabelYs([90, 108, 135], 12), [90, 108, 135])
+})
+
+test('spreadLabelYs preserves INPUT order (not sorted order)', () => {
+  // input out of order: the label at index 0 (y=108) and index 1 (y=90) — output keeps index positions
+  assert.deepStrictEqual(spreadLabelYs([108, 90], 12), [108, 90])
+})
+
+test('spreadLabelYs cascades a tight cluster', () => {
+  // three within <minGap of each other → 90, 102, 114
+  assert.deepStrictEqual(spreadLabelYs([90, 95, 100], 12), [90, 102, 114])
+})
+
+test('spreadLabelYs handles single + empty', () => {
+  assert.deepStrictEqual(spreadLabelYs([90], 12), [90])
+  assert.deepStrictEqual(spreadLabelYs([], 12), [])
+})
+
+test('generateTrendSvg emits two same-final-Score movers at different label ys (wiring)', () => {
+  // guards against a future refactor silently unwiring spreadLabelYs while the pure-fn
+  // tests stay green — the actual #65 bug was two movers ending at 88 overlapping.
+  const trend = { months: ['2026-04', '2026-05', '2026-06'], partialMonths: new Set(), series: {} }
+  const movers = {
+    declining: [],
+    improving: [
+      { id: 'copilot', name: 'GitHub Copilot', delta: 19, points: [{ score: 69 }, { score: 78 }, { score: 88 }] },
+      { id: 'perplexity', name: 'Perplexity', delta: 12, points: [{ score: 76 }, { score: 82 }, { score: 88 }] },
+    ],
+  }
+  const svg = generateTrendSvg(trend, { movers, nameFor: id => id })
+  const ys = [...svg.matchAll(/<text[^>]*\sy="([0-9.]+)"[^>]*>(?:GitHub Copilot|Perplexity)/g)].map(m => Number(m[1]))
+  eq(ys.length, 2, `both mover labels present (got ${ys.length})`)
+  assert.ok(Math.abs(ys[0] - ys[1]) >= 12, `same-score labels must be ≥12 apart, got ${JSON.stringify(ys)}`)
 })
 
 // ── Summary ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem
In the **3-Month Trend** chart (`assets/{YYYY-MM}/trend-chart.svg`), mover end-labels **overlap** when two movers finish the window at the same Score. June 2026: **GitHub Copilot** (88, +19) and **Perplexity** (88, +12) both end at 88, so both labels printed at the same y (≈90).

## Root cause
`generateTrendSvg` placed each mover's end-label at `yFor(finalScore)` with no de-collision.

## Fix
- **`generate-charts.js`** — pure `spreadLabelYs(ys, minGap)`: sort anchors by y, greedily push any closer than `minGap` down to `prev+minGap`, restore input order. `generateTrendSvg` de-collides the mover label ys via `spreadLabelYs(…, 12)`. Rendering is otherwise unchanged (line iff ≥2 points; label iff a last drawn point exists). Greedy push-down is safe: movers cap at 3+3=6, so worst-case 72px spread fits the ~300px plot.
- **`generate-charts.test.js`** — 5 unit tests for `spreadLabelYs` + 1 wiring test (`generateTrendSvg` emits two same-final-Score movers at different label ys).

## Verification
- [x] all script tests pass (5/5 files, 65 tests)
- [x] regenerating June's trend chart moves Perplexity 90 → 102 (Copilot stays 90); no overlap
- [ ] **follow-up (delivery)**: regenerate the actual `2026-06` trend chart on `report/2026-06` (hence `refs #65`, not `closes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
