### PR TITLE
feat(report): read the calendar-month Score everywhere (refs #993)

### DIFF
--- a/scripts/generate-charts.js
+++ b/scripts/generate-charts.js
@@ -430,13 +430,43 @@ function rosterForMonth(categoryOrder, archiveServiceIds) {
 
 // Normalize an archive-like object into a trend month-entry. `daysCollected`
 // (when present) drives the partial-month flag; absent → assumed full.
+/**
+ * aiwatch#993 — resolve a service's report Score/grade from the archive. Prefer the CALENDAR-MONTH
+ * value (`monthlyScore`/`monthlyGrade`, computed at build time over the same window as MTTR/downtime)
+ * so every score in a monthly report shares one window; fall back to the build-day rolling snapshot
+ * (`score`/`grade`) for archives written before #993, which carry neither monthly field. Used by BOTH
+ * the trend/Notable-Movers path (toMonthEntry) and the report's ranking table / chart / Summary, so
+ * the same month never shows two different scores. NOTE: a 3-month trend spanning the #993 cutover
+ * mixes monthly-window points (post-#993 archives) with snapshot points (legacy archives, via the
+ * fallback) — unavoidable since old archives cannot be back-filled, and not a bug.
+ */
+function resolveMonthlyScore(s) {
+  if (!s) return { score: null, grade: null }
+  // A MODERN archive always writes `monthlyScore` (the worker emits it even when null — a month it
+  // deliberately WITHHELD for insufficient signal, #713). So key PRESENCE, not the value, marks a
+  // modern archive: honor its value verbatim (number → use it; null → stay withheld, never borrow
+  // the build-day snapshot, which would rank the service on data from outside the month). Only a
+  // LEGACY archive (no `monthlyScore` key at all) falls back to the snapshot `score`/`grade`.
+  if ('monthlyScore' in s) {
+    return {
+      score: typeof s.monthlyScore === 'number' ? s.monthlyScore : null,
+      grade: s.monthlyGrade || null,
+    }
+  }
+  return {
+    score: typeof s.score === 'number' ? s.score : null,
+    grade: s.grade || null,
+  }
+}
+
 function toMonthEntry(month, archiveLike) {
   if (!archiveLike || !archiveLike.services) return null
   const services = {}
   for (const [id, s] of Object.entries(archiveLike.services)) {
+    const resolved = resolveMonthlyScore(s)
     services[id] = {
-      score: s && typeof s.score === 'number' ? s.score : null,
-      grade: s && s.grade ? s.grade : null,
+      score: resolved.score,
+      grade: resolved.grade,
       // MTTR + total downtime feed the Notable Movers decomposition — both incident-feed
       // MEASURED values, consistent across services. The archive's `uptime` field is
       // deliberately NOT used: it mixes per-service sources (group aggregates like ChatGPT's
@@ -892,7 +922,7 @@ ${partialNote}
 module.exports = {
   generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade,
   // trend (aiwatch-reports#41)
-  monthsBefore, daysInMonthOf, readDataArchive, rosterForMonth, toMonthEntry, monthEntryFromScoreRows,
+  monthsBefore, daysInMonthOf, readDataArchive, rosterForMonth, toMonthEntry, monthEntryFromScoreRows, resolveMonthlyScore,
   uptimeLookbackDays, uptimeLookbackSpan, explainWindow, missingMonthDays, elapsedMonthDays, hasDayData,
   heatmapGate, describeMissing, dataSpan, UPTIME_MAX_LOOKBACK_DAYS,
   buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta, loadTrendEntries,

--- a/scripts/generate-charts.test.js
+++ b/scripts/generate-charts.test.js
@@ -2,7 +2,7 @@ const {
   generateScoreBarSvg, generateUptimeHeatmapSvg, scoreColorByGrade,
   monthsBefore, buildTrendSeries, computeScoreMovers, computeNotableMovers, formatTrendArrow, fmtScoreDelta,
   generateTrendSvg, toMonthEntry, monthEntryFromScoreRows, rosterForMonth, spreadLabelYs,
-  buildMoverExclude, notableMoversForChart, medianOf,
+  buildMoverExclude, notableMoversForChart, medianOf, resolveMonthlyScore,
   uptimeLookbackDays, uptimeLookbackSpan, explainWindow, missingMonthDays, elapsedMonthDays, hasDayData,
   heatmapGate, describeMissing, dataSpan, daysInMonthOf, UPTIME_MAX_LOOKBACK_DAYS,
 } = require('./generate-charts')
@@ -454,6 +454,37 @@ test('toMonthEntry computes daysInMonth + carries daysCollected', () => {
   eq(e.daysInMonth, 31)
   eq(e.daysCollected, 12)
   eq(e.services.claude.score, 71)
+})
+
+test('resolveMonthlyScore honors a present-but-null monthlyScore (withheld ≠ legacy fallback)', () => {
+  // The load-bearing distinction: key PRESENT + null = the worker withheld this month → stay null.
+  // key ABSENT = pre-#993 archive → fall back to the snapshot. Conflating them would rank a service
+  // on the build-day snapshot for a month whose score was deliberately withheld.
+  eq(resolveMonthlyScore({ score: 90, monthlyScore: null, monthlyGrade: null }).score, null)
+  eq(resolveMonthlyScore({ score: 90 }).score, 90)
+})
+
+test('resolveMonthlyScore: monthlyScore/grade win, snapshot is the fallback (aiwatch#993)', () => {
+  eq(resolveMonthlyScore({ score: 44, grade: 'Fair', monthlyScore: 61, monthlyGrade: 'Good' }).score, 61)
+  eq(resolveMonthlyScore({ score: 44, grade: 'Fair', monthlyScore: 61, monthlyGrade: 'Good' }).grade, 'Good')
+  eq(resolveMonthlyScore({ score: 55, grade: 'Fair' }).score, 55, 'legacy archive falls back')
+  eq(resolveMonthlyScore({ score: 55, grade: 'Fair' }).grade, 'Fair')
+  eq(resolveMonthlyScore({ score: 44, grade: 'Fair', monthlyScore: null, monthlyGrade: null }).score, null, 'a modern archive that WITHHELD the month stays null, does not borrow the snapshot')
+  eq(resolveMonthlyScore({ score: 44, grade: 'Fair' }).score, 44, 'a LEGACY archive (no monthlyScore key) falls back to the snapshot')
+  eq(resolveMonthlyScore(null).score, null)
+})
+
+test('toMonthEntry prefers monthlyScore over the snapshot score (aiwatch#993)', () => {
+  // The calendar-month Score (#993) is window-aligned with MTTR/downtime, so the trend/Movers must
+  // use it when present, and fall back to the build-day `score` snapshot for legacy archives.
+  const withMonthly = toMonthEntry('2026-06', { services: { x: { score: 44, monthlyScore: 61, grade: 'Fair' } } })
+  eq(withMonthly.services.x.score, 61, 'monthlyScore wins')
+
+  const legacy = toMonthEntry('2026-05', { services: { x: { score: 55, grade: 'Fair' } } })
+  eq(legacy.services.x.score, 55, 'no monthlyScore falls back to the snapshot score')
+
+  const withheld = toMonthEntry('2026-06', { services: { x: { score: 44, monthlyScore: null, monthlyGrade: null, grade: 'Fair' } } })
+  eq(withheld.services.x.score, null, 'a withheld month (present monthlyScore: null) stays null, not the snapshot 44')
 })
 
 test('toMonthEntry returns null when services are missing', () => {

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -1034,8 +1034,15 @@ function fillTemplate(template, month, archive, meta) {
   const nxt = nextMonthName(month)
   const publishMonth = nxt.name
 
-  // Extract service array from archive
-  const services = Object.entries(archive.services).map(([id, data]) => ({ id, data }))
+  // Extract service array from archive. aiwatch#993 — normalize each service's score/grade to the
+  // CALENDAR-MONTH value here, at the single load point, so the ranking table, score chart, Summary
+  // and buildWhy all read the same number the trend/Notable-Movers do (which resolve it in
+  // toMonthEntry). Legacy archives without monthlyScore keep their build-day snapshot via the
+  // fallback. scoreConfidence / officialUptime gating are left untouched — a separate signal.
+  const services = Object.entries(archive.services).map(([id, data]) => {
+    const { score, grade } = charts.resolveMonthlyScore(data)
+    return { id, data: { ...data, score, grade } }
+  })
 
   // aiwatch#951 — the uptime columns now trust the archive. Say so out loud when the archive can't
   // be trusted, rather than publishing fabricated "Official" figures silently (which is the bug).
@@ -1190,11 +1197,16 @@ function archiveToAnalysisRows(archive, meta) {
   const incidents = []
   for (const [id, data] of Object.entries(archive.services || {})) {
     const name = meta[id]?.name || id
-    if (data.score !== null && data.score !== undefined) {
+    // aiwatch#993 — the auto-draft Summary/TL;DR narrates these score NUMBERS, so they must be the
+    // calendar-month value the ranking table shows, not the build-day snapshot. Normalize the same
+    // way the main load point (the `services` array) does, or the draft says "84/100" while the
+    // table says "77".
+    const { score, grade } = charts.resolveMonthlyScore(data)
+    if (score !== null && score !== undefined) {
       scores.push({
         Service: name,
-        Score: String(data.score),
-        Grade: gradeLabel(data.grade),
+        Score: String(score),
+        Grade: gradeLabel(grade),
         Confidence: confidence({ data }),
       })
     }

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -38,6 +38,7 @@ const {
   fillTemplate,
 } = require('./generate-report')
 const assert = require('assert')
+const charts = require('./generate-charts')
 
 let passed = 0
 let failed = 0
@@ -197,6 +198,25 @@ test('archive flag drives staleness; STALE_SOURCE constant is empty since aiwatc
   eq(isStaleSource({ id: 'deepseek', data: { incidentSourceStale: true } }), true) // May archive: flag still set → stale
   eq(isStaleSource({ id: 'deepseek', data: {} }), false)                           // #618 — removed from STALE_SOURCE; absent flag ⇒ not stale (June+)
   eq(isStaleSource({ id: 'cohere', data: {} }), false)                             // neither
+})
+
+console.log('\naiwatch#993 — the ranking table and the trend use the SAME calendar-month score')
+test('ranking table shows monthlyScore, matching what toMonthEntry feeds Notable Movers', () => {
+  // The report normalizes at load (generate-report.js line ~959) via charts.resolveMonthlyScore, so
+  // buildScoreTable receives the monthly value. Reproduce that mapping and assert the table shows 61
+  // (monthly), not 44 (the build-day snapshot) — and that toMonthEntry hands the trend the same 61,
+  // so the same month can never show two different scores.
+  const archive = { services: { deepgram: { score: 44, grade: 'Degrading', monthlyScore: 61, monthlyGrade: 'Fair', uptime: 90, incidents: 6, avgResolutionMin: 456, officialUptime: 99 } } }
+  const services = Object.entries(archive.services).map(([id, data]) => {
+    const { score, grade } = charts.resolveMonthlyScore(data)
+    return { id, data: { ...data, score, grade } }
+  })
+  const table = buildScoreTable(services, { deepgram: { name: 'Deepgram' } }, '2026-06')
+  assert.ok(/\| 61 \|/.test(table), `ranking table must show the monthly score 61: ${table}`)
+  assert.ok(!/\| 44 \|/.test(table), `must NOT show the snapshot score 44: ${table}`)
+
+  const entry = charts.toMonthEntry('2026-06', archive)
+  assert.strictEqual(entry.services.deepgram.score, 61, 'trend/Movers use the same monthly score')
 })
 
 console.log('\nbuildScoreTable + buildRankingNote — stale exclusion (#591)')
@@ -1214,6 +1234,20 @@ console.log('\nintegration: 2026-04 archive end-to-end')
 const fs = require('fs')
 const path = require('path')
 
+  test('archiveToAnalysisRows narrates the monthly score, not the snapshot (aiwatch#993 bypass)', () => {
+    // The auto-draft Summary/TL;DR is built from these rows. If they carried the snapshot score, the
+    // draft would say "84/100" while the ranking table shows the monthly 77 — the two-window
+    // disagreement #993 removes. Reverting the resolveMonthlyScore call here reintroduces it.
+    const archive = { services: {
+      openai: { score: 84, grade: 'good', monthlyScore: 77, monthlyGrade: 'good', incidents: 1, officialUptime: 99 },
+    } }
+    const { scores } = archiveToAnalysisRows(archive, { openai: { name: 'OpenAI API' } })
+    const row = scores.find(r => r.Service === 'OpenAI API')
+    assert.ok(row, 'openai must appear in the analysis rows')
+    assert.strictEqual(row.Score, '77', `must narrate the monthly score, got ${row.Score}`)
+  })
+
+
 test('archiveToAnalysisRows on the real April snapshot yields expected counts', () => {
   const archive = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '_data', '2026-04.json'), 'utf-8'))
   const { scores, incidents } = archiveToAnalysisRows(archive, {})
@@ -1225,6 +1259,23 @@ test('archiveToAnalysisRows on the real April snapshot yields expected counts', 
   // Score column passes through as a numeric string the analyzer can parseInt
   for (const s of scores) assert.ok(/^\d+$/.test(s.Score), `non-integer Score leaked: ${s.Score}`)
 })
+
+  test('full render uses monthlyScore in the ranking table (aiwatch#993 wiring at load)', () => {
+    // End-to-end guard for the line-~959 normalization: inject a monthlyScore that differs from the
+    // snapshot on a ranked service and confirm the RENDERED Score table shows the monthly value.
+    // Reverting the load-point normalization makes this fail (the table would show 84, the snapshot).
+    const archive = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '_data', '2026-04.json'), 'utf-8'))
+    archive.services.openai = { ...archive.services.openai, score: 84, grade: 'good', monthlyScore: 77, monthlyGrade: 'good' }
+    const tmpl = fs.readFileSync(path.join(__dirname, '..', '_templates', 'monthly-report.md'), 'utf-8')
+    const meta = {}
+    for (const id of Object.keys(archive.services)) meta[id] = { name: id }
+    const { fillTemplate } = require('./generate-report')
+    const out = fillTemplate(tmpl, '2026-04', archive, meta)
+    const openaiRow = out.split('\n').find(l => l.startsWith('|') && /openai/.test(l))
+    assert.ok(openaiRow, 'openai must have a ranking row')
+    assert.ok(/\| 77 \|/.test(openaiRow), 'ranking row must show the monthly score 77: ' + openaiRow)
+    assert.ok(!/\| 84 \|/.test(openaiRow), 'must not show the snapshot score 84: ' + openaiRow)
+  })
 
 test('full pipeline against real April archive — Opening reflects 24 of 31, no "undefined" leakage', () => {
   const archive = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '_data', '2026-04.json'), 'utf-8'))


### PR DESCRIPTION
## What

Makes the **entire** monthly report read the calendar-month `monthlyScore`/`monthlyGrade` the worker now stores (aiwatch#993 / aiwatch PR #997), falling back to the build-day snapshot for legacy archives.

## Why

Without this, only Notable Movers would use the calendar-month Score (window-aligned with MTTR/downtime) while the ranking table kept the snapshot — the same service would show two different scores on one page. Adopting it everywhere keeps the whole report on one window.

## How

- **`resolveMonthlyScore`** (single pure helper): key-presence distinguishes a modern archive's **withheld** month (`monthlyScore` present + null → stays null, unranked) from a **legacy** archive (key absent → snapshot fallback).
- Applied at the three archive-load paths that each read `services` raw: the report `services` array (ranking table / chart / Summary / `buildWhy`), `toMonthEntry` (trend + Notable Movers), and `archiveToAnalysisRows` (the auto-draft narrative — the reviewer-caught bypass).
- `scoreConfidence` / `officialUptime` gating left untouched (a separate signal).

A 3-month trend spanning the #993 cutover mixes monthly and snapshot points (legacy archives can't be back-filled) — documented, not a bug.

## Tests

charts 75 + report 209; the ranking-table and auto-draft wiring are mutation-verified end-to-end via `fillTemplate`. Reviewed to 0 Critical/Important across two rounds (caught a real withheld-null-vs-legacy-fallback bug and the auto-draft bypass).

## Merge order & deploy

Last of four: **#77 → #75 → #78 → #993-report**. Depends on aiwatch PR #997 (worker) being deployed + the month's archive rebuilt before `monthlyScore` is populated — until then this is a no-op fallback to the snapshot.

Refs #993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)