### PR TITLE
fix(charts): 3-Month Trend chart emphasizes the same services as the Notable Movers table (#67)

### DIFF
--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -402,6 +402,68 @@ function presentDelta(points, field) {
   return { first, last, delta: present.length >= 2 ? last - first : null }
 }
 
+// ── Mover exclusion predicates (moved here from generate-report.js, aiwatch-reports#67) ──
+// Single source of truth: both the Notable Movers TABLE (generate-report.js) and the trend
+// CHART (this file's CLI) must exclude the SAME services, so they live next to
+// computeNotableMovers and generate-report.js imports them from here.
+
+// Estimate-uptime services that ALSO have no reliable incident feed (RSS-only — a blank
+// incident count is monitoring coverage, not a verified zero). With neither an accessible
+// uptime metric nor trustworthy incident data there's nothing to score fairly, so they're
+// dropped from the Score ranking entirely. Subset of NO_PUBLIC_UPTIME; matches the 2026-04
+// report's "29 of 31 ranked — Bedrock/Azure excluded" handling.
+const NO_INCIDENT_FEED = new Set(['bedrock', 'azureopenai'])
+
+// Services whose status page migrated to a platform AIWatch can't reach server-side, so the
+// feed is FROZEN at the last reachable fetch — the incident count, uptime and Score reflect only
+// data up to that cutoff, NOT the full month. Unlike NO_INCIDENT_FEED these DO carry an "official"
+// uptime + an incident history, but both are STALE, which is more insidious: a partial-month count
+// reads as a verified low number and the frozen uptime reads as current. The guard surfaces a
+// caveat every report and stops a frozen zero-count from being labelled a "confirmed zero".
+//   • deepseek — migrated Atlassian Statuspage → Flashduty (~May 2026). REMOVED here as of June
+//     2026: AIWatch now reads the full Flashduty feed via a browser-rendered fetch (aiwatch#618),
+//     so DeepSeek (and the new DeepSeek App, aiwatch#619) are no longer frozen. From the June 2026
+//     archive onward their incidentSourceStale flag is absent → not stale; the May 2026 archive
+//     still carries the flag, so a May regeneration stays correctly stale (flag-driven, below).
+// Maintained constant — REMOVE a service here once its feed is reachable again (aiwatch#507).
+// Empty today; reserved for a future status-page migration that re-freezes a feed.
+const STALE_SOURCE = new Set([])
+
+// aiwatch#591 — is a service's incident source stale this month? PRIMARY signal is the archive's
+// per-service `incidentSourceStale` flag (the deployed Worker sets it from ServiceConfig; absent ⇒
+// not stale on a post-#591 archive). The STALE_SOURCE constant is the FALLBACK for archives built
+// before the Worker emitted the flag. Stale services are excluded from the Score ranking (their
+// frozen empty incident window would inflate the Score — DeepSeek ranked #4 live before the fix).
+function isStaleSource(s) {
+  return !!(s.data.incidentSourceStale ?? STALE_SOURCE.has(s.id))
+}
+
+// reports#45 — a service added DURING (or after) the report month lacked full-month coverage, so its
+// partial-month Score must not be ranked or featured in Notable Movers against full-month services
+// (the report-side equivalent of aiwatch#802's <30d-coverage dashboard gate). Reads the static
+// `addedAt` the monthly archive now exposes (aiwatch#809). `addedAt` absent = established service =
+// full coverage. Compares YYYY-MM prefixes: addedAt in a PRIOR month → ranked; in the report month
+// (or later) → excluded. `period` = the report month 'YYYY-MM'.
+function isRecentlyAdded(s, period) {
+  const addedAt = s && s.data && s.data.addedAt
+  if (!addedAt || !period) return false
+  return addedAt.slice(0, 7) >= period.slice(0, 7)
+}
+
+// PURE. Build the set of service ids the Notable Movers table / trend chart must exclude
+// (services the Score ranking itself drops: NO_INCIDENT_FEED + stale source + mid-month-added).
+// Keyed off `month`'s archive services. Fail-open: a null archive → empty set (the
+// computeNotableMovers "score at both ends" guard still filters mid-month / null-score services).
+function buildMoverExclude(archiveServices, month) {
+  if (!archiveServices) return new Set()
+  return new Set(
+    Object.entries(archiveServices)
+      .map(([id, data]) => ({ id, data }))
+      .filter(s => NO_INCIDENT_FEED.has(s.id) || isStaleSource(s) || isRecentlyAdded(s, month)) // reports#45 — partial-month delta is not a real mover
+      .map(s => s.id),
+  )
+}
+
 // PURE. "Notable Movers" — the decision-grade list. Unlike computeScoreMovers (which ranks
 // by Score delta only, for the slope chart's emphasis), this ranks by the LARGEST move across
 // Score / MTTR / total-downtime — incident-feed MEASURED metrics — so a service with a FLAT
@@ -474,6 +536,23 @@ function computeNotableMovers(trend, opts = {}) {
 
   rows.sort((a, b) => b.notability - a.notability || Math.abs(b.score.delta) - Math.abs(a.score.delta))
   return rows.slice(0, limit)
+}
+
+// PURE. Reshape computeNotableMovers output → generateTrendSvg's { declining, improving } shape
+// (aiwatch-reports#67), so the CHART emphasizes the SAME services the table ranks. generateTrendSvg
+// colours/labels each line purely by `item.delta` (= SCORE delta), NOT by which array it's in — so
+// the split here is organizational (kept for the interface shape), and a flat-Score row (delta 0)
+// renders green / labelled "±0" even when the table marks it 🔻 (an MTTR/downtime regressor). That's
+// accepted: on a Score-axis plot the line honestly shows the Score didn't move; the table below
+// carries the headline metric. Flat rows are bucketed by the table's `declining` flag for tidiness.
+function notableMoversForChart(notable) {
+  const declining = [], improving = []
+  for (const r of notable) {
+    const item = { id: r.id, name: r.name, delta: r.score.delta, points: r.score.points }
+    const up = r.score.delta > 0 || (r.score.delta === 0 && !r.declining) // flat Score → table's flag
+    ;(up ? improving : declining).push(item)
+  }
+  return { declining, improving }
 }
 
 // "71 → 68 → 63" from a series' points (skips months the service was absent).
@@ -631,6 +710,8 @@ module.exports = {
   monthsBefore, daysInMonthOf, readDataArchive, rosterForMonth, toMonthEntry, monthEntryFromScoreRows,
   buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta, loadTrendEntries,
   generateTrendSvg, spreadLabelYs, nameToId, ID_TO_NAME, TREND_MONTHS,
+  // mover exclusion + chart-reshape (aiwatch-reports#67)
+  NO_INCIDENT_FEED, STALE_SOURCE, isStaleSource, isRecentlyAdded, buildMoverExclude, notableMoversForChart,
 }
 
 // ── CLI ──────────────────────────────────────────────────
@@ -680,21 +761,30 @@ if (require.main === module) {
   fs.writeFileSync(scorePath, scoreSvg + '\n', 'utf-8')
   console.log(`✓ ${scorePath}`)
 
-  // 3-month trend chart (sync — prior months from committed _data/, current month
-  // from this report's parsed Score table). Written only when ≥2 months are available
-  // (a lone first month has no trend); the report's TREND_SECTION applies the same
-  // gate so the `![](trend-chart.svg)` ref never dangles.
-  const currentEntry = monthEntryFromScoreRows(monthKey, scores)
+  // 3-month trend chart (sync — prior months from committed _data/). The CURRENT month is
+  // built from THIS month's archive snapshot (toMonthEntry) so it carries MTTR + downtime —
+  // the Notable-Movers ranking axes — exactly like the report table's current entry; it falls
+  // back to the parsed Score table (score/grade only) when the snapshot is absent. Building it
+  // from the Score table alone would drop MTTR/downtime-driven movers (a flat-Score service
+  // with an MTTR spike), diverging from the table (#67). Written only when ≥2 months are
+  // available; the report's TREND_SECTION applies the same gate so the ref never dangles.
+  const monthArchive = readDataArchive(monthKey, path.resolve('_data'))
+  const currentEntry = monthArchive
+    ? toMonthEntry(monthKey, monthArchive)
+    : monthEntryFromScoreRows(monthKey, scores)
   const trendEntries = loadTrendEntries(monthKey, currentEntry, { dataDir: path.resolve('_data') })
   if (trendEntries.length >= 2) {
     const trend = buildTrendSeries(trendEntries)
-    // No explicit `exclude` here (unlike the report-section path): the current-month entry is
-    // built from the parsed AIWatch Score table, and buildScoreTable already drops the services
-    // the report doesn't rank (NO_INCIDENT_FEED + stale), so an excluded service has a null
-    // current-month score and computeScoreMovers' "score at both ends" guard filters it from
-    // emphasis automatically — it can only ever appear as a faint context line. If the current
-    // month is ever sourced from the full archive instead, pass the same exclude set here too.
-    const movers = computeScoreMovers(trend, { nameFor: id => ID_TO_NAME[id] || id })
+    // aiwatch-reports#67 — emphasize the SAME services as the report's Notable Movers TABLE
+    // (Score/MTTR/downtime ranking) rather than a Score-delta-only slope, so the chart and the
+    // table can never highlight different services. Uses the SAME exclude as the table, keyed off
+    // the current month's archive. Fail-open: a missing/corrupt `_data/{month}.json` → empty
+    // exclude (computeNotableMovers' "score at both ends" guard still filters mid-month / null-
+    // score services). notableMoversForChart reshapes the table rows → the chart's {declining,
+    // improving} shape, split by SCORE delta since generateTrendSvg is a Score-axis plot.
+    const exclude = buildMoverExclude(monthArchive && monthArchive.services ? monthArchive.services : null, monthKey)
+    const notable = computeNotableMovers(trend, { nameFor: id => ID_TO_NAME[id] || id, exclude })
+    const movers = notableMoversForChart(notable)
     const trendSvg = generateTrendSvg(trend, { nameFor: id => ID_TO_NAME[id] || id, movers })
     const trendPath = path.join(outDir, 'trend-chart.svg')
     fs.writeFileSync(trendPath, trendSvg + '\n', 'utf-8')

--- a/scripts/generate-charts.test.js
+++ b/scripts/generate-charts.test.js
@@ -2,6 +2,7 @@ const {
   generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade,
   monthsBefore, buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta,
   generateTrendSvg, toMonthEntry, monthEntryFromScoreRows, rosterForMonth, spreadLabelYs,
+  buildMoverExclude, notableMoversForChart,
 } = require('./generate-charts')
 const assert = require('assert')
 
@@ -529,6 +530,107 @@ test('generateTrendSvg emits two same-final-Score movers at different label ys (
   const ys = [...svg.matchAll(/<text[^>]*\sy="([0-9.]+)"[^>]*>(?:GitHub Copilot|Perplexity)/g)].map(m => Number(m[1]))
   eq(ys.length, 2, `both mover labels present (got ${ys.length})`)
   assert.ok(Math.abs(ys[0] - ys[1]) >= 12, `same-score labels must be ≥12 apart, got ${JSON.stringify(ys)}`)
+})
+
+// ── buildMoverExclude (moved from generate-report.js, aiwatch-reports#67) ──
+console.log('\nbuildMoverExclude')
+
+test('excludes NO_INCIDENT_FEED / stale / recently-added, keeps established; null → empty', () => {
+  const services = {
+    bedrock: { score: 90 },                             // NO_INCIDENT_FEED
+    deepseek: { score: 88, incidentSourceStale: true }, // stale (archive flag)
+    fal: { score: 77, addedAt: '2026-06-24' },          // added IN the report month
+    claude: { score: 71 },                              // established → kept
+  }
+  const ex = buildMoverExclude(services, '2026-06')
+  assert.ok(ex.has('bedrock'), 'bedrock (NO_INCIDENT_FEED) excluded')
+  assert.ok(ex.has('deepseek'), 'stale source excluded')
+  assert.ok(ex.has('fal'), 'recently-added (addedAt in report month) excluded')
+  assert.ok(!ex.has('claude'), 'established service kept')
+  assert.strictEqual(ex.size, 3)
+})
+
+test('a service added in a PRIOR month is NOT excluded', () => {
+  const ex = buildMoverExclude({ fal: { score: 77, addedAt: '2026-05-10' } }, '2026-06')
+  assert.ok(!ex.has('fal'), 'prior-month addedAt → full coverage → not excluded')
+})
+
+test('null archive → empty set (fail-open)', () => {
+  const ex = buildMoverExclude(null, '2026-06')
+  assert.ok(ex instanceof Set && ex.size === 0)
+})
+
+// ── notableMoversForChart (aiwatch-reports#67) ──
+console.log('\nnotableMoversForChart')
+
+test('splits by SCORE delta and carries {id,name,delta,points}', () => {
+  const pts = [{ score: 70 }, { score: 78 }]
+  const notable = [
+    { id: 'up', name: 'Up', score: { first: 70, last: 78, delta: 8, points: pts }, declining: false },
+    { id: 'down', name: 'Down', score: { first: 78, last: 70, delta: -8, points: pts }, declining: true },
+  ]
+  const { declining, improving } = notableMoversForChart(notable)
+  eq(improving.length, 1)
+  eq(improving[0].id, 'up')
+  eq(declining.length, 1)
+  eq(declining[0].id, 'down')
+  // item shape
+  eq(improving[0].name, 'Up')
+  eq(improving[0].delta, 8)
+  eq(improving[0].points, pts)
+})
+
+test('a flat-Score row (delta 0) follows the table declining flag', () => {
+  const pts = [{ score: 64 }, { score: 64 }]
+  const flatDeclining = [{ id: 'g', name: 'G', score: { delta: 0, points: pts }, declining: true }]
+  const flatImproving = [{ id: 'g', name: 'G', score: { delta: 0, points: pts }, declining: false }]
+  eq(notableMoversForChart(flatDeclining).declining.length, 1)   // declining flag → declining
+  eq(notableMoversForChart(flatDeclining).improving.length, 0)
+  eq(notableMoversForChart(flatImproving).improving.length, 1)   // not declining → improving
+})
+
+// ── wiring: the CHART emphasizes the NOTABLE set, not the Score-mover set (#67) ──
+console.log('\ntrend chart wiring (notable movers, #67)')
+
+test('generateTrendSvg emphasizes the Notable Movers, not computeScoreMovers', () => {
+  // NOTABLE_ENTRIES: gemini has a FLAT score (64→64) but a huge MTTR/downtime spike, so it is a
+  // Notable Mover but NOT a Score mover (delta 0). claude declines -8 (both a Notable + a Score
+  // mover). So the notable-chart must label gemini; the old Score-mover chart would NOT.
+  const trend = buildTrendSeries(NOTABLE_ENTRIES)
+  const nameFor = id => id
+
+  const notable = computeNotableMovers(trend, { nameFor })
+  const notableSet = new Set(notable.map(m => m.id))
+  assert.ok(notableSet.has('gemini') && notableSet.has('claude'), 'fixture sanity')
+
+  const movers = notableMoversForChart(notable)
+  const notableSvg = generateTrendSvg(trend, { nameFor, movers })
+  // Extract emphasized label ids (mover end-labels are the only service-name texts).
+  const labeled = id => new RegExp(`<text[^>]*>${id} [±+−]`).test(notableSvg)
+  assert.ok(labeled('gemini'), 'notable chart labels gemini (flat score, spiked MTTR)')
+  assert.ok(labeled('claude'), 'notable chart labels claude')
+
+  // The old Score-mover path would NOT emphasize gemini (delta 0 is not a score mover).
+  const scoreMovers = computeScoreMovers(trend, { nameFor })
+  const scoreSet = new Set([...scoreMovers.declining, ...scoreMovers.improving].map(m => m.id))
+  assert.ok(!scoreSet.has('gemini'), 'score movers exclude gemini — proves the chart changed source')
+  assert.deepStrictEqual([...notableSet].sort(), ['claude', 'gemini'])
+})
+
+// ── chart current-month entry must carry MTTR/downtime, else MTTR-driven movers vanish (#67) ──
+// Pins WHY the trend CLI builds the current month via toMonthEntry (archive) not
+// monthEntryFromScoreRows (Score/grade only): a flat-Score service whose only signal is an
+// MTTR spike is a Notable Mover in the table but disappears if the current entry lacks MTTR.
+test('computeNotableMovers surfaces an MTTR-driven mover ONLY when the current entry carries MTTR (#67)', () => {
+  const prior = toMonthEntry('2026-05', { services: { gemini: { score: 64, grade: 'Fair', avgResolutionMin: 120, totalDowntimeMin: 240 } } })
+  const archiveCurrent = toMonthEntry('2026-06', { services: { gemini: { score: 64, grade: 'Fair', avgResolutionMin: 1320, totalDowntimeMin: 2640 } } })
+  const rowsCurrent = monthEntryFromScoreRows('2026-06', [{ Service: 'Gemini API', Score: '64', Grade: 'Fair' }])
+  // archive-based current entry (the fixed CLI path) → gemini's MTTR spike is visible → mover
+  const withArchive = computeNotableMovers(buildTrendSeries([prior, archiveCurrent]))
+  assert.ok(withArchive.some(m => m.id === 'gemini'), 'gemini surfaces when current entry carries MTTR')
+  // Score-table-only current entry (the old bug path) → MTTR null → flat Score → NOT a mover
+  const withRows = computeNotableMovers(buildTrendSeries([prior, rowsCurrent]))
+  assert.ok(!withRows.some(m => m.id === 'gemini'), 'gemini vanishes when current entry lacks MTTR — why the CLI must use toMonthEntry')
 })
 
 // ── Summary ──────────────────────────────────────────────

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -28,6 +28,11 @@ const path = require('path')
 const summary = require('./generate-summary')
 const charts = require('./generate-charts')  // trend core (aiwatch-reports#41)
 
+// Mover-exclusion predicates now live in generate-charts.js (single source of truth) so the
+// Notable Movers TABLE (here) and the trend CHART (charts.js CLI) exclude the SAME services
+// (aiwatch-reports#67). Imported here; re-exported below so existing report.test.js callers work.
+const { NO_INCIDENT_FEED, isStaleSource, isRecentlyAdded } = charts
+
 const API_BASE = process.env.AIWATCH_API_BASE || 'https://aiwatch-worker.p2c2kbf.workers.dev'
 const TEMPLATE_PATH = path.join(__dirname, '..', '_templates', 'monthly-report.md')
 const OUT_DIR_ROOT = path.join(__dirname, '..')
@@ -48,48 +53,8 @@ const NO_PUBLIC_UPTIME = new Set([
   'bedrock', 'azureopenai', 'deepgram', 'gemini', 'mistral', 'perplexity', 'xai',
 ])
 
-// Estimate-uptime services that ALSO have no reliable incident feed (RSS-only — a blank
-// incident count is monitoring coverage, not a verified zero). With neither an accessible
-// uptime metric nor trustworthy incident data there's nothing to score fairly, so they're
-// dropped from the Score ranking entirely. Subset of NO_PUBLIC_UPTIME; matches the 2026-04
-// report's "29 of 31 ranked — Bedrock/Azure excluded" handling.
-const NO_INCIDENT_FEED = new Set(['bedrock', 'azureopenai'])
-
-// Services whose status page migrated to a platform AIWatch can't reach server-side, so the
-// feed is FROZEN at the last reachable fetch — the incident count, uptime and Score reflect only
-// data up to that cutoff, NOT the full month. Unlike NO_INCIDENT_FEED these DO carry an "official"
-// uptime + an incident history, but both are STALE, which is more insidious: a partial-month count
-// reads as a verified low number and the frozen uptime reads as current. The guard surfaces a
-// caveat every report and stops a frozen zero-count from being labelled a "confirmed zero".
-//   • deepseek — migrated Atlassian Statuspage → Flashduty (~May 2026). REMOVED here as of June
-//     2026: AIWatch now reads the full Flashduty feed via a browser-rendered fetch (aiwatch#618),
-//     so DeepSeek (and the new DeepSeek App, aiwatch#619) are no longer frozen. From the June 2026
-//     archive onward their incidentSourceStale flag is absent → not stale; the May 2026 archive
-//     still carries the flag, so a May regeneration stays correctly stale (flag-driven, below).
-// Maintained constant — REMOVE a service here once its feed is reachable again (aiwatch#507).
-// Empty today; reserved for a future status-page migration that re-freezes a feed.
-const STALE_SOURCE = new Set([])
-
-// aiwatch#591 — is a service's incident source stale this month? PRIMARY signal is the archive's
-// per-service `incidentSourceStale` flag (the deployed Worker sets it from ServiceConfig; absent ⇒
-// not stale on a post-#591 archive). The STALE_SOURCE constant is the FALLBACK for archives built
-// before the Worker emitted the flag. Stale services are excluded from the Score ranking (their
-// frozen empty incident window would inflate the Score — DeepSeek ranked #4 live before the fix).
-function isStaleSource(s) {
-  return !!(s.data.incidentSourceStale ?? STALE_SOURCE.has(s.id))
-}
-
-// reports#45 — a service added DURING (or after) the report month lacked full-month coverage, so its
-// partial-month Score must not be ranked or featured in Notable Movers against full-month services
-// (the report-side equivalent of aiwatch#802's <30d-coverage dashboard gate). Reads the static
-// `addedAt` the monthly archive now exposes (aiwatch#809). `addedAt` absent = established service =
-// full coverage. Compares YYYY-MM prefixes: addedAt in a PRIOR month → ranked; in the report month
-// (or later) → excluded. `period` = the report month 'YYYY-MM'.
-function isRecentlyAdded(s, period) {
-  const addedAt = s && s.data && s.data.addedAt
-  if (!addedAt || !period) return false
-  return addedAt.slice(0, 7) >= period.slice(0, 7)
-}
+// (NO_INCIDENT_FEED / STALE_SOURCE / isStaleSource / isRecentlyAdded moved to generate-charts.js
+// as the mover-exclusion single source of truth — aiwatch-reports#67; imported above.)
 
 // Services without direct probe coverage (excluded from API Response Time ranking).
 // Archive.avgLatencyMs will be null for these — tracked for explicit messaging.
@@ -633,12 +598,7 @@ function buildTrendSection(month, archive, meta, dataDir = path.join(__dirname, 
   // per buildScoreTable / the #29 note) so a trend mover never contradicts a report that
   // elsewhere states it does not rank that service. Estimate-only bedrock/azureopenai scores
   // CAN move month-to-month, so this isn't hypothetical. Keyed off the CURRENT month's archive.
-  const exclude = new Set(
-    Object.entries(archive.services)
-      .map(([id, data]) => ({ id, data }))
-      .filter(s => NO_INCIDENT_FEED.has(s.id) || isStaleSource(s) || isRecentlyAdded(s, month)) // reports#45 — partial-month delta is not a real mover
-      .map(s => s.id),
-  )
+  const exclude = charts.buildMoverExclude(archive.services, month)
 
   const movers = charts.computeScoreMovers(trend, { nameFor: id => serviceName(id, meta), exclude })
   if (!movers.declining.length && !movers.improving.length) return ''


### PR DESCRIPTION
## Problem
In the **3-Month Trend** section, the chart's emphasized (labeled) services differed from the **Notable Movers** table right below it. June 2026 — chart: Copilot/Perplexity/ChatGPT/Pinecone/Replicate/Deepgram; table: Gemini/Codex/Copilot/Together/Mistral (only Copilot overlapped).

## Root cause
Two different functions: the chart used `computeScoreMovers` (Score-delta only, no exclude); the table used `computeNotableMovers` (largest move across Score/MTTR/downtime + an `exclude` set).

## Fix — align the chart to the table
- Moved the exclude predicates (`NO_INCIDENT_FEED`, `STALE_SOURCE`, `isStaleSource`, `isRecentlyAdded`) from `generate-report.js` DOWN into `generate-charts.js` (report.js imports them back via its existing `charts` require — one-way, no circular dep). One source of truth.
- New pure `buildMoverExclude(archiveServices, month)` — both table and chart derive the SAME exclude.
- New pure `notableMoversForChart(notable)` — reshape `computeNotableMovers` rows → the chart's `{declining,improving}` shape (delta = Score delta; the chart is a Score-axis plot, so a flat-Score MTTR-regressor renders green/±0 — the table below carries the headline metric).
- **Trend CLI builds the current-month entry from the month archive via `toMonthEntry`** (carries MTTR + downtime), not `monthEntryFromScoreRows` (score/grade only) — otherwise a flat-Score, MTTR-driven mover (Gemini) vanishes and the chart diverges again (caught in review). Then `buildMoverExclude` → `computeNotableMovers` → `notableMoversForChart` → `generateTrendSvg`.

## Verification
- [x] all script tests pass (5/5 files; generate-charts 72 incl. `buildMoverExclude` / `notableMoversForChart` / a regression test pinning the MTTR-current-entry requirement; generate-report 170)
- [x] both scripts load cleanly (no dangling refs from the predicate move)
- [x] regenerating June's trend chart emphasizes exactly {Gemini, Codex, GitHub Copilot, Together AI, Mistral API} — the table's five
- [ ] **follow-up (delivery)**: regenerate the actual `2026-06` trend chart on `report/2026-06` (hence `refs #67`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
