### PR TITLE
fix(report): purge reader-facing prose that drifted from the worker (refs #75)

### DIFF
--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -13,6 +13,8 @@ published: true
 
 ## Summary
 
+> Every score in this report is the **AIWatch Score** (0–100): one number combining uptime, incident load, recovery speed and responsiveness. Higher is better. [How it's built →](#[SCORE_ANCHOR])
+
 - **Most reliable**:
 - **Riskiest this month**:
 - **High incident count, fast recovery**:
@@ -82,7 +84,7 @@ published: true
 
 > *"Which AI service is safest to rely on in production?"*
 
-Combines four components — Uptime (40%), Incident affected days (25%), Recovery speed (15%), Responsiveness (20%, derived from p75 probe RTT). The per-service p75 RTT figures feeding Responsiveness are listed in the [API Response Time — Monthly p75](#api-response-time--monthly-p75) section below; full breakdown of weights, fallbacks, and penalties is in [About This Report](#about-this-report). [How it's calculated →](https://ai-watch.dev/#about-score)
+Combines four components — Uptime (40%), Incident affected days (25%), Recovery speed (15%), Responsiveness (20%, derived from each service's median (p50) probe RTT and its RTT stability). The [API Response Time — Monthly p75](#api-response-time--monthly-p75) table below is a separate network-latency reference, not the Responsiveness input; full breakdown of weights, fallbacks, and penalties is in [About This Report → AIWatch Score](#about-this-report). [How it's calculated →](https://ai-watch.dev/#about-score)
 
 <!-- SCORE_RANKING_NOTE -->
 
@@ -95,8 +97,8 @@ Combines four components — Uptime (40%), Incident affected days (25%), Recover
 <!-- Generate with: node scripts/generate-charts.js [YYYY-MM]/index.md -->
 ![AIWatch Score Rankings](../assets/[YYYY-MM]/score-chart.svg)
 
-> **Uptime Source column**: **Official** (read directly from the service's status page) · **No official uptime** (the provider publishes none; the Score is computed from the remaining signals) · **Partial (Nd)** (service newly tracked mid-month). Full definitions: [About This Report → Uptime Source](#about-this-report).
-> <!-- Cycle-specific notes (e.g. "Codex was added on 22 Apr, mid-month") can be appended after the Partial label. Keep this caption short — full definitions live in the About This Report methodology section to avoid duplication. -->
+> **Uptime Source column**: **Official** (read directly from the service's status page) · **No official uptime** (the provider publishes none; the Score is computed from the remaining signals). A service tracked for less than the full month is excluded from the ranking, not labelled — see the note above the table. Full definitions: [About This Report → Uptime Source](#about-this-report).
+> <!-- Keep this caption short — full definitions live in the About This Report methodology section to avoid duplicating them here. -->
 
 ---
 
@@ -119,13 +121,10 @@ Combines four components — Uptime (40%), Incident affected days (25%), Recover
 
 ## API Response Time — Monthly p75
 
-<!-- Anchor below: substitute [month]/[year] with lowercase values (e.g. "april", "2026").
-     Jekyll/Kramdown collapses the heading's em-dash (`— `) into a double hyphen in the
-     slug — so the final anchor is e.g. "#aiwatch-score--april-2026-reliability-rankings". -->
-These p75 figures are the input to the **Responsiveness** component (20% weight) of [AIWatch Score](#aiwatch-score--[month]-[year]-reliability-rankings). Lower is better. The two tables answer different questions: Score Rankings sorts by *which service is safest to rely on* (combining uptime, incidents, recovery, and responsiveness); this table sorts by *which service is fastest at the network layer*.
+These p75 figures are a network-latency reference: direct API-endpoint round-trip time, probed from the Cloudflare Workers edge every 5 minutes — not inference latency. Lower is better. They are **not** the Score's Responsiveness input, which reads each service's median (p50) probe RTT and its stability. So this table ranks *which service is fastest on the network*, while [AIWatch Score](#[SCORE_ANCHOR]) ranks *which is safest to rely on*. A service AIWatch does not probe has no row here; that alone does not drop it from the Score ranking.
 
 <!-- Data source: curl https://api.ai-watch.dev/api/probe/history?days=30 -->
-<!-- 31 probe targets (30 API services incl. twelvelabs + cursor). Non-probe API services (Bedrock, Azure OpenAI, Modal) excluded. -->
+<!-- 32 probe targets: 30 API services (incl. twelvelabs) + cursor (coding agent) + characterai (app, detail-card only, aiwatch#921). A service AIWatch does not probe simply has no row here (13 of 41 in June 2026, ten of them ranked); that alone does not affect its Score. -->
 <!-- p95 + Spikes are present in probe:daily:{date} (CLAUDE.md KV schema) but not yet
      surfaced by /api/report. vs-Last-Month additionally requires reading the previous
      month's archive:monthly:* and computing deltas. Re-add the columns once the
@@ -135,7 +134,6 @@ These p75 figures are the input to the **Responsiveness** component (20% weight)
 |---|---|---|
 | 1 | | |
 
-> **Note**: Probe RTT measures direct API endpoint response time from Cloudflare Workers edge (5-min intervals). Values reflect network round-trip time, not inference latency. Services without probe coverage (Bedrock, Azure OpenAI, Modal) are excluded from rankings.
 
 ---
 
@@ -149,7 +147,7 @@ These p75 figures are the input to the **Responsiveness** component (20% weight)
 
 ## Incident Summary
 
-> **Reading the count column**: Incident counts reflect all affected components per service, so providers that report per-model (e.g., Anthropic counts Opus / Sonnet / Haiku separately) show inflated totals vs. providers that report at the service level. Higher count ≠ lower reliability — adjust for granularity before comparing across providers. Full provider-by-provider rules: [About This Report → Incident Counting](#about-this-report).
+> **Reading the count column**: The count is how many incidents a provider published for that service. Granularity differs — Anthropic posts a separate incident per model ("Elevated errors for Claude Opus 4.7", "Degraded performance for Claude Sonnet 4.6"), and Together AI's status page tracks each model as its own resource — so both show higher totals than providers that post one incident per event. Higher count ≠ lower reliability — adjust for granularity before comparing across providers. Full provider-by-provider rules: [About This Report → Incident Counting](#about-this-report).
 >
 > <!-- Cycle-specific data notes (excluded incidents, anomalies) go here. -->
 
@@ -210,10 +208,11 @@ Actionable takeaways per service. Descriptive context for each event lives in ea
 
 * **Data Sources:** Real-time data is aggregated from official status pages via multiple frameworks, including Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, OnlineOrNot, and RSS feeds (Source: [ai-watch.dev](https://ai-watch.dev)).
 * **Monitoring Frequency:** All 43 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
-* **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). Services without probe data use 80→100 score redistribution **plus a 5% penalty** to reflect the missing responsiveness signal. Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
-* **Uptime Source:** *Official* = the service publishes a rolling uptime % that AIWatch reads directly from its status page (the window varies by page — 30 or 90 days). *No official uptime* = the provider publishes no comparable figure. AIWatch **invents none**: the Score simply drops its 40-point Uptime component and is rescaled over the remaining signals (incidents, recovery, responsiveness), so these services are scored — and ranked — on what can actually be measured. *Partial (Nd)* = an official source exists but AIWatch's measurement window is shorter than the full month (e.g. service newly tracked mid-month). The label describes the Uptime input, not the Score's rigour.
-* **Incident Counting:** Incident counts reflect all affected components per service. Providers differ in reporting granularity — Anthropic reports per-model incidents (Opus/Sonnet/Haiku each counted separately), while others report at the service level.
-* **Uptime Metrics:** Uptime percentages reflect official single-component figures provided by the status pages. Services marked with "—" do not provide a publicly accessible uptime metric.
+* **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). A service with no probe endpoint is scored on the remaining components rescaled to 100, with **no penalty**. A service that has a probe but fewer than 7 days of samples gets that same rescale **plus a 5% penalty** until its probe data matures. Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
+* **Uptime Source:** *Official* = the service publishes a rolling uptime % that AIWatch reads directly from its status page (the window varies by page — 30 or 90 days). *No official uptime* = the provider publishes no comparable figure. AIWatch **invents none**: the Score simply drops its 40-point Uptime component and is rescaled over the remaining signals (incidents, recovery, responsiveness), A service that still has a probe is scored and ranked on what can be measured; one with **neither** uptime **nor** a probe has too little signal, so its Score is withheld and it is not ranked. The note above the Score table names whichever services that is — the membership is read from the data, not fixed here. A service AIWatch tracked for only part of the month is **excluded from the ranking** rather than labelled (aiwatch-reports#45) — its partial-month Score would rest on insufficient coverage. The label describes the Uptime input, not the Score's rigour.
+* **Incident Counting:** Counts are the incidents each provider published, attributed to the service they affected. Providers differ in granularity, and in *where* that granularity lives: Anthropic maps to a single status-page component but posts one incident **per model**; Together AI tracks each model as its own **resource**, so one event can surface as several incidents. Others post one incident per event at the service level. Compare counts only across providers with comparable granularity.
+* **Uptime Metrics:** Uptime percentages are the official figure each status page exposes — read from the page directly, or aggregated by AIWatch from the per-component availabilities it publishes — for some services a single component, for others a worst-of across a component set, for others still an upstream platform average, depending on what the page exposes. Services marked with "—" publish no accessible uptime metric.
+* **Component Reliability:** A **different measurement** from every other uptime figure in this report — do not compare them. AIWatch polls each service's status page every 5 minutes and, per component, counts a poll as good **only** when that component reads `operational`; `degraded` and `partial outage` both count against it, with no weighting by incident severity (severity is recorded per *service*, not per component). The percentage is that ratio of good polls, over the days AIWatch could read the page. Only components AIWatch surfaces for that service are counted — billing, docs and compliance surfaces are excluded — and a service needs at least two of them to appear at all. The table lists only each service's **weakest** component, and only when it fell below 99.9%: it is a list of where to look, not a ranking of everything.
 * **Timezone Standard:** All timestamps are recorded in **UTC**.
 
 **Next report**: [NEXT_MONTH] [YEAR]

--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -203,7 +203,7 @@ function generateUptimeHeatmapSvg(serviceNames, uptimeHistory, daysInMonth, mont
     ].join('\n')
   }).join('\n')
   // Footnote
-  const footnote = `  <text x="${padding.left}" y="${height - 4}" fill="${COLORS.textMuted}" font-size="8" font-family="ui-monospace,monospace" opacity="0.7">Gray cells = service added after monitoring began (e.g., Amazon Bedrock, Azure OpenAI added Mar 25)</text>`
+  const footnote = `  <text x="${padding.left}" y="${height - 4}" fill="${COLORS.textMuted}" font-size="8" font-family="ui-monospace,monospace" opacity="0.7">Gray cells = no monitoring data for that service on that day (e.g. onboarded partway through the month)</text>`
 
   const [yr, mo] = monthKey.split('-').map(Number)
   const monthName = new Date(yr, mo - 1).toLocaleString('en-US', { month: 'long' })
@@ -407,19 +407,27 @@ function presentDelta(points, field) {
 // CHART (this file's CLI) must exclude the SAME services, so they live next to
 // computeNotableMovers and generate-report.js imports them from here.
 
-// Services with no reliable incident feed (aggregated event JSON / RSS only — a blank
-// incident count is monitoring coverage, not a verified zero). With neither an accessible
-// uptime metric nor trustworthy incident data there's nothing to score fairly, so they're
-// dropped from the Score ranking entirely. Matches the 2026-04
-// report's "29 of 31 ranked — Bedrock/Azure excluded" handling.
-const NO_INCIDENT_FEED = new Set(['bedrock', 'azureopenai'])
+// Services whose Score the WORKER WITHHOLDS: they publish no official uptime and have no latency
+// probe, so only 2 of the Score's 4 components are measurable and `score.ts` emits `null` at
+// `confidence: 'low'` rather than over-state a figure (aiwatch#713). Unrankable, and with no Score
+// there is nothing to trend, so they're dropped from the ranking, the Notable Movers table and the
+// trend chart alike.
+//
+// It was called NO_INCIDENT_FEED and justified as "no reliable incident feed (RSS only) — a blank
+// incident count is monitoring coverage, not a verified zero". That is false: `worker/src/services.ts`
+// gives bedrock the AWS Health public events JSON (aiwatch#677 — one event per incident, real start
+// and end timestamps) and azureopenai an Azure RSS feed; both are read and archived, and bedrock's
+// June 2026 archive carries a genuine incident. Their incidents are tracked. Their *uptime* is not.
+const SCORE_WITHHELD = new Set(['bedrock', 'azureopenai'])
 
-// Services whose status page migrated to a platform AIWatch can't reach server-side, so the
-// feed is FROZEN at the last reachable fetch — the incident count, uptime and Score reflect only
-// data up to that cutoff, NOT the full month. Unlike NO_INCIDENT_FEED these DO carry an "official"
-// uptime + an incident history, but both are STALE, which is more insidious: a partial-month count
-// reads as a verified low number and the frozen uptime reads as current. The guard surfaces a
-// caveat every report and stops a frozen zero-count from being labelled a "confirmed zero".
+// Services whose status feed is FROZEN at the last reachable fetch: the incident count and uptime
+// stop at that cutoff rather than covering the full month. The flag is cause-agnostic (DeepSeek's
+// page was bot-walled behind Flashduty, aiwatch#507; Character.AI's was deactivated, aiwatch#689/
+// #800) and reader-facing copy must not name a cause — we observe that a feed stopped, never why.
+// Unlike SCORE_WITHHELD these DO carry an "official" uptime + an incident history, which is more
+// insidious than having none: a partial-month count reads as a verified low number and the frozen
+// uptime reads as current. The guard surfaces a caveat every report and stops a frozen zero-count
+// from being labelled a "confirmed zero".
 //   • deepseek — migrated Atlassian Statuspage → Flashduty (~May 2026). REMOVED here as of June
 //     2026: AIWatch now reads the full Flashduty feed via a browser-rendered fetch (aiwatch#618),
 //     so DeepSeek (and the new DeepSeek App, aiwatch#619) are no longer frozen. From the June 2026
@@ -451,7 +459,7 @@ function isRecentlyAdded(s, period) {
 }
 
 // PURE. Build the set of service ids the Notable Movers table / trend chart must exclude
-// (services the Score ranking itself drops: NO_INCIDENT_FEED + stale source + mid-month-added).
+// (services the Score ranking itself drops: SCORE_WITHHELD + stale source + mid-month-added).
 // Keyed off `month`'s archive services. Fail-open: a null archive → empty set (the
 // computeNotableMovers "score at both ends" guard still filters mid-month / null-score services).
 function buildMoverExclude(archiveServices, month) {
@@ -459,7 +467,7 @@ function buildMoverExclude(archiveServices, month) {
   return new Set(
     Object.entries(archiveServices)
       .map(([id, data]) => ({ id, data }))
-      .filter(s => NO_INCIDENT_FEED.has(s.id) || isStaleSource(s) || isRecentlyAdded(s, month)) // reports#45 — partial-month delta is not a real mover
+      .filter(s => SCORE_WITHHELD.has(s.id) || isStaleSource(s) || isRecentlyAdded(s, month)) // reports#45 — partial-month delta is not a real mover
       .map(s => s.id),
   )
 }
@@ -711,7 +719,7 @@ module.exports = {
   buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta, loadTrendEntries,
   generateTrendSvg, spreadLabelYs, nameToId, ID_TO_NAME, TREND_MONTHS,
   // mover exclusion + chart-reshape (aiwatch-reports#67)
-  NO_INCIDENT_FEED, STALE_SOURCE, isStaleSource, isRecentlyAdded, buildMoverExclude, notableMoversForChart,
+  SCORE_WITHHELD, STALE_SOURCE, isStaleSource, isRecentlyAdded, buildMoverExclude, notableMoversForChart,
 }
 
 // ── CLI ──────────────────────────────────────────────────

--- a/scripts/generate-charts.test.js
+++ b/scripts/generate-charts.test.js
@@ -377,7 +377,7 @@ test('returns [] for a single month', () => {
   eq(computeNotableMovers(buildTrendSeries([NOTABLE_ENTRIES[2]])).length, 0)
 })
 
-test('excludes services the report does not rank (NO_INCIDENT_FEED / stale)', () => {
+test('excludes services the report does not rank (SCORE_WITHHELD / stale)', () => {
   // bedrock moves hard on every axis but is in the exclude set → must never surface as a mover,
   // mirroring the Score table's exclusion (else the trend contradicts the rest of the report).
   const withBedrock = NOTABLE_ENTRIES.map((e, i) => ({
@@ -535,15 +535,15 @@ test('generateTrendSvg emits two same-final-Score movers at different label ys (
 // ── buildMoverExclude (moved from generate-report.js, aiwatch-reports#67) ──
 console.log('\nbuildMoverExclude')
 
-test('excludes NO_INCIDENT_FEED / stale / recently-added, keeps established; null → empty', () => {
+test('excludes SCORE_WITHHELD / stale / recently-added, keeps established; null → empty', () => {
   const services = {
-    bedrock: { score: 90 },                             // NO_INCIDENT_FEED
+    bedrock: { score: 90 },                             // SCORE_WITHHELD
     deepseek: { score: 88, incidentSourceStale: true }, // stale (archive flag)
     fal: { score: 77, addedAt: '2026-06-24' },          // added IN the report month
     claude: { score: 71 },                              // established → kept
   }
   const ex = buildMoverExclude(services, '2026-06')
-  assert.ok(ex.has('bedrock'), 'bedrock (NO_INCIDENT_FEED) excluded')
+  assert.ok(ex.has('bedrock'), 'bedrock (SCORE_WITHHELD) excluded')
   assert.ok(ex.has('deepseek'), 'stale source excluded')
   assert.ok(ex.has('fal'), 'recently-added (addedAt in report month) excluded')
   assert.ok(!ex.has('claude'), 'established service kept')

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -31,7 +31,7 @@ const charts = require('./generate-charts')  // trend core (aiwatch-reports#41)
 // Mover-exclusion predicates now live in generate-charts.js (single source of truth) so the
 // Notable Movers TABLE (here) and the trend CHART (charts.js CLI) exclude the SAME services
 // (aiwatch-reports#67). Imported here; re-exported below so existing report.test.js callers work.
-const { NO_INCIDENT_FEED, isStaleSource, isRecentlyAdded } = charts
+const { SCORE_WITHHELD, isStaleSource, isRecentlyAdded } = charts
 
 const API_BASE = process.env.AIWATCH_API_BASE || 'https://aiwatch-worker.p2c2kbf.workers.dev'
 const TEMPLATE_PATH = path.join(__dirname, '..', '_templates', 'monthly-report.md')
@@ -59,7 +59,7 @@ const NO_PUBLIC_UPTIME = new Set([
 // stray "100.00%" row). Deliberately narrow: it must NOT grow back into the drifted taxonomy above.
 const NEVER_PUBLISHES_UPTIME = new Set(['bedrock', 'azureopenai'])
 
-// (NO_INCIDENT_FEED / STALE_SOURCE / isStaleSource / isRecentlyAdded moved to generate-charts.js
+// (SCORE_WITHHELD / STALE_SOURCE / isStaleSource / isRecentlyAdded moved to generate-charts.js
 // as the mover-exclusion single source of truth — aiwatch-reports#67; imported above.)
 
 // Services without direct probe coverage (excluded from API Response Time ranking).
@@ -141,6 +141,28 @@ function fmtDurationMin(mins) {
 
 function serviceName(id, meta) {
   return meta[id]?.name || id
+}
+
+// aiwatch-reports#74 — Kramdown's `generate_id`, reimplemented: delete every character outside
+// [A-Za-z0-9 -], turn spaces into hyphens, downcase. Leading digits are KEPT ("3-Month Trend" →
+// `3-month-trend`). The consequence people trip on: an em-dash is *deleted*, not replaced, so the
+// spaces around it survive and collapse into a DOUBLE hyphen — `AIWatch Score — June 2026 …`
+// becomes `#aiwatch-score--june-2026-…`. Same for `&`. Verified against all 22 heading ids Jekyll
+// emitted for the June 2026 report.
+function kramdownAnchor(heading) {
+  return [...heading]
+    .filter(c => /[A-Za-z0-9 -]/.test(c))
+    .join('')
+    .replace(/ /g, '-')
+    .toLowerCase()
+}
+
+/** Anchor of the first heading in `md` matching `re` (capture group 1 = the heading text).
+ *  Derived from the text that actually shipped, so it cannot drift from the heading. */
+function anchorForHeading(md, re) {
+  const m = md.match(re)
+  if (!m) throw new Error(`anchorForHeading: no heading matched ${re}`)
+  return kramdownAnchor(m[1])
 }
 
 // ── Ranking helpers ──────────────────────────────────────────────────
@@ -225,55 +247,96 @@ function confidence(svc) {
 // that had drifted in both directions. "Official" = the archive carries a status-page figure, which
 // is exactly when the Score consumed it; otherwise "No official uptime", mirroring the dashboard's
 // `noOfficialUptime` wording. The old "Estimate" value is gone with the estimate itself (aiwatch#713).
-// ("Partial (Nd)" for mid-month additions stays a manual edit; not derivable from the archive yet.)
+// There is deliberately NO third label. A "Partial (Nd)" label used to be hand-typed for a
+// mid-month addition, but reports#45 EXCLUDES such a service from the ranking outright, so the
+// label named a row that can no longer exist — and its one real use read "Partial (9-day)",
+// not the "(Nd)" the legend taught. Removed from the template with the rest of the drifted prose.
 function uptimeSourceLabel(svc, id = svc?.id) {
   const official = officialUptimeFor(svc, id)
   return official === null || official === undefined ? 'No official uptime' : 'Official'
 }
 
-// Ranking-exclusion note (#29). NO_INCIDENT_FEED services have neither an accessible uptime
-// metric nor a reliable incident feed, so they're dropped from the Score ranking and called
-// out above the table. Returns '' when none are excluded (the marker then collapses).
+// Ranking-exclusion note (#29). SCORE_WITHHELD services publish no official uptime and have no
+// latency probe, so the worker withholds their Score entirely; they're dropped from the ranking and
+// called out above the table. Returns '' when none are excluded (the marker then collapses).
 // Joins display names with " and " for two, commas otherwise.
 function joinNames(svcs, meta) {
   const names = svcs.map(s => serviceName(s.id, meta))
   return names.length === 2 ? names.join(' and ') : names.join(', ')
 }
 
+/**
+ * A service whose Score the worker withholds. aiwatch#713 withholds by emitting `score: null` at
+ * `scoreConfidence: 'low'` — so a modern archive marks these by DATA, and reading them off the
+ * hardcoded id-set alone both goes stale on a new low-confidence service AND (worse) finds nothing
+ * once a `score !== null` filter has already dropped them. Legacy archives predate `scoreConfidence`
+ * and still carry the invented estimate (bedrock score=90), so the id-set remains the fallback.
+ */
+function isScoreWithheld(s) {
+  return SCORE_WITHHELD.has(s.id) || (s.data.score === null && s.data.scoreConfidence === 'low')
+}
+
 function buildRankingNote(services, meta, period) {
-  const scored = services.filter(s => s.data.score !== null)
-  const noFeed = scored.filter(s => NO_INCIDENT_FEED.has(s.id))
-  // STALE_SOURCE that isn't already a no-feed service (avoid double-listing) — #591.
-  const stale = scored.filter(s => isStaleSource(s) && !NO_INCIDENT_FEED.has(s.id))
-  // reports#45 — recently-added (partial-month) services, excluding any already covered above.
-  const recent = scored.filter(s => isRecentlyAdded(s, period) && !NO_INCIDENT_FEED.has(s.id) && !isStaleSource(s))
-  if (noFeed.length === 0 && stale.length === 0 && recent.length === 0) return ''
-  const ranked = scored.length - noFeed.length - stale.length - recent.length
+  // Partition ALL services, never a `score !== null` prefilter. Every excluded group can carry a
+  // null score — withheld ones by aiwatch#713, and a frozen-feed service because it has no uptime
+  // and (in its month) no probe. Filtering on score first made each group's own members invisible
+  // to the clause that exists to explain them: the June 2026 archive silently dropped bedrock,
+  // azureopenai AND Character.AI from both the ranking and the note, printing "30 of 38" for 41
+  // services.
+  const withheld = services.filter(isScoreWithheld)
+  // STALE_SOURCE that isn't already withheld (avoid double-listing) — #591.
+  const stale = services.filter(s => !isScoreWithheld(s) && isStaleSource(s))
+  const rest = services.filter(s => !isScoreWithheld(s) && !isStaleSource(s))
+  // reports#45 — recently-added (partial-month) services.
+  const recent = rest.filter(s => isRecentlyAdded(s, period))
+  const rankedSvcs = rest.filter(s => !isRecentlyAdded(s, period) && s.data.score !== null)
+  // Warn BEFORE the early return: a service with no Score and no exclusion reason is exactly the
+  // silent drop this function exists to prevent, and it can be the ONLY anomaly — in which case the
+  // "nothing excluded" return below would swallow the warning too.
+  const unexplained = rest.filter(s => !isRecentlyAdded(s, period) && s.data.score === null)
+  if (unexplained.length) {
+    console.warn(`::warning::buildRankingNote: ${unexplained.map(s => s.id).join(', ')} have no Score and no exclusion reason — omitted from the ranking without explanation`)
+  }
+  if (withheld.length === 0 && stale.length === 0 && recent.length === 0) return ''
+  const ranked = rankedSvcs.length
+  const considered = ranked + withheld.length + stale.length + recent.length
   const clauses = []
-  if (noFeed.length) {
-    const verb = noFeed.length === 1 ? 'is' : 'are'
-    clauses.push(`**${joinNames(noFeed, meta)} ${verb} excluded from this ranking** — neither publishes an accessible uptime metric, so their Score would otherwise inherit an industry-average assumption rather than a measured value, and AIWatch has no reliable incident feed for them (see "No incident feed" under [Incident Summary](#incident-summary))`)
+  if (withheld.length) {
+    const verb = withheld.length === 1 ? 'is' : 'are'
+    // Two claims removed here. "Industry-average assumption" — aiwatch#713 deleted the invented
+    // uptime. "No reliable incident feed" — false: bedrock reads the AWS Health public events JSON
+    // (aiwatch#677) and azureopenai an Azure RSS feed; both are archived. What they lack is an
+    // official uptime AND a probe, so `score.ts` can measure 2 of 4 components and withholds the
+    // Score at `confidence: 'low'` rather than over-state one.
+    // Phrased without a subject pronoun: an earlier draft read "it publishes an official uptime
+    // metric and has a direct latency probe" in the singular — the negation vanished with the plural.
+    clauses.push(`**${joinNames(withheld, meta)} ${verb} excluded from this ranking** — no official uptime metric and no direct latency probe, so AIWatch can measure only two of the Score's four components and withholds a Score rather than rank on insufficient signal. Incidents are still tracked (see [Incident Summary](#incident-summary))`)
   }
   if (stale.length) {
     const verb = stale.length === 1 ? 'is' : 'are'
     const poss = stale.length === 1 ? 'its' : 'their'
-    clauses.push(`**${joinNames(stale, meta)} ${verb} excluded from this ranking** — ${poss} status source migrated to a platform AIWatch can't reach, so the incident feed is frozen and the Score would be inflated by an empty 30-day window (see "Stale source" under [Incident Summary](#incident-summary))`)
+    // Cause-free, for the same reason as buildStaleSourceCaveat: the flag says the feed is frozen,
+    // not why. DeepSeek's page was bot-walled (aiwatch#507); Character.AI's was deactivated (#689/#800).
+    // One clause, one pointer. The full explanation is the canonical "Stale source" caveat under
+    // Incident Summary; restating it here made a reader meet the same paragraph three times.
+    const feed = stale.length === 1 ? 'incident feed is' : 'incident feeds are'
+    clauses.push(`**${joinNames(stale, meta)} ${verb} excluded from this ranking** — ${poss} ${feed} frozen, so the Score would rest on a partial month (see "Stale source" under [Incident Summary](#incident-summary))`)
   }
   if (recent.length) {
     const verb = recent.length === 1 ? 'is' : 'are'
     const poss = recent.length === 1 ? 'it was' : 'they were'
     clauses.push(`**${joinNames(recent, meta)} ${verb} excluded from this ranking** — ${poss} added to AIWatch mid-month, so the partial-month Score rests on insufficient coverage; ${recent.length === 1 ? 'it rejoins' : 'they rejoin'} once a full month of data accrues`)
   }
-  return `*${ranked} of ${scored.length} services ranked. ${clauses.join('. ')}.*`
+  return `*${ranked} of ${considered} services ranked. ${clauses.join('. ')}.*`
 }
 
 // ── Table builders ───────────────────────────────────────────────────
 function buildScoreTable(services, meta, period) {
-  // Drop NO_INCIDENT_FEED services (no uptime metric + no reliable incidents), STALE_SOURCE services
+  // Drop SCORE_WITHHELD services (no uptime metric + no reliable incidents), STALE_SOURCE services
   // (#591 — frozen feed inflates the Score from an empty window), and recently-added services
   // (reports#45 — partial-month coverage would rank off insufficient data) from the ranking; all are
   // surfaced in the ranking-exclusion note + the Incident Summary ("No incident feed" / "Stale source").
-  const withScore = services.filter(s => s.data.score !== null && !NO_INCIDENT_FEED.has(s.id) && !isStaleSource(s) && !isRecentlyAdded(s, period))
+  const withScore = services.filter(s => s.data.score !== null && !isScoreWithheld(s) && !isStaleSource(s) && !isRecentlyAdded(s, period))
   const ranked = competitionRank(withScore, s => s.data.score)
   const rows = ranked.map(r => {
     const s = r.item
@@ -286,13 +349,29 @@ function buildScoreTable(services, meta, period) {
   ].join('\n')
 }
 
-// aiwatch#507 — caveat line for STALE_SOURCE services (frozen status feed). Pure + exported so the
+// aiwatch#507 — caveat line for services whose status feed is frozen. Pure + exported so the
 // singular/plural agreement is unit-testable without mutating the maintained set. '' for empty input.
+//
+// It used to name a CAUSE — "a status page that migrated to a platform AIWatch can't reach
+// server-side" — which is the DeepSeek case (bot-walled Flashduty, aiwatch#507) and false for the
+// other one: Character.AI's Statuspage was 401-DEACTIVATED (aiwatch#689/#800). The flag says the feed
+// is frozen; it does not say why. State the observable fact and stop.
+//
+// It also claimed "the incident count, uptime, and Score reflect only data up to that cutoff". Whether
+// a Score exists at all is not this function's to assert: the worker withholds it (null) only at
+// `scoreConfidence: 'low'`, so a stale service that still carries a probe keeps a real number. What IS
+// unconditionally true is that `buildScoreTable` drops every stale service from the ranking. Say that,
+// and say nothing about the Score's existence — asserting a number that may not be there is the
+// mirror-image of the error being fixed.
 function buildStaleSourceCaveat(names) {
   if (!names.length) return ''
   const n = names.length
-  const verb = n === 1 ? 'is' : 'are'
-  return `**Stale source (${n} service${n === 1 ? '' : 's'}):** ${names.join(', ')} ${verb} served from a status page that migrated to a platform AIWatch can't reach server-side, so the feed is frozen at the last reachable fetch. The incident count, uptime, and Score reflect only data up to that cutoff — not the full month — so treat the figures as a floor, not a verified picture.`
+  const one = n === 1
+  // Only the INCIDENT COUNT is truncated. AIWatch keeps polling status, so its measured uptime still
+  // covers the whole month; an official uptime, if the page stops publishing one, goes absent rather
+  // than partial. Character.AI's June proves it: incident feed frozen 15 Jun, daily counters recorded
+  // all 30 days. Saying "and uptime" made a claim the data contradicts.
+  return `**Stale source (${n} service${one ? '' : 's'}):** ${names.join(', ')} — AIWatch can no longer read ${one ? 'its incident feed, which is' : 'their incident feeds, which are'} frozen at the last reachable fetch. The incident count covers only the window up to that cutoff, not the full month, so treat it as a floor rather than a verified picture. A frozen feed also removes ${one ? 'the service' : 'these services'} from the Score ranking.`
 }
 
 function buildIncidentTable(services, meta) {
@@ -308,33 +387,30 @@ function buildIncidentTable(services, meta) {
     return `<tr><td>${serviceName(s.id, meta)}</td><td>${inc}</td><td>${totalWithLongest}</td><td class="hide-mobile">${longest}</td><td class="hide-mobile">${avg}</td></tr>`
   })
 
-  // Zero-incident services split (#29): a "confirmed zero" needs a real, CURRENT incident feed.
-  // The bucket keys off NO_INCIDENT_FEED (bedrock/azureopenai), NOT the uptime taxonomy. It used to
-  // use NO_PUBLIC_UPTIME, conflating two unrelated questions — whether a provider publishes an uptime
-  // %, and whether AIWatch can read its incidents. aiwatch#951 made that conflation visible: Perplexity
-  // publishes a real uptime and has a real incident feed, yet a zero-incident month would have printed
-  // "Official · Zero incidents, 100.00% uptime" in the Score table and, two sections later, "No incident
-  // feed: Perplexity — a blank incident count reflects monitoring coverage, not verified incident-free
-  // operation." Both about the same month. STALE_SOURCE services (aiwatch#507) stay excluded from
-  // "confirmed": their feed is frozen, so a zero count is "nothing since the cutoff".
+  // Zero-incident services (#29): a "confirmed zero" needs a real, CURRENT incident feed. Exactly one
+  // condition disqualifies a service — a FROZEN feed (aiwatch#507): its zero means "nothing since the
+  // cutoff", not "nothing happened". The stale-source caveat below covers those.
+  //
+  // There used to be a second bucket, "No incident feed", for bedrock/azureopenai, asserting AIWatch
+  // had no reliable feed for them so their blank count was "monitoring coverage, not verified
+  // incident-free operation". That was false. `worker/src/services.ts` reads bedrock's AWS Health
+  // public events JSON (aiwatch#677 — one event per incident, real start and end timestamps) and
+  // azureopenai's Azure RSS; both are archived, and bedrock's June 2026 archive carries a genuine
+  // incident. Their zero is as observed as anyone else's. What they lack is an official uptime and a
+  // probe — a Score problem, not a feed problem — and `buildRankingNote` says so.
+  //
   // Use isStaleSource (flag-OR-constant) — not the raw STALE_SOURCE constant — so a service marked
   // stale by the archive's incidentSourceStale flag is handled even though the constant is now empty
   // (aiwatch#618 emptied it; the May 2026 archive still carries the flag).
   const zero = services.filter(s => s.data.incidents === 0)
   const confirmed = zero
-    .filter(s => !NO_INCIDENT_FEED.has(s.id) && !isStaleSource(s))
-    .map(s => serviceName(s.id, meta))
-  // Stale sources are excluded from noFeed too (defensive — a future stale service that also lacks an
-  // incident feed must get the more-specific Stale-source line, not a double caveat).
-  const noFeed = zero
-    .filter(s => NO_INCIDENT_FEED.has(s.id) && !isStaleSource(s))
+    .filter(s => !isStaleSource(s))
     .map(s => serviceName(s.id, meta))
   const zeroLines = []
   if (confirmed.length) {
-    zeroLines.push(`**Zero incidents (${confirmed.length} services):** ${confirmed.join(', ')} — confirmed via their status-page incident feeds.`)
-  }
-  if (noFeed.length) {
-    zeroLines.push(`**No incident feed (${noFeed.length} services):** ${noFeed.join(', ')} — AIWatch has no reliable incident feed for these (aggregated event JSON / RSS only), so a blank incident count reflects monitoring coverage, not verified incident-free operation.`)
+    const n = confirmed.length
+    const via = n === 1 ? 'its status-page incident feed' : 'their status-page incident feeds'
+    zeroLines.push(`**Zero incidents (${n} service${n === 1 ? '' : 's'}):** ${confirmed.join(', ')} — confirmed via ${via}.`)
   }
   // Stale-source caveat (aiwatch#507) — rendered whenever a stale service is in the report (by the
   // archive's incidentSourceStale flag or the STALE_SOURCE constant), regardless of incident count:
@@ -753,7 +829,10 @@ function buildComponentReliabilitySection(archive, meta) {
   return [
     '## Component Reliability',
     '',
-    "> AIWatch is the only monitor publishing a **monthly per-component uptime ranking**. This surfaces each multi-surface service's weakest component this month — the surface most likely to be your bottleneck, which a single service-level uptime number hides.",
+    // The window is NOT the month: per-component counting is younger than the report, and a service
+    // whose status page goes dark simply stops contributing days (aiwatch-reports#73). Say "the days
+    // AIWatch could read its status page", which is what the ratio actually measures.
+    "> AIWatch is the only monitor publishing a **per-component uptime ranking**. This surfaces each multi-surface service's weakest component over the days AIWatch could read its status page — the surface most likely to be your bottleneck, which a single service-level uptime number hides. It is a different measurement from the Official Uptime table; see [About This Report → Component Reliability](#about-this-report).",
     '',
     '| Service | Weakest Component | Uptime | Components |',
     '|---|---|---|---|',
@@ -770,7 +849,7 @@ function buildTrendSection(month, archive, meta, dataDir = path.join(__dirname, 
   if (entries.length < 2) return ''
 
   const trend = charts.buildTrendSeries(entries)
-  // Exclude the services the Score ranking itself excludes (NO_INCIDENT_FEED + stale source,
+  // Exclude the services the Score ranking itself excludes (SCORE_WITHHELD + stale source,
   // per buildScoreTable / the #29 note) so a trend mover never contradicts a report that
   // elsewhere states it does not rank that service. Estimate-only bedrock/azureopenai scores
   // CAN move month-to-month, so this isn't hypothetical. Keyed off the CURRENT month's archive.
@@ -785,7 +864,7 @@ function buildTrendSection(month, archive, meta, dataDir = path.join(__dirname, 
   const parts = [
     `## ${span}-Month Trend`,
     '',
-    `AIWatch Score direction over the last ${span} months (${entries[0].month} → ${month}). The chart shows the composite-Score direction for every service; **Notable Movers** below decompose the biggest changes into the incident-measured metrics that actually drive a "keep relying on this?" decision — recovery time (MTTR) and total downtime — since a flat Score can hide a recovery-time regression.`,
+    `AIWatch Score direction over the last ${span} months (${entries[0].month} → ${month}). The lines plot each service's composite Score. **Notable Movers** below are NOT ranked by these lines — a service earns its place, and its order, by the largest change on *any* of three axes (Score, recovery time, or total downtime), which is why one with a small Score move can top the list on a downtime swing the chart cannot show.`,
     '',
     `![AIWatch Score ${span}-month trend](../assets/${month}/trend-chart.svg)`,
     '',
@@ -980,6 +1059,16 @@ function fillTemplate(template, month, archive, meta) {
   out = out.replace(/\[LAST_DAY\]/g, String(lastDay))
   out = out.replace(/\[PUBLISH_MONTH\]/g, publishMonth)
   out = out.replace(/\[NEXT_MONTH\]/g, nxt.name)
+
+  // aiwatch-reports#74 — resolve `[SCORE_ANCHOR]` from the heading that actually shipped, rather
+  // than hand-slugging it in the template. The old template asked a human to substitute a lowercase
+  // `[month]`/`[year]` inside the anchor (the generator only substitutes the UPPERCASE forms), and
+  // June 2026 was published with a literal `#aiwatch-score--[month]-[year]-…` dead link.
+  // Only resolved when the placeholder is present; when it is, a missing heading THROWS rather than
+  // emitting another dead link (a template with neither is fine — several tests use one).
+  if (out.includes('[SCORE_ANCHOR]')) {
+    out = out.replace(/\[SCORE_ANCHOR\]/g, anchorForHeading(out, /^## (AIWatch Score .*)$/m))
+  }
 
   // Draft — human reviewer flips to true before merge
   out = out.replace(/^published: true$/m, 'published: false')
@@ -1688,6 +1777,8 @@ module.exports = {
   buildStaleSourceCaveat,
   buildUptimeTable,
   buildUptimeExclusionNote,
+  kramdownAnchor,
+  anchorForHeading,
   buildLatencyTable,
   buildBySourceTable,
   buildBySeverityTable,

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -18,6 +18,8 @@ const {
   buildStaleSourceCaveat,
   buildUptimeTable,
   buildUptimeExclusionNote,
+  kramdownAnchor,
+  anchorForHeading,
   buildLatencyTable,
   buildBySourceTable,
   buildBySeverityTable,
@@ -171,7 +173,7 @@ test('legacy archive (no officialUptime field) falls back to the maintained set'
 })
 
 console.log('\nbuildRankingNote (#29)')
-test('names the NO_INCIDENT_FEED services excluded from the ranking', () => {
+test('names the score-withheld services excluded from the ranking', () => {
   const services = [
     { id: 'modal', data: { score: 97 } },
     { id: 'bedrock', data: { score: 90 } },
@@ -208,17 +210,24 @@ test('buildScoreTable drops a stale service from the ranking', () => {
   assert.ok(table.includes('Cohere API'), 'non-stale service still ranked')
   assert.ok(!table.includes('DeepSeek API'), 'stale service dropped from the Score table')
 })
-test('buildRankingNote names stale + no-feed in separate clauses with distinct reasons', () => {
+test('buildRankingNote names stale + score-withheld in separate clauses with distinct reasons', () => {
   const services = [
     { id: 'modal', data: { score: 97 } },
-    { id: 'bedrock', data: { score: 90 } },                       // NO_INCIDENT_FEED
+    { id: 'bedrock', data: { score: 90 } },                       // SCORE_WITHHELD
     { id: 'deepseek', data: { score: 88, incidentSourceStale: true } }, // STALE_SOURCE
   ]
   const meta = { modal: { name: 'Modal' }, bedrock: { name: 'Amazon Bedrock' }, deepseek: { name: 'DeepSeek API' } }
   const note = buildRankingNote(services, meta)
   assert.ok(note.includes('1 of 3 services ranked'), `got: ${note}`)
   assert.ok(/Amazon Bedrock is excluded from this ranking/.test(note), `no-feed clause: ${note}`)
-  assert.ok(/no reliable incident feed/.test(note), `no-feed reason: ${note}`)
+  // aiwatch-reports#75 — the reason is the WITHHELD SCORE, not a missing feed. Bedrock's incidents
+  // come from the AWS Health events JSON (aiwatch#677) and are archived; Azure's from its RSS.
+  assert.ok(!/no reliable incident feed/.test(note), `must not claim a missing feed: ${note}`)
+  assert.ok(/no official uptime metric and no direct latency probe/.test(note), `reason: ${note}`)
+  assert.ok(/withholds a Score/.test(note), note)
+  assert.ok(/Incidents are still tracked/.test(note), note)
+  // The singular must keep the negation — an earlier draft read "it publishes an official uptime metric".
+  assert.ok(!/ publishes an official uptime metric/.test(note), `negation lost: ${note}`)
   assert.ok(/DeepSeek API is excluded from this ranking/.test(note), `stale clause: ${note}`)
   assert.ok(/incident feed is frozen/.test(note), `stale reason: ${note}`)
 })
@@ -337,7 +346,7 @@ test('header is "Uptime Source" (not "Confidence"); the column reads the archive
   const modalRow = table.split('\n').find(r => r.includes('Modal'))
   assert.ok(/\| Official \|/.test(modalRow), `status-page service must be Official: ${modalRow}`)
 })
-test('excludes NO_INCIDENT_FEED services (Bedrock/Azure) from the ranking (#29)', () => {
+test('excludes SCORE_WITHHELD services (Bedrock/Azure) from the ranking (#29)', () => {
   const services = [
     { id: 'modal', data: { score: 97, grade: 'excellent', uptime: 99.4, incidents: 5, avgResolutionMin: 65 } },
     { id: 'bedrock', data: { score: 90, grade: 'excellent', uptime: 100, incidents: 0, avgResolutionMin: null } },
@@ -356,7 +365,7 @@ test('excludes services with zero incidents from the table body', () => {
   assert.ok(!tableRows.includes('Cohere API'), 'zero-incident service should be excluded')
   assert.ok(tableRows.includes('Claude API'), 'non-zero-incident service should appear')
   assert.ok(zeroIncLine.includes('Cohere API'), 'zero-inc line should list Cohere')
-  assert.ok(zeroIncLine.startsWith('**Zero incidents (1 services):**'), `got: ${zeroIncLine}`)
+  assert.ok(zeroIncLine.startsWith('**Zero incidents (1 service):**'), `singular agreement: ${zeroIncLine}`)
 })
 test('sorts by incident count desc', () => {
   const { tableRows } = buildIncidentTable(sampleServices, sampleMeta)
@@ -365,7 +374,7 @@ test('sorts by incident count desc', () => {
   assert.ok(claudeIdx > 0 && openaiIdx > 0, 'both should appear')
   assert.ok(claudeIdx < openaiIdx, 'Claude (9 inc) should appear before OpenAI (1 inc)')
 })
-test('splits zero-incident services into confirmed vs no-feed (estimate) (#29)', () => {
+test('every zero-incident service with a live feed is a confirmed zero (aiwatch-reports#75)', () => {
   const services = [
     { id: 'cohere', data: { score: 89, incidents: 0, uptime: 100, avgResolutionMin: null, totalDowntimeMin: null, longestIncidentMin: null } },
     { id: 'bedrock', data: { score: 90, incidents: 0, uptime: 100, avgResolutionMin: null, totalDowntimeMin: null, longestIncidentMin: null } },
@@ -373,8 +382,10 @@ test('splits zero-incident services into confirmed vs no-feed (estimate) (#29)',
   const meta = { cohere: { name: 'Cohere API' }, bedrock: { name: 'Amazon Bedrock' } }
   const { zeroIncLine } = buildIncidentTable(services, meta)
   // Official-uptime zero → confirmed; estimate-uptime zero (bedrock) → "No incident feed"
-  assert.ok(/\*\*Zero incidents \(1 services\):\*\* Cohere API — confirmed/.test(zeroIncLine), `confirmed line: ${zeroIncLine}`)
-  assert.ok(/\*\*No incident feed \(1 services\):\*\* Amazon Bedrock/.test(zeroIncLine), `no-feed line: ${zeroIncLine}`)
+  // aiwatch-reports#75 — the "No incident feed" bucket is gone. Bedrock's feed is real (AWS Health
+  // events JSON, aiwatch#677) and archived, so its zero is as observed as Cohere's.
+  assert.ok(/\*\*Zero incidents \(2 services\):\*\* Cohere API, Amazon Bedrock — confirmed/.test(zeroIncLine), `confirmed line: ${zeroIncLine}`)
+  assert.ok(!/No incident feed/.test(zeroIncLine), `bucket must be gone: ${zeroIncLine}`)
 })
 
 // aiwatch#507 — a status page that migrated to an unreachable platform freezes its feed, so neither
@@ -388,8 +399,8 @@ test('STALE_SOURCE: caveat renders with a NONZERO count (3 partial-month inciden
   const meta = { deepseek: { name: 'DeepSeek API' } }
   const { tableRows, zeroIncLine } = buildIncidentTable(services, meta)
   assert.ok(tableRows.includes('DeepSeek API'), 'still listed in the incident table (data is real, just dated)')
-  assert.ok(/\*\*Stale source \(1 service\):\*\* DeepSeek API is /.test(zeroIncLine), `stale line: ${zeroIncLine}`)
-  assert.ok(/floor, not a verified picture\./.test(zeroIncLine), 'self-contained caveat')
+  assert.ok(/\*\*Stale source \(1 service\):\*\* DeepSeek API — AIWatch can no longer read its incident feed/.test(zeroIncLine), `stale line: ${zeroIncLine}`)
+  assert.ok(/floor rather than a verified picture\./.test(zeroIncLine), 'self-contained caveat')
   assert.ok(!/#\d+/.test(zeroIncLine), 'no reader-facing internal issue number')
 })
 test('STALE_SOURCE: a frozen ZERO count is NOT labelled "confirmed zero" (flag set)', () => {
@@ -400,17 +411,58 @@ test('STALE_SOURCE: a frozen ZERO count is NOT labelled "confirmed zero" (flag s
   const meta = { cohere: { name: 'Cohere API' }, deepseek: { name: 'DeepSeek API' } }
   const { zeroIncLine } = buildIncidentTable(services, meta)
   // deepseek's zero must NOT appear in the confirmed list…
-  assert.ok(/\*\*Zero incidents \(1 services\):\*\* Cohere API — confirmed/.test(zeroIncLine), `confirmed: ${zeroIncLine}`)
-  assert.ok(!/Zero incidents.*DeepSeek/.test(zeroIncLine), 'deepseek not in confirmed-zero')
+  assert.ok(/\*\*Zero incidents \(1 service\):\*\* Cohere API — confirmed/.test(zeroIncLine), `confirmed: ${zeroIncLine}`)
+  assert.ok(!/Zero incidents.*DeepSeek/.test(zeroIncLine), 'deepseek not in confirmed-zero (frozen feed)')
   // …it appears in the stale-source caveat instead
   assert.ok(/\*\*Stale source \(1 service\):\*\* DeepSeek API/.test(zeroIncLine), `stale: ${zeroIncLine}`)
 })
 test('buildStaleSourceCaveat: singular vs plural agreement, empty → ""', () => {
   eq(buildStaleSourceCaveat([]), '')
   const one = buildStaleSourceCaveat(['DeepSeek API'])
-  assert.ok(/\*\*Stale source \(1 service\):\*\* DeepSeek API is /.test(one), `singular: ${one}`)
+  assert.ok(/\*\*Stale source \(1 service\):\*\* DeepSeek API — AIWatch can no longer read its incident feed, which is frozen/.test(one), `singular: ${one}`)
   const two = buildStaleSourceCaveat(['DeepSeek API', 'Foo API'])
-  assert.ok(/\*\*Stale source \(2 services\):\*\* DeepSeek API, Foo API are /.test(two), `plural: ${two}`)
+  assert.ok(/\*\*Stale source \(2 services\):\*\* DeepSeek API, Foo API — AIWatch can no longer read their incident feeds, which are frozen/.test(two), `plural: ${two}`)
+})
+// The caveat used to assert a CAUSE and a SCORE, and was wrong about both.
+test('buildStaleSourceCaveat claims no cause — the flag says frozen, not why', () => {
+  const c = buildStaleSourceCaveat(['Character.AI'])
+  // DeepSeek's status page was bot-walled (aiwatch#507); Character.AI's was 401-deactivated
+  // (aiwatch#689/#800). One sentence cannot name both, so it names neither.
+  assert.ok(!/migrated/.test(c), `must not guess the cause: ${c}`)
+  assert.ok(!/platform/.test(c), c)
+})
+test('buildStaleSourceCaveat asserts nothing about whether a Score exists', () => {
+  const c = buildStaleSourceCaveat(['Character.AI'])
+  // The old line said the Score "reflects data up to that cutoff" — but a stale service may have no
+  // Score at all (withheld at low confidence). Nor may we claim it IS withheld: a stale service with
+  // a probe keeps a real number. Only the ranking exclusion is unconditionally true.
+  assert.ok(!/Score reflect/.test(c), `must not claim a partial Score: ${c}`)
+  assert.ok(!/withheld/.test(c), `must not claim the Score was withheld either: ${c}`)
+  assert.ok(/removes the service from the Score ranking/.test(c), c)
+  assert.ok(/floor/.test(c) && /cutoff/.test(c), c)
+})
+// The identical false cause lived one function up, where it was reachable for a stale service that
+// still carries a score (DeepSeek, May 2026 — stale yet ranked #4 before the exclusion landed).
+test('buildRankingNote names no cause for a stale service either', () => {
+  const note = buildRankingNote(
+    [{ id: 'deepseek', data: { score: 88, incidentSourceStale: true } }],
+    { deepseek: { name: 'DeepSeek API' } },
+    '2026-05',
+  )
+  assert.ok(/DeepSeek API is excluded from this ranking/.test(note), note)
+  assert.ok(/incident feed is frozen/.test(note), note)
+  assert.ok(!/migrated/.test(note), `must not guess the cause: ${note}`)
+  assert.ok(!/platform/.test(note), note)
+})
+test('buildRankingNote no longer cites the industry-average assumption aiwatch#713 deleted', () => {
+  const note = buildRankingNote(
+    [{ id: 'bedrock', data: { score: 73 } }, { id: 'azureopenai', data: { score: 90 } }],
+    { bedrock: { name: 'Amazon Bedrock' }, azureopenai: { name: 'Azure OpenAI' } },
+    '2026-05',
+  )
+  assert.ok(/excluded from this ranking/.test(note), note)
+  assert.ok(!/industry-average/.test(note), `AIWatch invents no uptime (aiwatch#713): ${note}`)
+  assert.ok(!/assumption/.test(note), note)
 })
 
 console.log('\nbuildUptimeTable')
@@ -1447,7 +1499,7 @@ const pathT = require('path')
 
 // Write two prior-month _data snapshots to a temp dir, then render the section for a current
 // month supplied via the archive arg. The archive carries a normal mover (codex, declining hard)
-// AND an excluded estimate-only mover (bedrock, NO_INCIDENT_FEED) that ALSO moves hard.
+// AND an excluded estimate-only mover (bedrock, SCORE_WITHHELD) that ALSO moves hard.
 function withTrendFixture(fn) {
   const dir = fsT.mkdtempSync(pathT.join(osT.tmpdir(), 'trend-test-'))
   try {
@@ -1487,7 +1539,7 @@ test('renders a ## 3-Month Trend section with the Notable Movers list', () => {
   })
 })
 
-test('excludes a NO_INCIDENT_FEED service (bedrock) from the rendered movers — the round-2 fix', () => {
+test('excludes a SCORE_WITHHELD service (bedrock) from the rendered movers — the round-2 fix', () => {
   withTrendFixture(dir => {
     const out = buildTrendSection('2026-06', TREND_ARCHIVE, TREND_META, dir)
     assert.ok(!out.includes('Amazon Bedrock'), 'estimate-only bedrock must NOT surface as a trend mover')
@@ -1763,6 +1815,19 @@ test('loadPriorNarrative skips months with no index.md (never throws)', () => {
 // ── buildComponentReliabilitySection (aiwatch#605 Phase 3b) ─────────
 console.log('\nbuildComponentReliabilitySection (#605 Phase 3b)')
 const crMeta = { services: {} }
+// aiwatch-reports#73 — per-component counting is younger than the report, and a service whose status
+// page goes dark stops contributing days. The intro must not call the window "monthly".
+test('the intro claims no monthly window (the ratio covers only the readable days)', () => {
+  const out = buildComponentReliabilitySection(
+    { services: { deepgram: { components: [{ id: 'a', name: 'A', uptime: 65.81 }, { id: 'b', name: 'B', uptime: 100 }] } } },
+    { deepgram: { name: 'Deepgram' } },
+  )
+  assert.ok(out.includes('## Component Reliability'), out)
+  assert.ok(!/monthly per-component/.test(out), `the window is not the month: ${out.slice(0, 300)}`)
+  assert.ok(/over the days AIWatch could read its status page/.test(out), out)
+  // …and it must point the reader at the definition, since this number is not the service uptime.
+  assert.ok(/About This Report/.test(out), out)
+})
 test('omits the section when no service has components', () => {
   eq(buildComponentReliabilitySection({ services: { openai: { score: 90 } } }, crMeta), '')
   eq(buildComponentReliabilitySection({}, crMeta), '')
@@ -1944,12 +2009,39 @@ test('collapses to an empty string when every service publishes uptime', () => {
   eq(buildUptimeExclusionNote([{ id: 'groq', data: { officialUptime: 100 } }], NOTE_META), '')
 })
 
-console.log('\nNEVER_PUBLISHES_UPTIME stays in lockstep with NO_INCIDENT_FEED')
+// aiwatch-reports#74 — the template used to hand-slug this anchor and ask a human to substitute a
+// lowercase [month]/[year] that the generator never replaced. April and May were substituted by hand;
+// June shipped `#aiwatch-score--[month]-[year]-reliability-rankings`, a dead link.
+console.log('\nkramdownAnchor / anchorForHeading (aiwatch-reports#74)')
+test('reproduces the ids Jekyll actually emitted for the June 2026 report', () => {
+  // Captured from the rendered HTML — all 22 heading ids matched this rule.
+  eq(kramdownAnchor('AIWatch Score — June 2026 Reliability Rankings'), 'aiwatch-score--june-2026-reliability-rankings')
+  eq(kramdownAnchor('API Response Time — Monthly p75'), 'api-response-time--monthly-p75')
+  eq(kramdownAnchor('Official Uptime (Primary Component)'), 'official-uptime-primary-component')
+})
+test('an em-dash (and an &) is DELETED, so its surrounding spaces become a double hyphen', () => {
+  // The gotcha the old template comment tried to explain in prose, now executable.
+  eq(kramdownAnchor('A — B'), 'a--b')
+  eq(kramdownAnchor('Detection & RTT Degradation'), 'detection--rtt-degradation')
+})
+test('leading digits survive', () => {
+  eq(kramdownAnchor('3-Month Trend'), '3-month-trend')
+  eq(kramdownAnchor('1. Codex — one incident'), '1-codex--one-incident')
+})
+test('anchorForHeading derives from the heading that actually shipped', () => {
+  const md = '# t\n\n## AIWatch Score — May 2026 Reliability Rankings\n\nbody\n'
+  eq(anchorForHeading(md, /^## (AIWatch Score .*)$/m), 'aiwatch-score--may-2026-reliability-rankings')
+})
+test('anchorForHeading throws rather than emitting a dead link', () => {
+  assert.throws(() => anchorForHeading('# nothing here\n', /^## (AIWatch Score .*)$/m), /no heading matched/)
+})
+
+console.log('\nNEVER_PUBLISHES_UPTIME stays in lockstep with SCORE_WITHHELD')
 test('the two sets encode the same providers (incident-feed-only → no uptime to publish)', () => {
   // They live in different files for different reasons; if a future gcloud-incident-only service is
   // added to one but not the other, the #29 stray-row / mislabel class of bug comes straight back.
-  const { NO_INCIDENT_FEED } = require('./generate-charts')
-  assert.deepEqual([...NO_INCIDENT_FEED].sort(), ['azureopenai', 'bedrock'])
+  const { SCORE_WITHHELD } = require('./generate-charts')
+  assert.deepEqual([...SCORE_WITHHELD].sort(), ['azureopenai', 'bedrock'])
 })
 test('emitUptimeWarnings annotates on stdout in CI, warns on stderr locally', () => {
   // The annotation goes to stdout (matching lint-recurrence.js / @actions/core); the local
@@ -1991,15 +2083,254 @@ test('mistral/perplexity appear; openrouter/stability do not', () => {
 })
 
 console.log('\nzero-incident split keys off the INCIDENT feed, not the uptime taxonomy (aiwatch#951)')
-test('perplexity with a zero-incident month is a confirmed zero, not "no incident feed"', () => {
+test('perplexity with a zero-incident month is a confirmed zero', () => {
   const services = [
     { id: 'perplexity', data: { incidents: 0, officialUptime: 100, scoreConfidence: 'high' } },
     { id: 'bedrock', data: { incidents: 0, officialUptime: null, scoreConfidence: 'low' } },
   ]
   const { zeroIncLine } = buildIncidentTable(services, { perplexity: { name: 'Perplexity' }, bedrock: { name: 'Amazon Bedrock' } })
-  assert.ok(/Zero incidents \(1 services\):\*\* Perplexity/.test(zeroIncLine), zeroIncLine)
-  assert.ok(/No incident feed \(1 services\):\*\* Amazon Bedrock/.test(zeroIncLine), zeroIncLine)
-  assert.ok(!/No incident feed[^\n]*Perplexity/.test(zeroIncLine), `must not contradict its "Official" label: ${zeroIncLine}`)
+  assert.ok(/Zero incidents \(2 services\):\*\* Perplexity, Amazon Bedrock — confirmed/.test(zeroIncLine), zeroIncLine)
+  assert.ok(!/No incident feed/.test(zeroIncLine), `the bucket rested on a false premise: ${zeroIncLine}`)
+})
+
+
+// ── report-wide ratchet (aiwatch-reports#75) ────────────────────────────────
+// The per-function `!/…/` guards elsewhere pin a claim's absence from ONE builder's output. Half the
+// ten corrected claims live in _templates/monthly-report.md — static prose no builder produces, so
+// nothing stopped them returning there. fillTemplate splices every builder INTO that template, so a
+// single full render ratchets both surfaces at once.
+console.log('\nreport-wide false-claim ratchet (#75)')
+
+const REAL_TEMPLATE = fs.readFileSync(path.join(__dirname, '..', '_templates', 'monthly-report.md'), 'utf-8')
+const REAL_ARCHIVE = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '_data', '2026-05.json'), 'utf-8'))
+
+const RETIRED_CLAIMS = [
+  [/no reliable incident feed/i,          'bedrock reads AWS Health events JSON (aiwatch#677); azureopenai an Azure RSS'],
+  [/migrated to a platform/i,             'cause-free stale caveat — we do not know why a feed froze'],
+  [/industry-average/i,                   'aiwatch#713 deleted the invented uptime estimate'],
+  [/monthly per-component/i,              'Component Reliability is a poll ratio, not a monthly per-component figure'],
+  [/derived from p75 probe RTT/i,         'computeResponsiveness reads ProbeSummary.p50 + cvCombined; ProbeSummary has no p75'],
+  [/reflect all affected components per service/i, 'counts are published incidents; Anthropic is single-component but posts per model'],
+  [/single-component figures/i,           'parseIncidentIoUptime is worst-of a component LIST; BetterStack averages resources'],
+  [/scored — and ranked — on what can actually be measured/i, 'a low-confidence service is withheld, not ranked'],
+  [/Score reflect/i,                      'removed overclaim'],
+  [/still has a probe \(Gemini, xAI, OpenRouter\)/, 'the medium-confidence set was 7 services in June 2026, not 3'],
+  [/neither uptime nor a probe \(Amazon Bedrock, Azure OpenAI\)/, 'characterai joined that set in June 2026'],
+  [/without probe coverage \([^)]*\) are excluded from rankings/, 'no probe alone never unranks a service — Modal ranked #2 in June 2026 without one'],
+  [/Partial \(Nd\)/,                     'uptimeSourceLabel emits only Official / No official uptime; #45 excludes short-window services instead'],
+]
+
+/**
+ * The real 2026-05 archive has no stale-flagged service and no `components`, so a render of it
+ * never emits the stale caveat or the Component Reliability intro — three of the nine regexes below
+ * would pass vacuously. Force every conditional section to render.
+ */
+function archiveExercisingEverySection(base) {
+  const a = JSON.parse(JSON.stringify(base))
+  const ids = Object.keys(a.services)
+  a.services[ids[0]].incidentSourceStale = true            // → stale caveat + stale ranking clause
+  a.services[ids[1]].components = [                        // → Component Reliability section
+    { name: 'API', uptime: 98.7 }, { name: 'Console', uptime: 99.99 },
+  ]
+  a.services[ids[2]] = { ...a.services[ids[2]], score: null, scoreConfidence: 'low' } // → withheld clause (data path)
+  return a
+}
+
+test('no retired false claim survives a full report render', () => {
+  const out = fillTemplate(REAL_TEMPLATE, '2026-05', REAL_ARCHIVE, {})
+  for (const [re, why] of RETIRED_CLAIMS) assert.ok(!re.test(out), `retired claim resurfaced (${why}): ${re}`)
+})
+
+test('the ratchet actually exercises every conditional section', () => {
+  // Guard the guard: if a future template change drops one of these sections, the regexes that
+  // target it start passing for the wrong reason.
+  const out = fillTemplate(REAL_TEMPLATE, '2026-05', archiveExercisingEverySection(REAL_ARCHIVE), {})
+  assert.match(out, /excluded from this ranking/, 'withheld/stale ranking clause must render')
+  assert.match(out, /no longer read/, 'stale caveat must render')
+  assert.match(out, /Component Reliability/, 'component reliability section must render')
+  for (const [re, why] of RETIRED_CLAIMS) assert.ok(!re.test(out), `retired claim resurfaced (${why}): ${re}`)
+})
+
+test('a full render leaves no unresolved placeholder or dead anchor', () => {
+  const out = fillTemplate(REAL_TEMPLATE, '2026-05', REAL_ARCHIVE, {})
+  const leftovers = out.match(/\[[A-Z_]{4,}\]/g) || []
+  assert.deepStrictEqual(leftovers, [], `unsubstituted placeholders: ${leftovers.join(', ')}`)
+  assert.ok(!/#aiwatch-score--\[/.test(out), 'the AIWatch Score anchor must not embed a placeholder')
+})
+
+console.log('\nwithheld membership tracks the DATA, not a hardcoded id-set (#75)')
+
+const mkSvc = (id, score, conf) => ({ id, data: { score, grade: score ? 'good' : null, uptime: null, incidents: 0, avgResolutionMin: null, ...(conf ? { scoreConfidence: conf } : {}) } })
+const WMETA = { modal: { name: 'Modal' }, bedrock: { name: 'Amazon Bedrock' }, azureopenai: { name: 'Azure OpenAI' }, newlow: { name: 'New Low Svc' } }
+
+test('a modern archive (score=null, confidence=low) still explains the exclusion', () => {
+  // aiwatch#713 withholds by emitting score:null; `scored = filter(score !== null)` dropped them
+  // FIRST, so the note collapsed to '' — the ranking lost bedrock/azureopenai with no reason given.
+  // The June 2026 archive already has this shape.
+  const note = buildRankingNote([mkSvc('modal', 97, 'high'), mkSvc('bedrock', null, 'low'), mkSvc('azureopenai', null, 'low')], WMETA, '2026-07')
+  assert.notStrictEqual(note, '', 'the note must not collapse on a modern archive')
+  assert.ok(note.includes('Amazon Bedrock') && note.includes('Azure OpenAI'), note)
+  assert.match(note, /1 of 3 services ranked/, 'the denominator counts every service considered')
+})
+
+test('the withheld clause keeps its negation in the PLURAL branch', () => {
+  // SCORE_WITHHELD has two members, so production always renders the plural — the singular guard
+  // never runs on the shipped sentence.
+  const note = buildRankingNote([mkSvc('modal', 97, 'high'), mkSvc('bedrock', null, 'low'), mkSvc('azureopenai', null, 'low')], WMETA, '2026-07')
+  assert.ok(/are excluded/.test(note), `plural branch not taken: ${note}`)
+  assert.ok(!/ publish an official uptime metric/.test(note), `plural negation lost: ${note}`)
+  assert.ok(!/ have (a )?direct latency probe/.test(note), `plural negation lost: ${note}`)
+  assert.ok(/no official uptime/.test(note) && /no direct latency probe/.test(note), note)
+})
+
+test('a NEW low-confidence service is named even though the id-set is stale', () => {
+  const note = buildRankingNote([mkSvc('modal', 97, 'high'), mkSvc('newlow', null, 'low')], WMETA, '2026-07')
+  assert.ok(note.includes('New Low Svc'), `a low-confidence service outside SCORE_WITHHELD vanished silently: ${note}`)
+})
+
+test('a legacy archive (score=90, no scoreConfidence) still uses the id-set', () => {
+  const note = buildRankingNote([mkSvc('modal', 97), mkSvc('bedrock', 90)], WMETA, '2026-07')
+  assert.ok(note.includes('Amazon Bedrock'), `the id-set must still cover pre-scoreConfidence archives: ${note}`)
+  assert.match(note, /1 of 2 services ranked/)
+})
+
+test('the stale clause agrees in number', () => {
+  const st = id => ({ id, data: { score: 70, grade: 'good', uptime: null, incidents: 0, avgResolutionMin: null, incidentSourceStale: true } })
+  const ok = { id: 'm', data: { score: 90, grade: 'excellent', uptime: 99, incidents: 0, avgResolutionMin: null } }
+  const meta = { a: { name: 'DeepSeek API' }, b: { name: 'Character.AI' }, m: { name: 'Modal' } }
+  assert.match(buildRankingNote([ok, st('a')], meta, '2026-07'), /its incident feed is frozen/)
+  const two = buildRankingNote([ok, st('a'), st('b')], meta, '2026-07')
+  assert.match(two, /their incident feeds are frozen/)
+  assert.ok(!/their incident feed is/.test(two), 'plural subject took a singular verb')
+})
+
+
+test('a frozen-feed service with a null Score is still named and still counted', () => {
+  // The twin of the withheld bug: `stale = scored.filter(...)` also ran behind a `score !== null`
+  // prefilter, so Character.AI (frozen feed, no uptime, no probe that month → null Score) vanished
+  // from the ranking, from the stale clause, AND from the denominator. June 2026 printed
+  // "30 of 38 services ranked" for an archive holding 41.
+  const frozenNull = { id: 'characterai', data: { score: null, grade: null, uptime: null, incidents: 0, avgResolutionMin: null, incidentSourceStale: true } }
+  const ok = { id: 'modal', data: { score: 90, grade: 'excellent', uptime: 99, incidents: 0, avgResolutionMin: null } }
+  const meta = { characterai: { name: 'Character.AI' }, modal: { name: 'Modal' } }
+  const note = buildRankingNote([ok, frozenNull], meta, '2026-07')
+  assert.ok(note.includes('Character.AI'), `a null-Score stale service vanished: ${note}`)
+  assert.match(note, /1 of 2 services ranked/, 'it must remain in the denominator')
+  assert.match(note, /its incident feed is frozen/, 'and be explained by the STALE clause, not the withheld one')
+})
+
+test('every service lands in exactly one group — ranked, withheld, stale, or recent', () => {
+  const mk = (id, over) => ({ id, data: { score: 80, grade: 'good', uptime: 99, incidents: 0, avgResolutionMin: null, ...over } })
+  const services = [
+    mk('modal'),                                                     // ranked
+    mk('bedrock', { score: null, scoreConfidence: 'low' }),          // withheld (data)
+    mk('azureopenai', { score: 88 }),                                // withheld (legacy id-set)
+    mk('characterai', { score: null, incidentSourceStale: true }),   // stale, null score
+    mk('deepseek', { incidentSourceStale: true }),                   // stale, has score
+    mk('newsvc', { addedAt: '2026-07-15' }),                         // recent (field is addedAt)
+  ]
+  const meta = Object.fromEntries(services.map(s => [s.id, { name: s.id }]))
+  const note = buildRankingNote(services, meta, '2026-07')
+  // 6 services: 1 ranked + 2 withheld + 2 stale + 1 recent
+  assert.match(note, /1 of 6 services ranked/, note)
+  for (const id of ['bedrock', 'azureopenai', 'characterai', 'deepseek', 'newsvc']) {
+    assert.ok(note.includes(id), `${id} was excluded without explanation: ${note}`)
+  }
+  // A withheld service must not ALSO appear in the stale clause.
+  const staleClause = note.slice(note.indexOf('can no longer read'))
+  assert.ok(!staleClause.includes('bedrock'), 'withheld service double-listed as stale')
+})
+
+
+test('uptimeSourceLabel emits exactly two labels — there is no Partial', () => {
+  // The template taught a third label the generator cannot produce. Its one historical use was
+  // hand-typed as "Partial (9-day)" (not the "(Nd)" the legend showed), and reports#45 now excludes
+  // a short-window service from the ranking entirely rather than labelling its row.
+  const labels = new Set([
+    uptimeSourceLabel({ id: 'groq', data: { officialUptime: 100, scoreConfidence: 'high' } }, 'groq'),
+    uptimeSourceLabel({ id: 'openrouter', data: { officialUptime: null } }, 'openrouter'),
+    uptimeSourceLabel({ id: 'bedrock', data: {} }, 'bedrock'),
+  ])
+  assert.deepStrictEqual([...labels].sort(), ['No official uptime', 'Official'])
+  for (const l of labels) assert.ok(!/Partial/.test(l), `unexpected label: ${l}`)
+})
+
+
+test('every About This Report link names the bullet it points at', () => {
+  // The bullets carry no anchors of their own (kramdown only auto-ids headings), so the link lands
+  // at the section top and the "→ Bullet" suffix is the only thing telling a reader where to look.
+  // Three of six references omitted it.
+  const out = fillTemplate(REAL_TEMPLATE, '2026-05', archiveExercisingEverySection(REAL_ARCHIVE), {})
+  const links = [...out.matchAll(/\[([^\]]*About This Report[^\]]*)\]\(#about-this-report\)/g)].map(m => m[1])
+  assert.ok(links.length >= 3, `expected several methodology links, found ${links.length}`)
+  for (const text of links) {
+    assert.match(text, /^About This Report → \S/, `link text must name its bullet: "${text}"`)
+  }
+})
+
+
+test('the stale caveat truncates the incident COUNT, never the uptime', () => {
+  // AIWatch keeps polling a stale-feed service: Character.AI's June incident feed froze on 15 Jun,
+  // yet its daily ok/total counters were recorded all 30 days (measured uptime 98.03). An official
+  // uptime, when the page stops publishing one, goes ABSENT rather than partial. The old caveat
+  // said "the incident count and uptime cover only the window up to that cutoff" — the data says no.
+  const caveat = buildStaleSourceCaveat(['Character.AI'])
+  assert.match(caveat, /The incident count covers only the window/)
+  assert.ok(!/count and uptime/.test(caveat), 'uptime is not truncated by a frozen incident feed')
+  assert.ok(!/treat them as a floor/.test(caveat), 'one truncated quantity takes a singular pronoun')
+  assert.match(caveat, /treat it as a floor/)
+})
+
+
+test('the Score is named and linked where a reader first meets a number', () => {
+  // Summary is three sections above the AIWatch Score heading, yet it opens with bare figures like
+  // "44/100". A first-time reader met the numbers before the metric had a name.
+  const out = fillTemplate(REAL_TEMPLATE, '2026-05', REAL_ARCHIVE, {})
+  const summary = out.slice(out.indexOf('## Summary'), out.indexOf('## Recommendations'))
+  assert.match(summary, /\*\*AIWatch Score\*\* \(0–100\)/, 'Summary must name the metric')
+  assert.match(summary, /\(#aiwatch-score--/, 'and link to its definition')
+  assert.ok(!summary.includes('[SCORE_ANCHOR]'), 'the anchor placeholder must resolve')
+  // The definition must precede the first score in the body.
+  assert.ok(summary.indexOf('AIWatch Score') < summary.indexOf('- **Most reliable**'), 'definition comes first')
+})
+
+
+test('the API Response Time section carries ONE prose block, and it is true', () => {
+  // The intro and a trailing "> **Note**:" footnote grew separately around the same table, each
+  // half-explaining the method. Merged into the intro; the footnote is gone.
+  // June 2026: 13 of 41 services had no probe; 10 of them were ranked, Modal at #2 with a 95.
+  // The old footnote named three of the thirteen and claimed all were "excluded from rankings".
+  const out = fillTemplate(REAL_TEMPLATE, '2026-05', REAL_ARCHIVE, {})
+  const start = out.indexOf('## API Response Time')
+  const section = out.slice(start, out.indexOf('\n## ', start + 5))
+  assert.ok(!/^> \*\*Note\*\*: Probe RTT/m.test(section), 'the footnote must not return')
+
+  const intro = section.split('\n').find(l => l.startsWith('These p75 figures'))
+  assert.ok(intro, 'the section must open with its one prose block')
+  // Everything the footnote used to carry now lives here, once.
+  assert.match(intro, /Cloudflare Workers edge every 5 minutes/, 'measurement method')
+  assert.match(intro, /not inference latency/, 'the disclaimer readers need')
+  assert.match(intro, /median \(p50\) probe RTT/, 'and the p75-is-not-the-Score-input correction')
+  assert.match(intro, /no row here/, 'a probe-less service is absent from THIS table')
+  assert.match(intro, /does not drop it from the Score ranking/, 'and that is all this needs to say')
+  assert.ok(!/are excluded from rankings/.test(intro), 'the false causal claim must stay dead')
+  // Never claim the Score is "unaffected": `unsupported` drops the Responsiveness component and
+  // rescales the remaining 80 points onto 100. Composition changes; only the penalty is absent.
+  assert.ok(!/unaffected|costs it nothing/.test(intro), `no-probe still reshapes the Score: ${intro}`)
+  assert.ok(!/withheld/.test(intro), 'the withheld rule belongs to the ranking note, not here')
+  for (const name of ['Bedrock', 'Azure OpenAI', 'Modal']) {
+    assert.ok(!intro.includes(name), `hardcoded service name in a rule that should be derived: ${name}`)
+  }
+})
+
+
+test('every resolved SCORE_ANCHOR link keeps its leading #', () => {
+  // `[SCORE_ANCHOR]` resolves to a bare id, so the template must write `(#[SCORE_ANCHOR])`.
+  // Omitting the # yields `](aiwatch-score--june-…)` — a relative-path link that 404s silently.
+  const out = fillTemplate(REAL_TEMPLATE, '2026-05', REAL_ARCHIVE, {})
+  const links = [...out.matchAll(/\]\(([^)]*aiwatch-score--[^)]*)\)/g)].map(m => m[1])
+  assert.ok(links.length >= 2, `expected several Score links, found ${links.length}`)
+  for (const href of links) assert.ok(href.startsWith('#'), `anchor link lost its #: ${href}`)
 })
 
 console.log(`\n${passed} passed, ${failed} failed`)


### PR DESCRIPTION
## Problem

A line-by-line audit of every reader-facing string against `worker/src` found **ten** false or stale claims. The generator's prose asserted facts about the worker the worker no longer makes.

## Fix

- **`NO_INCIDENT_FEED` → `SCORE_WITHHELD`** — the constant's *name* was the false premise. Bedrock reads AWS Health events JSON (aiwatch#677), azureopenai an Azure RSS; both are archived. They're unranked because `score.ts` withholds their Score (no official uptime **and** no probe), not because feeds are unreadable. The "No incident feed" bucket is deleted; those zeros are confirmed zeros.
- **`buildRankingNote` derives withheld/stale from the DATA** (`score===null` + low confidence; `incidentSourceStale`), not a `score !== null` prefilter that silently dropped bedrock/azureopenai/characterai on modern archives. The denominator counts every service considered; an unexplained drop emits a `::warning::`.
- Corrected claims: Responsiveness = p50 + RTT stability (there is no p75 field); the 5% penalty applies to `insufficient` only, not `unsupported`; uptime is worst-of / platform-average, not single-component; the removed `Partial (Nd)` label; Anthropic posts a separate incident **per model** on one component; the stale caveat truncates the incident **count**, not the uptime.
- Tests assert the **absence** of each retired claim (a ratchet), exercised against a full render with every conditional section forced on.

## Tests

report 232 + charts 72. Reviewed to 0 Critical/Important across five rounds (it caught two of my own inversions: a lost singular negation, and a Frankenstein sentence keeping the old premise).

## Merge order

Second of four: **#77 → #75 → #78 → #993-report**. Rebase onto #77; the `generateUptimeHeatmapSvg` footnote + the export block are the expected conflicts.

Refs #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)