### PR TITLE
fix(charts): heatmap window from the month, not daysInMonth (refs #77)

### DIFF
--- a/.github/workflows/generate-charts.yml
+++ b/.github/workflows/generate-charts.yml
@@ -16,6 +16,11 @@ on:
       report_path:
         description: 'Report file path (e.g., 2026-04/index.md)'
         required: true
+      allow_partial:
+        description: 'Render even if the uptime API misses days of the month (#77). Only for a month whose head is past the 90-day uptime-history window (endpoint cap + counter TTL) — the chart will state the narrower span it actually covers.'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   generate:
@@ -51,7 +56,15 @@ jobs:
       - name: Generate charts
         env:
           REPORT_PATH: ${{ steps.report.outputs.path }}
-        run: node scripts/generate-charts.js "$REPORT_PATH"
+          ALLOW_PARTIAL: ${{ inputs.allow_partial }}
+        run: |
+          # #77 — a coverage gap hard-exits by default so a month can never silently lose its
+          # opening days. A deliberately-partial regeneration must be opted into.
+          if [ "$ALLOW_PARTIAL" = "true" ]; then
+            node scripts/generate-charts.js "$REPORT_PATH" --allow-partial
+          else
+            node scripts/generate-charts.js "$REPORT_PATH"
+          fi
 
       - name: Commit and push
         env:

--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -129,10 +129,12 @@ ${naText}
 }
 
 // ── Uptime Heatmap (real data) ───────────────────────────
-function generateUptimeHeatmapSvg(serviceNames, uptimeHistory, daysInMonth, monthKey, monitoringStartDay, lastDataDay) {
-  // Only render days with actual data (monitoringStartDay to lastDataDay)
+function generateUptimeHeatmapSvg(serviceNames, uptimeHistory, daysInMonth, monthKey, firstDataDay, lastDataDay) {
+  // Render the span the caller vouched for. The caller asserts month coverage before getting here
+  // (aiwatch-reports#77), so a late START means a deliberate --allow-partial run, not an unnoticed
+  // short fetch. An early END is still normal: an in-progress month legitimately stops at today.
   const endDay = lastDataDay || daysInMonth
-  const visibleDays = endDay - monitoringStartDay + 1
+  const visibleDays = endDay - firstDataDay + 1
 
   const cellSize = 16
   const cellGap = 3
@@ -145,7 +147,7 @@ function generateUptimeHeatmapSvg(serviceNames, uptimeHistory, daysInMonth, mont
 
   // Day number headers — only visible days
   const dayHeaders = Array.from({ length: visibleDays }, (_, i) => {
-    const dayNum = monitoringStartDay + i
+    const dayNum = firstDataDay + i
     const x = padding.left + labelWidth + i * (cellSize + cellGap)
     const interval = visibleDays <= 15 ? 3 : 5
     const show = i === 0 || dayNum % interval === 1 || i === visibleDays - 1
@@ -166,20 +168,20 @@ function generateUptimeHeatmapSvg(serviceNames, uptimeHistory, daysInMonth, mont
     const svcId = nameToId(name)
 
     const cells = Array.from({ length: visibleDays }, (_, i) => {
-      const dayNum = monitoringStartDay + i
+      const dayNum = firstDataDay + i
       const x = padding.left + labelWidth + i * (cellSize + cellGap)
       const dateKey = `${monthKey}-${String(dayNum).padStart(2, '0')}`
       const dayData = uptimeHistory[dateKey]?.[svcId]
 
+      // A ratio we cannot compute is ABSENCE, not an outage. `{}` and `{ok:0,total:0}` both yield
+      // NaN, which used to fall through to COLORS.down — painting a missing measurement red.
+      // Gray is the only honest color for "we did not measure this" (aiwatch-reports#77).
+      const ratio = dayData ? dayData.ok / dayData.total : NaN
       let color
-      if (!dayData) {
-        color = COLORS.noData
-      } else {
-        const ratio = dayData.ok / dayData.total
-        if (ratio >= 0.99) color = COLORS.operational
-        else if (ratio >= 0.90) color = COLORS.heatDegraded
-        else color = COLORS.down
-      }
+      if (!Number.isFinite(ratio)) color = COLORS.noData
+      else if (ratio >= 0.99) color = COLORS.operational
+      else if (ratio >= 0.90) color = COLORS.heatDegraded
+      else color = COLORS.down
 
       return `  <rect x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" rx="2" fill="${color}" opacity="0.85"/>`
     }).join('\n')
@@ -193,7 +195,9 @@ function generateUptimeHeatmapSvg(serviceNames, uptimeHistory, daysInMonth, mont
     { color: COLORS.operational, label: 'Operational' },
     { color: COLORS.heatDegraded, label: 'Degraded' },
     { color: COLORS.down, label: 'Down' },
-    { color: COLORS.noData, label: 'Added Later' },
+    // Gray means "not measured that day" — a service onboarded mid-month, a day with no counters,
+    // or a ratio we cannot compute. "Added Later" named only the first of the three.
+    { color: COLORS.noData, label: 'No data' },
   ]
   const legend = legendItems.map((item, i) => {
     const x = padding.left + i * 110
@@ -207,9 +211,9 @@ function generateUptimeHeatmapSvg(serviceNames, uptimeHistory, daysInMonth, mont
 
   const [yr, mo] = monthKey.split('-').map(Number)
   const monthName = new Date(yr, mo - 1).toLocaleString('en-US', { month: 'long' })
-  const subtitle = monitoringStartDay > 1
-    ? `${monthName} ${monitoringStartDay}–${endDay} — based on AIWatch polling (5-min intervals)`
-    : `${monthName} 1–${daysInMonth} — based on AIWatch polling (5-min intervals)`
+  // Always state the span actually rendered. The old branch printed `1–daysInMonth` whenever
+  // the chart started on the 1st, even when it ended early (in-progress month).
+  const subtitle = `${monthName} ${firstDataDay}–${endDay} — based on AIWatch polling (5-min intervals)`
 
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">
   <style>
@@ -255,6 +259,144 @@ function monthsBefore(month, count) {
   return out
 }
 
+// The /api/uptime endpoint's `days` is a LOOKBACK WINDOW anchored to today: `days=N` returns
+// [today-N+1, today]. It is not a count of days in some target month. Passing `daysInMonth`
+// conflated the two, so a chart built after month-end silently began where the window happened to
+// land — April's chart started on the 5th and May's on the 3rd while both headers read "1–30"/"1–31"
+// (aiwatch-reports#77). Derive the window from the month's first day instead.
+// 90 is BOTH limits at once, which is why widening the request would not help: /api/uptime caps
+// ?days= at 90 (worker index.ts:3994), AND the `history:<date>` daily counters it reads are written
+// with a 90-day KV TTL (index.ts:237). A month whose first day is more than 90 days before
+// generation is unreachable through the endpoint and its counters are already evicted — there is no
+// deeper source to point a wider window at.
+const UPTIME_MAX_LOOKBACK_DAYS = 90
+
+/** Days from `monthKey`'s first day through today, inclusive — before the retention cap. */
+function uptimeLookbackSpan(monthKey, today = new Date()) {
+  const [y, m] = String(monthKey).split('-').map(Number)
+  if (!y || !m || m < 1 || m > 12) throw new Error(`invalid monthKey ${monthKey} (expected YYYY-MM)`)
+  const first = Date.UTC(y, m - 1, 1)
+  const now = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate())
+  if (now < first) throw new Error(`${monthKey} has not started yet`)
+  return Math.floor((now - first) / 86_400_000) + 1
+}
+
+/** Lookback window to request, capped at retention. Below the cap it equals uptimeLookbackSpan. */
+function uptimeLookbackDays(monthKey, today = new Date()) {
+  return Math.min(uptimeLookbackSpan(monthKey, today), UPTIME_MAX_LOOKBACK_DAYS)
+}
+
+/**
+ * A day counts as covered only if it carries at least one service's counters. `{}` is the trap: it
+ * is truthy, so an empty day-entry slips through a `!history[key]` check and renders as an all-gray
+ * column — a chart with zero data that still passes the coverage gate. (`null`/`undefined` are
+ * already falsy; guarded here so the predicate is total.)
+ */
+function hasDayData(entry) {
+  return !!entry && typeof entry === 'object' && Object.keys(entry).length > 0
+}
+
+/**
+ * Days of `monthKey` that the API response does not cover. Days still in the future are not
+ * missing — an in-progress month legitimately ends at today.
+ */
+function missingMonthDays(history, monthKey, daysInMonth, today = new Date()) {
+  const [y, m] = String(monthKey).split('-').map(Number)
+  const now = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate())
+  const missing = []
+  for (let d = 1; d <= daysInMonth; d++) {
+    if (Date.UTC(y, m - 1, d) > now) break
+    const key = `${monthKey}-${String(d).padStart(2, '0')}`
+    if (!hasDayData(history[key])) missing.push(key)
+  }
+  return missing
+}
+
+/** Days of `monthKey` that have already happened (the whole month, unless it is in progress). */
+function elapsedMonthDays(monthKey, daysInMonth, today = new Date()) {
+  const [y, m] = String(monthKey).split('-').map(Number)
+  const now = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate())
+  let n = 0
+  for (let d = 1; d <= daysInMonth; d++) {
+    if (Date.UTC(y, m - 1, d) > now) break
+    n++
+  }
+  return n
+}
+
+/**
+ * One line naming the actual cause: a retention clamp (the month's head is unreachable, and no flag
+ * brings it back) versus a hole inside a window we did fetch. The two need opposite responses, so
+ * the message must not blur them.
+ */
+function explainWindow(monthKey, today = new Date()) {
+  const span = uptimeLookbackSpan(monthKey, today)
+  if (span <= UPTIME_MAX_LOOKBACK_DAYS) {
+    return `Requested days=${span}, within the ${UPTIME_MAX_LOOKBACK_DAYS}-day history window, so the gap is in the data itself.`
+  }
+  const preamble = `Reaching ${monthKey}-01 needs a ${span}-day lookback, but uptime history only goes ` +
+    `back ${UPTIME_MAX_LOOKBACK_DAYS} days (endpoint cap + counter TTL)`
+  // `span - CAP` counts days before the window opens, which can exceed the month itself — a month
+  // that ended before the window even begins loses ALL of its days, not "the first 42 of 31".
+  const daysInMonth = daysInMonthOf(monthKey)
+  const lost = Math.min(span - UPTIME_MAX_LOOKBACK_DAYS, daysInMonth)
+  if (lost >= daysInMonth) return `${preamble} — all ${daysInMonth} days of ${monthKey} are permanently unreachable.`
+  const subject = lost === 1 ? `the first day of ${monthKey} is` : `the first ${lost} days of ${monthKey} are`
+  return `${preamble} — ${subject} permanently unreachable.`
+}
+
+/**
+ * Decide whether a heatmap may be rendered. PURE — the CLI only prints and exits on this verdict.
+ *
+ * The ORDER is the contract, not an implementation detail: zero coverage is refused BEFORE
+ * `allowPartial` is consulted, so no flag can produce an empty chart captioned as a full month.
+ * That precedence is what a refactor could silently invert, which is why it lives here under test
+ * rather than inline in the CLI.
+ *
+ * @returns {{action:'render'|'refuse', reason:'complete'|'partial'|'zero-coverage', missing:string[]}}
+ */
+function heatmapGate(history, monthKey, daysInMonth, today, { allowPartial = false } = {}) {
+  const missing = missingMonthDays(history, monthKey, daysInMonth, today)
+  if (missing.length === 0) return { action: 'render', reason: 'complete', missing }
+  if (missing.length === elapsedMonthDays(monthKey, daysInMonth, today)) {
+    return { action: 'refuse', reason: 'zero-coverage', missing }
+  }
+  if (!allowPartial) return { action: 'refuse', reason: 'partial', missing }
+  return { action: 'render', reason: 'partial', missing }
+}
+
+/**
+ * Human-readable summary of a gate verdict's missing days. Total by construction: an empty list is
+ * not a gap to describe, and rendering it as "0 day(s) … (undefined)" would put a bug in an error
+ * message. The CLI only calls this when `reason !== 'complete'`; this keeps that safe for any caller.
+ */
+function describeMissing(missing, monthKey) {
+  if (!missing || missing.length === 0) return `no missing days in ${monthKey}`
+  const span = missing.length > 1 ? `${missing[0]} … ${missing[missing.length - 1]}` : missing[0]
+  const noun = missing.length === 1 ? 'day' : 'days'
+  return `${missing.length} ${noun} of ${monthKey} absent from the API response (${span})`
+}
+
+/**
+ * First and last day of `monthKey` that carry data. PURE. Shares `hasDayData` with the gate, so the
+ * span rendered can never disagree with the span the gate vouched for — the last piece of #77 logic
+ * that lived inline in the CLI, where a reverted truthy check or an off-by-one scan went unseen.
+ * Returns null when nothing has data (the gate refuses that case before this is reached).
+ */
+function dataSpan(history, monthKey, daysInMonth) {
+  const dayKey = d => `${monthKey}-${String(d).padStart(2, '0')}`
+  let first = null
+  for (let d = 1; d <= daysInMonth; d++) {
+    if (hasDayData(history[dayKey(d)])) { first = d; break }
+  }
+  if (first === null) return null
+  let last = first
+  for (let d = daysInMonth; d >= first; d--) {
+    if (hasDayData(history[dayKey(d)])) { last = d; break }
+  }
+  return { firstDataDay: first, lastDataDay: last }
+}
+
 function daysInMonthOf(month) {
   const [y, m] = month.split('-').map(Number)
   return new Date(y, m, 0).getDate()
@@ -275,7 +417,7 @@ function readDataArchive(month, dataDir) {
 // PURE. Filter the full category-ordered id list down to the roster that EXISTED in the
 // report month — the ids present in that month's `_data/{month}.json` archive (the #909
 // `existedInMonth` set). Drops services added AFTER the month (which would otherwise
-// render as blank "Added Later" heatmap rows, aiwatch-reports#63), while KEEPING
+// render as blank gray heatmap rows, aiwatch-reports#63), while KEEPING
 // score-excluded-but-existed services (bedrock/azureopenai/characterai + the mid-month-
 // added ones) — they still have that month's uptime. Criterion is archive membership,
 // NOT "has a score". Fail-open: a null/empty roster (missing or corrupt snapshot) returns
@@ -708,6 +850,8 @@ module.exports = {
   generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade,
   // trend (aiwatch-reports#41)
   monthsBefore, daysInMonthOf, readDataArchive, rosterForMonth, toMonthEntry, monthEntryFromScoreRows,
+  uptimeLookbackDays, uptimeLookbackSpan, explainWindow, missingMonthDays, elapsedMonthDays, hasDayData,
+  heatmapGate, describeMissing, dataSpan, UPTIME_MAX_LOOKBACK_DAYS,
   buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta, loadTrendEntries,
   generateTrendSvg, spreadLabelYs, nameToId, ID_TO_NAME, TREND_MONTHS,
   // mover exclusion + chart-reshape (aiwatch-reports#67)
@@ -716,10 +860,19 @@ module.exports = {
 
 // ── CLI ──────────────────────────────────────────────────
 if (require.main === module) {
-  const file = process.argv[2]
+  const argv = process.argv.slice(2)
+  // Accept the flag in any position so `--allow-partial 2026-03/index.md` works too.
+  const allowPartial = argv.includes('--allow-partial')
+  const unknown = argv.filter(a => a.startsWith('--') && a !== '--allow-partial')
+  if (unknown.length) {
+    console.error(`Unknown option(s): ${unknown.join(', ')}`)
+    process.exit(1)
+  }
+  const file = argv.find(a => !a.startsWith('--'))
   if (!file) {
-    console.error('Usage: node scripts/generate-charts.js <report.md>')
+    console.error('Usage: node scripts/generate-charts.js <report.md> [--allow-partial]')
     console.error('Example: node scripts/generate-charts.js 2026-03/index.md')
+    console.error('  --allow-partial  render even if the API response misses days of the month')
     process.exit(1)
   }
 
@@ -794,7 +947,19 @@ if (require.main === module) {
   }
 
   // Uptime heatmap — fetch real data from API
-  const API_URL = 'https://aiwatch-worker.p2c2kbf.workers.dev/api/uptime?days=' + daysInMonth
+  // One clock for the whole run: the fetch can take 30s, and re-reading `new Date()` afterwards
+  // could cross midnight UTC and shift the elapsed-day count under us.
+  const today = new Date()
+  let lookbackDays
+  try {
+    lookbackDays = uptimeLookbackDays(monthKey, today)
+  } catch (err) {
+    // Matches this file's convention (one actionable line, not a stack dump) — reachable from a
+    // real path: `2026-13/index.md` parses, and `2027-01/index.md` is simply in the future.
+    console.error(`✗ Cannot determine the uptime window: ${err.message}`)
+    process.exit(1)
+  }
+  const API_URL = 'https://aiwatch-worker.p2c2kbf.workers.dev/api/uptime?days=' + lookbackDays
   console.log(`Fetching uptime data from ${API_URL}...`)
 
   fetch(API_URL, { signal: AbortSignal.timeout(30000) })
@@ -809,23 +974,43 @@ if (require.main === module) {
         process.exit(1)
       }
 
-      // Detect monitoring start day (first day with data)
-      let monitoringStartDay = 1
-      for (let d = 1; d <= daysInMonth; d++) {
-        const key = `${monthKey}-${String(d).padStart(2, '0')}`
-        if (history[key]) { monitoringStartDay = d; break }
+      // aiwatch-reports#77 — a day absent from the response means NOT FETCHED or OUTSIDE
+      // RETENTION. It never means "monitoring had not started".
+      const gate = heatmapGate(history, monthKey, daysInMonth, today, { allowPartial })
+      if (gate.reason !== 'complete') {
+        const msg = describeMissing(gate.missing, monthKey)
+        if (gate.reason === 'zero-coverage') {
+          // Do NOT assert "outside retention" here: the same verdict is reached by a transient API
+          // failure, a response carrying only adjacent-month days, and a current month whose first
+          // daily counter has not been written yet. Two of those are fixed by re-running.
+          console.error(`✗ Heatmap has NO data for any elapsed day of ${monthKey}: ${msg}`)
+          console.error(`  ${explainWindow(monthKey, today)}`)
+          console.error(`  Possible causes: the month is older than the ${UPTIME_MAX_LOOKBACK_DAYS}-day history window, the API returned nothing usable,`)
+          console.error(`  or ${monthKey} is the current month and no daily counter exists yet.`)
+          console.error(`  --allow-partial buys a narrower chart, never an empty one. Nothing to render.`)
+          process.exit(1)
+        }
+        if (gate.action === 'refuse') {
+          console.error(`✗ Heatmap coverage gap: ${msg}`)
+          console.error(`  ${explainWindow(monthKey, today)}`)
+          console.error(`  If the gap is genuine, re-run with --allow-partial to render a narrower chart on purpose.`)
+          process.exit(1)
+        }
+        console.warn(`⚠ Heatmap coverage gap: ${msg} — rendering a partial chart (--allow-partial)`)
       }
 
-      // Detect last day with data
-      let lastDataDay = daysInMonth
-      for (let d = daysInMonth; d >= monitoringStartDay; d--) {
-        const key = `${monthKey}-${String(d).padStart(2, '0')}`
-        if (history[key]) { lastDataDay = d; break }
+      // The gate above guarantees at least one day has data, so dataSpan cannot return null;
+      // fail loudly rather than render a chart from a span we did not compute.
+      const span = dataSpan(history, monthKey, daysInMonth)
+      if (!span) {
+        console.error(`✗ Internal: coverage gate passed but no day of ${monthKey} carries data.`)
+        process.exit(1)
       }
+      const { firstDataDay, lastDataDay } = span
 
       // Roster = services that EXISTED in the report month (that month's archive keys),
       // not the current live CATEGORY_ORDER — otherwise services added AFTER the month
-      // (e.g. turbopuffer / Twelve Labs for a June report) render as blank "Added Later"
+      // (e.g. turbopuffer / Twelve Labs for a June report) render as blank gray
       // rows (aiwatch-reports#63). Score-excluded-but-existed services stay (the criterion
       // is archive membership, not "has a score"). Fail-open to the full list if absent.
       const monthArchive = readDataArchive(monthKey, path.resolve('_data'))
@@ -835,14 +1020,16 @@ if (require.main === module) {
       )
       const serviceNames = rosterIds.map(id => ID_TO_NAME[id]).filter(Boolean)
 
-      const heatmapSvg = generateUptimeHeatmapSvg(serviceNames, history, daysInMonth, monthKey, monitoringStartDay, lastDataDay)
+      const heatmapSvg = generateUptimeHeatmapSvg(serviceNames, history, daysInMonth, monthKey, firstDataDay, lastDataDay)
       const heatmapPath = path.join(outDir, 'uptime-heatmap.svg')
       fs.writeFileSync(heatmapPath, heatmapSvg + '\n', 'utf-8')
       console.log(`✓ ${heatmapPath}`)
-      console.log(`\nDone! Monitoring data: day ${monitoringStartDay}–${lastDataDay} (${lastDataDay - monitoringStartDay + 1} days)`)
+      console.log(`\nDone! Heatmap span: ${monthKey}-${String(firstDataDay).padStart(2, '0')} … ${monthKey}-${String(lastDataDay).padStart(2, '0')} (${lastDataDay - firstDataDay + 1} days)`)
     })
     .catch(err => {
-      console.error('Failed to fetch uptime data:', err.message)
+      // This catch spans the whole chain, not just the network call — a write EACCES or a render
+      // throw lands here too. Stay neutral rather than sending the reader after the network.
+      console.error('✗ Heatmap generation failed:', err.message)
       process.exit(1)
     })
 }

--- a/scripts/generate-charts.test.js
+++ b/scripts/generate-charts.test.js
@@ -3,8 +3,12 @@ const {
   monthsBefore, buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta,
   generateTrendSvg, toMonthEntry, monthEntryFromScoreRows, rosterForMonth, spreadLabelYs,
   buildMoverExclude, notableMoversForChart,
+  uptimeLookbackDays, uptimeLookbackSpan, explainWindow, missingMonthDays, elapsedMonthDays, hasDayData,
+  heatmapGate, describeMissing, dataSpan, daysInMonthOf, UPTIME_MAX_LOOKBACK_DAYS,
 } = require('./generate-charts')
 const assert = require('assert')
+const { spawnSync } = require('child_process')
+const path = require('path')
 
 let passed = 0
 let failed = 0
@@ -631,6 +635,413 @@ test('computeNotableMovers surfaces an MTTR-driven mover ONLY when the current e
   // Score-table-only current entry (the old bug path) → MTTR null → flat Score → NOT a mover
   const withRows = computeNotableMovers(buildTrendSeries([prior, rowsCurrent]))
   assert.ok(!withRows.some(m => m.id === 'gemini'), 'gemini vanishes when current entry lacks MTTR — why the CLI must use toMonthEntry')
+})
+
+// ── aiwatch-reports#77 — heatmap lookback window ──────────────────
+// The /api/uptime `days` param is a lookback anchored to TODAY. The old code passed
+// `daysInMonth`, so a chart built D days after month-end lost the month's first D days.
+
+const JUL10 = new Date(Date.UTC(2026, 6, 10)) // 2026-07-10
+
+test('uptimeLookbackDays reaches back to the month\'s first day', () => {
+  // June 1 → July 10 inclusive = 40 days. The old code passed 30 and started the chart on June 11.
+  assert.strictEqual(uptimeLookbackDays('2026-06', JUL10), 40)
+  assert.notStrictEqual(uptimeLookbackDays('2026-06', JUL10), 30, 'must not pass daysInMonth')
+})
+
+test('uptimeLookbackDays: generated on the last day of the month → exactly daysInMonth', () => {
+  // The one case where the old bug was invisible.
+  assert.strictEqual(uptimeLookbackDays('2026-06', new Date(Date.UTC(2026, 5, 30))), 30)
+})
+
+test('uptimeLookbackDays: generated on the 1st → 1 day (in-progress month)', () => {
+  assert.strictEqual(uptimeLookbackDays('2026-07', new Date(Date.UTC(2026, 6, 1))), 1)
+})
+
+test('uptimeLookbackDays regressions the months the bug actually truncated', () => {
+  // April and May were both generated after month-end, so days=daysInMonth landed the window
+  // mid-month: April's chart starts on the 5th, May's on the 3rd, while their headers read
+  // "April 1–30" / "May 1–31". These are the windows those runs SHOULD have requested.
+  assert.strictEqual(uptimeLookbackDays('2026-04', new Date(Date.UTC(2026, 4, 4))), 34) // Apr 1 → May 4
+  assert.strictEqual(uptimeLookbackDays('2026-05', new Date(Date.UTC(2026, 5, 2))), 33) // May 1 → Jun 2
+})
+
+test('March is NOT a victim — its late start was real, not truncation', () => {
+  // The first March chart (git 3aa29a2, committed 2026-03-27) is subtitled "March 20–27". With
+  // days=31 its window reached back to 2026-02-25 — it COULD see March 1–19 and found nothing.
+  // Monitoring genuinely began 2026-03-20, and the report header says so ("Period: March 20–31").
+  const firstGen = new Date(Date.UTC(2026, 2, 27))
+  assert.strictEqual(uptimeLookbackSpan('2026-03', firstGen), 27, 'the window already reached March 1')
+  assert.ok(uptimeLookbackSpan('2026-03', firstGen) < 31, 'days=31 over-reached into February')
+})
+
+test('uptimeLookbackDays clamps to the endpoint cap', () => {
+  const farFuture = new Date(Date.UTC(2027, 0, 1))
+  assert.strictEqual(uptimeLookbackDays('2026-06', farFuture), UPTIME_MAX_LOOKBACK_DAYS)
+})
+
+test('uptimeLookbackDays rejects a month that has not started', () => {
+  assert.throws(() => uptimeLookbackDays('2026-08', JUL10), /has not started/)
+})
+
+test('uptimeLookbackDays rejects a malformed monthKey', () => {
+  assert.throws(() => uptimeLookbackDays('2026-13', JUL10), /invalid monthKey/)
+  assert.throws(() => uptimeLookbackDays('nonsense', JUL10), /invalid monthKey/)
+})
+
+test('window errors carry no internal fn name — the CLI already prefixes them', () => {
+  // The CLI prints `✗ Cannot determine the uptime window: ${err.message}`; a `uptimeLookbackSpan:`
+  // prefix inside the message produced a double-prefixed line naming a helper the operator
+  // cannot act on.
+  for (const bad of ['2026-13', '2027-01']) {
+    assert.throws(() => uptimeLookbackDays(bad, JUL10), err => !/uptimeLookback/.test(err.message))
+  }
+})
+
+// ── coverage gate ────────────────────────────────────────────────
+
+const fullJune = Object.fromEntries(
+  Array.from({ length: 30 }, (_, i) => [`2026-06-${String(i + 1).padStart(2, '0')}`, { claude: {} }]),
+)
+
+test('missingMonthDays: full coverage → no gap', () => {
+  assert.deepStrictEqual(missingMonthDays(fullJune, '2026-06', 30, JUL10), [])
+})
+
+test('missingMonthDays names the exact days the old bug dropped', () => {
+  const truncated = { ...fullJune }
+  for (let d = 1; d <= 9; d++) delete truncated[`2026-06-0${d}`]
+  const missing = missingMonthDays(truncated, '2026-06', 30, JUL10)
+  assert.strictEqual(missing.length, 9)
+  assert.strictEqual(missing[0], '2026-06-01')
+  assert.strictEqual(missing[8], '2026-06-09')
+})
+
+test('missingMonthDays: an interior hole is a gap too', () => {
+  const holed = { ...fullJune }
+  delete holed['2026-06-15']
+  assert.deepStrictEqual(missingMonthDays(holed, '2026-06', 30, JUL10), ['2026-06-15'])
+})
+
+test('missingMonthDays: future days of an in-progress month are not missing', () => {
+  const julSoFar = Object.fromEntries(
+    Array.from({ length: 10 }, (_, i) => [`2026-07-${String(i + 1).padStart(2, '0')}`, { claude: {} }]),
+  )
+  // July has 31 days; only 1–10 have happened. No gap.
+  assert.deepStrictEqual(missingMonthDays(julSoFar, '2026-07', 31, JUL10), [])
+  // Drop July 3 → that one IS missing.
+  delete julSoFar['2026-07-03']
+  assert.deepStrictEqual(missingMonthDays(julSoFar, '2026-07', 31, JUL10), ['2026-07-03'])
+})
+
+// ── subtitle honesty ─────────────────────────────────────────────
+
+test('heatmap subtitle states the span actually rendered, not the whole month', () => {
+  const names = ['Claude']
+  // Starts on the 1st but ends on the 20th (in-progress month rendered with --allow-partial).
+  const svg = generateUptimeHeatmapSvg(names, fullJune, 30, '2026-06', 1, 20)
+  assert.ok(svg.includes('June 1–20'), 'must say 1–20')
+  assert.ok(!svg.includes('June 1–30'), 'old code printed 1–daysInMonth whenever it started on the 1st')
+})
+
+test('heatmap subtitle covers the full month when data does', () => {
+  const svg = generateUptimeHeatmapSvg(['Claude'], fullJune, 30, '2026-06', 1, 30)
+  assert.ok(svg.includes('June 1–30'))
+})
+
+test('elapsedMonthDays: a finished month is fully elapsed', () => {
+  assert.strictEqual(elapsedMonthDays('2026-06', 30, JUL10), 30)
+})
+
+test('elapsedMonthDays: an in-progress month stops at today', () => {
+  assert.strictEqual(elapsedMonthDays('2026-07', 31, JUL10), 10)
+})
+
+test('zero coverage is distinguishable from a partial gap', () => {
+  // The guard the CLI uses: missing.length === elapsedMonthDays → nothing at all was fetched.
+  // A month past retention returns no days; --allow-partial must not paint 31 gray columns
+  // captioned as the full month.
+  const none = missingMonthDays({}, '2026-03', 31, JUL10)
+  assert.strictEqual(none.length, elapsedMonthDays('2026-03', 31, JUL10), 'all 31 days missing = zero coverage')
+
+  const partial = { ...fullJune }
+  for (let d = 1; d <= 9; d++) delete partial[`2026-06-0${d}`]
+  assert.notStrictEqual(missingMonthDays(partial, '2026-06', 30, JUL10).length, elapsedMonthDays('2026-06', 30, JUL10))
+})
+
+test('explainWindow distinguishes the endpoint cap from a data hole', () => {
+  // 2026-04 on 2026-07-10 needs a 101-day lookback → clamped → first 11 days unreachable.
+  // Assert the load-bearing NUMBERS and the two-way classifier token, not the exact prose.
+  const clamped = explainWindow('2026-04', JUL10)
+  assert.match(clamped, /101/)          // the uncapped span it needed
+  assert.match(clamped, /11/)           // the days it cannot reach
+  assert.match(clamped, /unreachable/)  // classifier: the endpoint's ?days= cap
+
+  // 2026-06 needs 40 days — inside retention, so any gap is the data's fault, not the window's.
+  const inside = explainWindow('2026-06', JUL10)
+  assert.match(inside, /40/)
+  assert.ok(!/unreachable/.test(inside), 'classifier: not a cap')
+})
+
+test('uptimeLookbackSpan is uncapped; uptimeLookbackDays is capped', () => {
+  assert.strictEqual(uptimeLookbackSpan('2026-04', JUL10), 101)
+  assert.strictEqual(uptimeLookbackDays('2026-04', JUL10), UPTIME_MAX_LOOKBACK_DAYS)
+  // Below the cap the two agree.
+  assert.strictEqual(uptimeLookbackSpan('2026-06', JUL10), uptimeLookbackDays('2026-06', JUL10))
+})
+
+// ── a day key that exists but carries nothing must not count as coverage ─────
+// Two reviewers found this independently: `{}` is truthy, so a `!history[key]` gate would pass a
+// month of empty days and render a full grid of gray columns at exit 0 — reintroducing
+// the very silent failure #77 exists to remove.
+
+test('hasDayData rejects every empty shape', () => {
+  for (const empty of [undefined, null, {}, [], 0, '', false]) {
+    assert.strictEqual(hasDayData(empty), false, `${JSON.stringify(empty)} must not count as data`)
+  }
+  assert.strictEqual(hasDayData({ claude: { up: 288, total: 288 } }), true)
+})
+
+test('a month of {} day-entries is zero coverage, not full coverage', () => {
+  const allEmpty = Object.fromEntries(
+    Array.from({ length: 31 }, (_, i) => [`2026-03-${String(i + 1).padStart(2, '0')}`, {}]),
+  )
+  // The old truthiness check would have found 0 missing days here.
+  assert.strictEqual(Object.keys(allEmpty).filter(k => !allEmpty[k]).length, 0)
+  // The gate must see all 31 as missing → zero coverage → refuse even with --allow-partial.
+  const missing = missingMonthDays(allEmpty, '2026-03', 31, JUL10)
+  assert.strictEqual(missing.length, 31)
+  assert.strictEqual(missing.length, elapsedMonthDays('2026-03', 31, JUL10), 'zero coverage')
+})
+
+test('a single hollow day inside an otherwise full month is a gap', () => {
+  const holed = { ...fullJune, '2026-06-15': {} }
+  assert.deepStrictEqual(missingMonthDays(holed, '2026-06', 30, JUL10), ['2026-06-15'])
+})
+
+// ── one clock for the whole run ──────────────────────────────────────────────
+test('the three window fns agree when handed the same `today`', () => {
+  // They each default to `new Date()`; the CLI threads one captured clock through all of them so a
+  // midnight-UTC crossing during the 30s fetch cannot split the window from the coverage check.
+  const midnightish = new Date(Date.UTC(2026, 6, 10, 23, 59, 59))
+  assert.strictEqual(uptimeLookbackDays('2026-06', midnightish), 40)
+  assert.strictEqual(elapsedMonthDays('2026-06', 30, midnightish), 30)
+  assert.deepStrictEqual(missingMonthDays(fullJune, '2026-06', 30, midnightish), [])
+})
+
+test('an uncomputable uptime ratio renders gray, never red', () => {
+  // Absence must not be painted as an outage. {} and {ok:0,total:0} both give NaN.
+  const GRAY = '#21262d', RED = '#ef4444', GREEN = '#3fb950'
+  // Key on the cell's semantic signature (cellSize=16), NOT its x-position: an x-anchored regex
+  // silently latches onto a legend swatch when padding or labelWidth changes.
+  const cellColor = dayValue => {
+    const svg = generateUptimeHeatmapSvg(['Claude'], { '2026-06-01': dayValue }, 1, '2026-06', 1, 1)
+    const cells = [...svg.matchAll(/<rect [^>]*width="16"[^>]*fill="(#[0-9a-f]{6})"/g)]
+    assert.strictEqual(cells.length, 1, 'exactly one data cell for a 1-service 1-day heatmap')
+    return cells[0][1]
+  }
+  assert.strictEqual(cellColor({ claude: { ok: 288, total: 288 } }), GREEN)
+  assert.strictEqual(cellColor({ claude: {} }), GRAY, '{} used to render RED via NaN')
+  assert.strictEqual(cellColor({ claude: { ok: 0, total: 0 } }), GRAY, '0/0 is NaN, not an outage')
+  assert.strictEqual(cellColor({ claude: null }), GRAY)
+  // A genuine outage still renders red.
+  assert.strictEqual(cellColor({ claude: { ok: 0, total: 288 } }), RED)
+})
+
+// ── the gate's ORDER is the contract (aiwatch-reports#77) ────────────────────
+// The predicate tests above prove zero-coverage is *distinguishable* from a partial gap. These
+// prove the CLI's decision consults it FIRST. A refactor letting --allow-partial short-circuit
+// ahead of the zero-coverage check would render an empty chart captioned as a full month — the
+// exact silent failure #77 exists to kill — while every other test stayed green.
+
+const partialJune = (() => {
+  const h = { ...fullJune }
+  for (let d = 1; d <= 9; d++) delete h[`2026-06-0${d}`]
+  return h
+})()
+
+test('gate: zero coverage refuses even WITH --allow-partial', () => {
+  const v = heatmapGate({}, '2026-03', 31, JUL10, { allowPartial: true })
+  assert.strictEqual(v.action, 'refuse')
+  assert.strictEqual(v.reason, 'zero-coverage', 'the flag must not reclassify this as partial')
+})
+
+test('gate: a partial gap refuses WITHOUT the flag, renders WITH it', () => {
+  assert.strictEqual(heatmapGate(partialJune, '2026-06', 30, JUL10, { allowPartial: false }).action, 'refuse')
+  const allowed = heatmapGate(partialJune, '2026-06', 30, JUL10, { allowPartial: true })
+  assert.strictEqual(allowed.action, 'render')
+  assert.strictEqual(allowed.reason, 'partial', 'a rendered partial chart must still be labelled partial')
+})
+
+test('gate: full coverage renders with no flag and reports `complete`', () => {
+  const v = heatmapGate(fullJune, '2026-06', 30, JUL10)
+  assert.strictEqual(v.action, 'render')
+  assert.strictEqual(v.reason, 'complete')
+  assert.deepStrictEqual(v.missing, [])
+})
+
+test('gate: a month of {} entries is zero coverage, not full coverage', () => {
+  const hollow = Object.fromEntries(
+    Array.from({ length: 30 }, (_, i) => [`2026-06-${String(i + 1).padStart(2, '0')}`, {}]),
+  )
+  assert.strictEqual(heatmapGate(hollow, '2026-06', 30, JUL10, { allowPartial: true }).reason, 'zero-coverage')
+})
+
+test('gate: a response carrying only adjacent-month days is zero coverage', () => {
+  // The most operationally likely "API returned something, but nothing usable" case.
+  const wrongMonth = { '2026-05-30': { claude: { ok: 288, total: 288 } }, '2026-07-01': { claude: { ok: 1, total: 1 } } }
+  const v = heatmapGate(wrongMonth, '2026-06', 30, JUL10, { allowPartial: true })
+  assert.strictEqual(v.reason, 'zero-coverage')
+  assert.strictEqual(v.missing.length, 30)
+})
+
+test('describeMissing names one day without an ellipsis, many with a span', () => {
+  assert.strictEqual(describeMissing(['2026-06-15'], '2026-06'), '1 day of 2026-06 absent from the API response (2026-06-15)')
+  assert.match(describeMissing(['2026-06-01', '2026-06-02'], '2026-06'), /^2 days .*\(2026-06-01 … 2026-06-02\)/)
+})
+
+test('describeMissing is total — an empty list never prints "(undefined)"', () => {
+  for (const empty of [[], null, undefined]) {
+    const out = describeMissing(empty, '2026-06')
+    assert.ok(!/undefined/.test(out), `describeMissing(${JSON.stringify(empty)}) leaked undefined: ${out}`)
+  }
+})
+
+// ── calendar edges ───────────────────────────────────────────────────────────
+
+test('daysInMonthOf handles leap February', () => {
+  assert.strictEqual(daysInMonthOf('2024-02'), 29)
+  assert.strictEqual(daysInMonthOf('2026-02'), 28)
+})
+
+test('uptimeLookbackSpan spans a leap February correctly', () => {
+  assert.strictEqual(uptimeLookbackSpan('2024-02', new Date(Date.UTC(2024, 2, 1))), 30) // 29 + Mar 1
+})
+
+test('monthKey must be zero-padded — an unpadded key silently mismatches history', () => {
+  // `2026-6` passes the 1..12 range check but builds `2026-6-01` keys that match nothing.
+  // Documented, not supported: the CLI derives monthKey from a 2-digit directory name.
+  const missing = missingMonthDays({ '2026-06-01': { claude: { ok: 1, total: 1 } } }, '2026-6', 30, JUL10)
+  assert.strictEqual(missing[0], '2026-6-01', 'keys are built from the caller\'s monthKey verbatim')
+})
+
+test('elapsedMonthDays on the 1st of the month is 1', () => {
+  assert.strictEqual(elapsedMonthDays('2026-07', 31, new Date(Date.UTC(2026, 6, 1))), 1)
+})
+
+// ── subtitle: the late-START half of the contract ────────────────────────────
+
+test('heatmap subtitle states a LATE start span', () => {
+  const svg = generateUptimeHeatmapSvg(['Claude'], fullJune, 30, '2026-06', 12, 30)
+  assert.ok(svg.includes('June 12–30'), 'a --allow-partial chart must name its true start')
+  assert.ok(!svg.includes('June 1–30'))
+})
+
+// ── CLI early-exit paths (spawn) ─────────────────────────────────────────────
+// Everything below `require.main === module` is otherwise untested. These three exits happen
+// BEFORE the network fetch, so they need no report file, no fixture, and no mock. The coverage
+// gate itself is covered by heatmapGate's unit tests above — the CLI only prints its verdict.
+
+const SCRIPT = path.join(__dirname, 'generate-charts.js')
+const runCli = (...args) => spawnSync(process.execPath, [SCRIPT, ...args], { encoding: 'utf8', cwd: path.dirname(__dirname) })
+
+test('CLI rejects an unknown flag with exit 1', () => {
+  const r = runCli('--allow-parital', '2026-05/index.md')  // a plausible typo
+  assert.strictEqual(r.status, 1)
+  assert.match(r.stderr, /Unknown option\(s\): --allow-parital/)
+})
+
+test('CLI with no report path exits 1 and prints usage', () => {
+  const r = runCli('--allow-partial')
+  assert.strictEqual(r.status, 1)
+  assert.match(r.stderr, /Usage: node scripts\/generate-charts\.js/)
+  assert.match(r.stderr, /--allow-partial/, 'usage must document the flag')
+})
+
+test('CLI accepts the flag in either position', () => {
+  // Both orderings must reach the same next failure (a missing report file), not an arg-parse error.
+  for (const args of [['--allow-partial', 'nope-9999-99/index.md'], ['nope-9999-99/index.md', '--allow-partial']]) {
+    const r = runCli(...args)
+    assert.strictEqual(r.status, 1)
+    assert.match(r.stderr, /Cannot read report file/, `argv order ${args.join(' ')} must parse`)
+    assert.ok(!/Unknown option/.test(r.stderr))
+  }
+})
+
+test('the gray legend names the color by what it means, not one of its causes', () => {
+  const svg = generateUptimeHeatmapSvg(['Claude'], fullJune, 30, '2026-06', 1, 30)
+  assert.ok(svg.includes('No data'), 'gray covers mid-month onboarding AND unmeasured days')
+  assert.ok(!svg.includes('Added Later'), 'the old label named only the onboarding case')
+})
+
+test('explainWindow never claims more lost days than the month has', () => {
+  // span - CAP counts days before the window opens; for a month that ended before the window even
+  // begins it exceeds daysInMonth. "the first 42 days of 2026-03" is not a sentence about March.
+  const march = explainWindow('2026-03', JUL10)
+  assert.match(march, /all 31 days of 2026-03/)
+  assert.ok(!/first 42/.test(march))
+  assert.ok(!/first \d+ days? of 2026-03/.test(march), 'a wholly-unreachable month is not "the first N"')
+
+  // A partially-reachable month still reports its leading gap. Pin the COUNT, not the adverb.
+  assert.match(explainWindow('2026-04', JUL10), /the first 11 days of 2026-04 are/)
+})
+
+test('explainWindow uses a singular noun for a one-day gap', () => {
+  // 2026-04 seen on 2026-06-30: span = 91, cap 90 → exactly one day lost.
+  const oneDay = explainWindow('2026-04', new Date(Date.UTC(2026, 5, 30)))
+  assert.match(oneDay, /the first day of 2026-04 is/)
+  assert.ok(!/the first 1 day/.test(oneDay), '"the first 1 day" is stilted; the count is redundant at 1')
+  assert.ok(!/day of 2026-04 are/.test(oneDay), 'noun agreed but the verb did not')
+})
+
+// ── dataSpan: the span rendered must equal the span that has data ────────────
+
+test('dataSpan finds a late start and a full end', () => {
+  const h = { ...fullJune }
+  for (let d = 1; d <= 11; d++) delete h[`2026-06-${String(d).padStart(2, '0')}`]
+  assert.deepStrictEqual(dataSpan(h, '2026-06', 30), { firstDataDay: 12, lastDataDay: 30 })
+})
+
+test('dataSpan stops at today for an in-progress month', () => {
+  const h = Object.fromEntries(Array.from({ length: 10 }, (_, i) => [`2026-07-${String(i + 1).padStart(2, '0')}`, { claude: {} , x: {} }]))
+  assert.deepStrictEqual(dataSpan(h, '2026-07', 31), { firstDataDay: 1, lastDataDay: 10 })
+})
+
+test('dataSpan treats a hollow leading day as absent, like the gate does', () => {
+  // If this used a truthy check instead of hasDayData, firstDataDay would be 1 and the chart would
+  // open with an all-gray column the gate had already declared missing.
+  const h = { ...fullJune, '2026-06-01': {}, '2026-06-02': {} }
+  assert.strictEqual(dataSpan(h, '2026-06', 30).firstDataDay, 3)
+})
+
+test('dataSpan returns null when nothing has data', () => {
+  assert.strictEqual(dataSpan({}, '2026-06', 30), null)
+})
+
+test('dataSpan handles a single day of data', () => {
+  assert.deepStrictEqual(dataSpan({ '2026-06-17': { claude: {} } }, '2026-06', 30), { firstDataDay: 17, lastDataDay: 17 })
+})
+
+// ── explainWindow arithmetic boundaries ─────────────────────────────────────
+
+test('explainWindow: lost === daysInMonth - 1 still says "the first N", not "all"', () => {
+  // 2026-05 seen on 2026-08-28: span 120, lost = min(30, 31) = 30 — one day short of the whole month.
+  const almost = explainWindow('2026-05', new Date(Date.UTC(2026, 7, 28)))
+  assert.match(almost, /the first 30 days of 2026-05/)
+  assert.ok(!/all 31 days/.test(almost), 'the last day is still reachable')
+  // One day later it flips.
+  assert.match(explainWindow('2026-05', new Date(Date.UTC(2026, 7, 29))), /all 31 days of 2026-05/)
+})
+
+test('explainWindow: a leap February past the window reports 29 days', () => {
+  assert.match(explainWindow('2024-02', new Date(Date.UTC(2024, 6, 1))), /all 29 days of 2024-02/)
+})
+
+test('explainWindow: span exactly at the cap is inside the window, span+1 is not', () => {
+  // 2026-04's first day is exactly 90 days before 2026-06-29 → span 90 → within.
+  assert.strictEqual(uptimeLookbackSpan('2026-04', new Date(Date.UTC(2026, 5, 29))), 90)
+  assert.ok(!/unreachable/.test(explainWindow('2026-04', new Date(Date.UTC(2026, 5, 29)))))
+  assert.match(explainWindow('2026-04', new Date(Date.UTC(2026, 5, 30))), /unreachable/)
 })
 
 // ── Summary ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`generate-charts.js` fetched uptime history with `?days=daysInMonth`, but the endpoint's `days` is a **lookback anchored to today**, not a count of the month's days. So a chart built D days after month-end silently lost the month's first D days — every published month is affected (April "5–30", May "3–31", June "10–30") while each report header claims the full month.

Verified via git: the first March chart (`March 20–27`, generated with a window reaching back to Feb 25) proves March's late start was **genuine** monitoring, not truncation — the bug hit April/May/June.

## Fix

- `uptimeLookbackDays` derives the window from the month's first day, clamped to the 90-day endpoint/TTL window; `missingMonthDays`/`elapsedMonthDays` gate coverage.
- `heatmapGate` refuses a coverage gap (exit 1) unless `--allow-partial`, and refuses **zero** coverage regardless of the flag (a partial chart is narrow, never empty).
- `hasDayData`: a `{}` day-entry no longer counts as coverage; `dataSpan` renders a non-finite uptime ratio **gray** (absence), not red (outage).
- `explainWindow` distinguishes the endpoint cap from an in-window hole; CI gains an `allow_partial` dispatch input; legend "Added Later" → "No data".

## Tests

123 tests. The original bug is mutation-verified (revert `uptimeLookbackDays` → 9 fail). Reviewed to 0 Critical/Important across three rounds.

## Merge order

First of four generator PRs (they overlap in `generate-charts.js` exports): **#77 → #75 → #78 → #993-report**. Rebase each onto the prior; expect a mechanical export-block conflict.

Refs #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)