### PR TITLE
fix(charts): normalize Notable Movers by each axis's own spread (refs #78)

### DIFF
--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -533,6 +533,17 @@ function computeScoreMovers(trend, opts = {}) {
   return { declining, improving, firstMonth, lastMonth }
 }
 
+/**
+ * Median of a numeric array (sorted copy; deterministic). null for an empty array. Scales each
+ * mover axis by its own typical magnitude (aiwatch-reports#78).
+ */
+function medianOf(values) {
+  if (!values.length) return null
+  const s = [...values].sort((a, b) => a - b)
+  const m = s.length >> 1
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2
+}
+
 // Delta of a sparse metric over the months that actually have data: first-present →
 // last-present. { first, last, delta } where delta is null for <2 present points (a value,
 // not a trend) and { null, null, null } when the metric is never present.
@@ -621,8 +632,11 @@ function buildMoverExclude(archiveServices, month) {
 // surfaces; that's the "should I keep relying on this?" signal a composite score hides.
 // `uptime` is intentionally excluded (see toMonthEntry: mixed sources / #586 over-count make it
 // misleading and it hijacks the ranking). Each row carries all three deltas + which axis moved
-// most (`emphasize`) so the renderer can bold it. Magnitudes are normalized to comparable units:
-// 10 score pts ≈ 60 min MTTR ≈ 120 min downtime ≈ 1.0.
+// most (`emphasize`) so the renderer can bold it. Each axis is normalized by its OWN typical
+// move this window (median absolute delta among services that moved on it,
+// aiwatch-reports#78), so "1.0" means "a typical move for this axis" — NOT a fixed physical
+// quantity. The old fixed divisors (/10, /60, /120) let downtime's hundreds-of-hours swings
+// win every time (16/16 movers across both windows).
 function computeNotableMovers(trend, opts = {}) {
   const { limit = 5, nameFor = id => id, exclude = new Set() } = opts
   const { months, series } = trend
@@ -630,26 +644,47 @@ function computeNotableMovers(trend, opts = {}) {
   const firstMonth = months[0]
   const lastMonth = months[months.length - 1]
 
-  const rows = []
+  // PASS 1 — collect every candidate's raw deltas. A candidate needs a Score at both window ends
+  // so a mid-window-added service isn't a fake mover.
+  const candidates = []
   for (const id of Object.keys(series)) {
     if (exclude.has(id)) continue // services the report doesn't rank (no-incident-feed / stale source)
     const pts = series[id].points
     const f = pts.find(p => p.month === firstMonth)
     const l = pts.find(p => p.month === lastMonth)
-    // Require Score at both ends so a mid-window-added service isn't a fake mover.
     if (!f || !l || f.score === null || l.score === null) continue
 
-    const scoreDelta = l.score - f.score
-    // MTTR / downtime are sparse (null in a zero-incident month — common in a partial month
-    // like a mid-month-onboarded March), so measure their delta over the months that HAVE
-    // data (first-present → last-present), not the strict window endpoints. A single present
-    // point → delta null (a value, not a trend). Score always uses the window endpoints.
-    const mttr = presentDelta(pts, 'mttr')
-    const downtime = presentDelta(pts, 'downtime')
+    // MTTR / downtime are sparse (null in a zero-incident month — common in a partial month like a
+    // mid-month-onboarded March), so measure their delta over the months that HAVE data
+    // (first-present → last-present), not the strict window endpoints. A single present point →
+    // delta null (a value, not a trend). Score always uses the window endpoints.
+    candidates.push({ id, f, l, pts, scoreDelta: l.score - f.score, mttr: presentDelta(pts, 'mttr'), downtime: presentDelta(pts, 'downtime') })
+  }
 
-    const nScore = Math.abs(scoreDelta) / 10
-    const nMttr = mttr.delta !== null ? Math.abs(mttr.delta) / 60 : 0
-    const nDowntime = downtime.delta !== null ? Math.abs(downtime.delta) / 120 : 0
+  // Per-axis SCALE = median absolute delta among services that actually moved on that axis
+  // (aiwatch-reports#78). "1.0" then means "a typical move for this axis", so downtime's
+  // hundreds-of-hours swings no longer dwarf a Score change the way the old fixed /10, /60, /120
+  // divisors did (they bolded downtime for 16 of 16 movers across both windows). Median (not mean)
+  // so one outlier can't set the scale. Non-zero movers only, so the scale is positive by
+  // construction and an axis nobody moved on simply contributes 0.
+  // CAVEAT: on a sparse axis (only 2-3 movers, possible for MTTR/downtime in a low-incident
+  // window) the median rests on a tiny sample, so a small absolute change that is merely large
+  // RELATIVE to that median can rank high — a milder mirror of the bug this fixes. Real windows are
+  // dense (~28 candidates); revisit with a scale floor or a min-movers gate if it ever bites.
+  const absMovers = (pick) => candidates.map(pick).filter(d => d !== null).map(Math.abs).filter(x => x > 0)
+  const scoreScale = medianOf(absMovers(c => c.scoreDelta))
+  const mttrScale = medianOf(absMovers(c => c.mttr.delta))
+  const downtimeScale = medianOf(absMovers(c => c.downtime.delta))
+  const norm = (delta, scale) => (delta !== null && scale) ? Math.abs(delta) / scale : 0
+
+  // PASS 2 — normalize and rank.
+  const rows = []
+  for (const { id, f, l, pts, scoreDelta, mttr, downtime } of candidates) {
+    // norm(0, scale) === 0 already, so score needs no per-axis zero-guard; the scale side
+    // (absMovers) is what keeps zeros out of the medians.
+    const nScore = norm(scoreDelta, scoreScale)
+    const nMttr = norm(mttr.delta, mttrScale)
+    const nDowntime = norm(downtime.delta, downtimeScale)
     const notability = Math.max(nScore, nMttr, nDowntime)
     if (notability === 0) continue // nothing moved meaningfully
 
@@ -864,6 +899,7 @@ module.exports = {
   generateTrendSvg, spreadLabelYs, nameToId, ID_TO_NAME, TREND_MONTHS,
   // mover exclusion + chart-reshape (aiwatch-reports#67)
   SCORE_WITHHELD, STALE_SOURCE, isStaleSource, isRecentlyAdded, buildMoverExclude, notableMoversForChart,
+  medianOf,
 }
 
 // ── CLI ──────────────────────────────────────────────────

--- a/scripts/generate-charts.test.js
+++ b/scripts/generate-charts.test.js
@@ -2,7 +2,7 @@ const {
   generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade,
   monthsBefore, buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta,
   generateTrendSvg, toMonthEntry, monthEntryFromScoreRows, rosterForMonth, spreadLabelYs,
-  buildMoverExclude, notableMoversForChart,
+  buildMoverExclude, notableMoversForChart, medianOf,
   uptimeLookbackDays, uptimeLookbackSpan, explainWindow, missingMonthDays, elapsedMonthDays, hasDayData,
   heatmapGate, describeMissing, dataSpan, daysInMonthOf, UPTIME_MAX_LOOKBACK_DAYS,
 } = require('./generate-charts')
@@ -341,13 +341,21 @@ test('excludes a service that did not move on any axis', () => {
 })
 
 test('direction follows the headline (emphasized) axis, not score', () => {
-  // Score +1 (slightly up) but downtime regresses 12h → 49h — the row must read 🔻 (declining),
-  // keying off the bolded downtime, not the small score gain.
-  const mistralish = [
-    { month: '2026-04', daysInMonth: 30, daysCollected: 30, services: { svc: { score: 77, grade: 'Good', mttr: 8, downtime: 735 } } },
-    { month: '2026-05', daysInMonth: 31, daysCollected: 31, services: { svc: { score: 78, grade: 'Good', mttr: 19, downtime: 2938 } } },
+  // Score +1 (slightly up) but downtime regresses hard — the row must read down (declining), keying
+  // off the bolded downtime, not the small score gain. Normalization is a CROSS-SERVICE statistic
+  // (median move per axis, aiwatch-reports#78), so the target needs peers: with a single candidate
+  // every moved axis normalizes to 1.0 and ties. These peers make a typical downtime move small, so
+  // the target's 37h regression stands out as the headline.
+  const mk = (sc, mt, dt) => ({ score: sc, grade: 'Good', mttr: mt, downtime: dt })
+  const trend = [
+    { month: '2026-04', daysInMonth: 30, daysCollected: 30, services: {
+      tgt: mk(77, 8, 735), p1: mk(80, 30, 200), p2: mk(60, 40, 300), p3: mk(90, 20, 150), p4: mk(70, 25, 250),
+    } },
+    { month: '2026-05', daysInMonth: 31, daysCollected: 31, services: {
+      tgt: mk(78, 19, 2938), p1: mk(78, 33, 210), p2: mk(57, 44, 315), p3: mk(87, 22, 158), p4: mk(66, 28, 262),
+    } },
   ]
-  const m = computeNotableMovers(buildTrendSeries(mistralish))[0]
+  const m = computeNotableMovers(buildTrendSeries(trend)).find(r => r.id === 'tgt')
   eq(m.score.delta, 1)
   eq(m.emphasize, 'downtime')
   eq(m.declining, true) // headline = downtime regression
@@ -1045,6 +1053,52 @@ test('explainWindow: span exactly at the cap is inside the window, span+1 is not
 })
 
 // ── Summary ──────────────────────────────────────────────
+
+test('medianOf: sorted-copy, even/odd, empty', () => {
+  eq(medianOf([3, 1, 2]), 2)
+  eq(medianOf([4, 1, 3, 2]), 2.5)
+  eq(medianOf([]), null)
+  const a = [3, 1, 2]; medianOf(a); eq(a[0], 3) // does not mutate input
+})
+
+test('normalization no longer lets downtime always win the emphasis (aiwatch-reports#78)', () => {
+  // `scorer` moves +12 on Score and +3h on downtime. Under the OLD fixed divisors that is
+  // nScore 1.2 vs nDowntime 1.5 → downtime wins (a 3h swing outweighs a 12-point Score jump, the
+  // whole bug). Median normalization scales each axis by its own typical move (score median 4,
+  // downtime median 180m here), giving nScore 3.0 vs nDowntime 1.0 → Score keeps its headline.
+  const mk = (sc, dt) => ({ score: sc, grade: 'Good', mttr: 10, downtime: dt })
+  const trend = [
+    { month: '2026-04', daysInMonth: 30, daysCollected: 30, services: {
+      scorer: mk(50, 300), dt1: mk(80, 300), dt2: mk(60, 320), dt3: mk(70, 310),
+    } },
+    { month: '2026-05', daysInMonth: 31, daysCollected: 31, services: {
+      scorer: mk(62, 480), dt1: mk(80, 480), dt2: mk(64, 520), dt3: mk(74, 470), // scorer +12 score/+3h down; dt1 flat score/+3h down; dt2/dt3 +4 score/big down
+    } },
+  ]
+  const movers = computeNotableMovers(buildTrendSeries(trend))
+  const scorer = movers.find(m => m.id === 'scorer')
+  assert.ok(scorer, 'the big Score mover must surface')
+  eq(scorer.emphasize, 'score') // under the OLD divisors this was 'downtime'
+  // And the emphasis is not monolithic: a flat-Score / big-downtime service still bolds downtime.
+  eq(movers.find(m => m.id === 'dt1').emphasize, 'downtime')
+})
+
+test('an axis nobody moved on contributes 0 — no divide-by-zero', () => {
+  // Every service has identical MTTR/downtime; only Score moves. Scale for mttr/downtime is
+  // undefined (no movers) → those axes score 0 for everyone, and the run does not throw / NaN.
+  const mk = sc => ({ score: sc, grade: 'Good', mttr: 15, downtime: 100 })
+  const trend = [
+    { month: '2026-04', daysInMonth: 30, daysCollected: 30, services: { a: mk(60), b: mk(70), c: mk(80) } },
+    { month: '2026-05', daysInMonth: 31, daysCollected: 31, services: { a: mk(66), b: mk(71), c: mk(90) } },
+  ]
+  const movers = computeNotableMovers(buildTrendSeries(trend))
+  for (const m of movers) {
+    assert.ok(Number.isFinite(m.notability), `notability must be finite: ${m.notability}`)
+    eq(m.emphasize, 'score')
+  }
+  // c moved most on Score (+10 vs +6/+1) → ranks first.
+  eq(movers[0].id, 'c')
+})
 
 console.log(`\n${passed} passed, ${failed} failed`)
 process.exit(failed > 0 ? 1 : 0)


### PR DESCRIPTION
## Problem

`computeNotableMovers` claimed to rank by the largest change across **Score / MTTR / downtime**, but the fixed divisors (`/10`, `/60`, `/120`) let downtime — routinely hundreds of hours — outweigh a Score move 30–100×. Across both real 3-month windows, **16 of 16 movers bolded downtime**: the three-axis ranking was a downtime sort and the `emphasize` field was dead. (Surfaced by a reader asking why Gemini +4 topped GitHub Copilot +19 — the answer, Gemini's −316h downtime, was invisible.)

## Fix

Each axis is scaled by the **median absolute delta among services that moved on it** (`medianOf`, non-zero movers only), so "1.0" means a typical move for that axis. Emphasis diversifies (June: mttr ×4, downtime ×1; Score movers like Copilot +19 and Pinecone −29 finally surface). The formula, sign, and 🔺/🔻 logic are unchanged — only the three normalized inputs. A small-N caveat is documented (a sparse axis rests on a tiny sample).

## Tests

75 tests; the fixed-divisor regression is mutation-verified. Reviewed to 0 Critical/Important across two rounds.

## Merge order

Third of four: **#77 → #75 → #78 → #993-report**. Rebase onto #75; `computeNotableMovers` doesn't overlap #77/#75's functions, so the conflict is limited to the export block.

Refs #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)