### PR TITLE
fix(css): stop the mobile Recommendations cards clipping the Why text

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -113,6 +113,12 @@ tr:nth-child(odd) { background: transparent !important; }
     overflow: hidden !important;
   }
   .recommendations td {
+    /* box-sizing:border-box so width:100% INCLUDES the 12px side padding — content-box added
+       it on top, pushing the cell ~24px past the card so tr{overflow:hidden} clipped the Why
+       text's right edge (aiwatch-reports). */
+    box-sizing: border-box !important;
+    display: block !important;
+    width: 100% !important;
     border: none !important;
     border-bottom: 1px solid var(--border) !important;
     padding: 8px 12px !important;


### PR DESCRIPTION
## Problem

On the stacked-card mobile layout (`<768px`), the Recommendations table clipped the right edge of the **Why** column — e.g. `…the most reliable voice service this mont[h]`, `Modal 94/10[0]`. Not overflow-scroll; the text was flush against the card border with characters hidden.

## Root cause (Playwright-measured)

A box-model bug, not overflow. The mobile `.recommendations td` had `width: 100%` under the default `box-sizing: content-box`, so the `12px` side padding was added **on top of** the 100% width — making each cell `~24px` wider than the card (`343px` vs the `319px` card). `.recommendations tr { overflow: hidden }` then silently clipped that overhang.

Measured at 375px:
- before: `td` right `368` vs card right `343` → 24px clipped
- after: `td` `319px` = card width, right `344` vs card `343`, **no Why cell's text extends past the card border**

## Fix

`box-sizing: border-box` (with the `display: block; width: 100%` the stacked layout relies on) so `width: 100%` includes the padding and the cell fits the card.

## Verification

Rendered the June 2026 report at 375px before/after; screenshots confirm every Why cell now wraps fully inside its card with proper right padding. Site-wide (`.recommendations` is used by every monthly report), so this fixes all months, not just June.

🤖 Generated with [Claude Code](https://claude.com/claude-code)