### PR TITLE
fix(css): align the Official Uptime table header with its body on mobile

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -147,8 +147,11 @@ tr:nth-child(odd) { background: transparent !important; }
   width: 100%;
   table-layout: fixed;
 }
-.uptime-cols tr td:first-child { width: 60%; }
-.uptime-cols tr td:last-child { width: 40%; }
+/* Give the HEADER cells the same 60/40 as the body. Without th widths the thead split 50/50
+   while the body split 60/40, so the "Service | Uptime" divider misaligned the value column
+   by ~29px on mobile (single-column). */
+.uptime-cols tr th:first-child, .uptime-cols tr td:first-child { width: 60%; }
+.uptime-cols tr th:last-child, .uptime-cols tr td:last-child { width: 40%; }
 @media (max-width: 768px) {
   .uptime-cols tbody { columns: 1; }
 }


### PR DESCRIPTION
## Problem

On mobile, the Official Uptime table's header (`Service | Uptime`) divider didn't line up with the body rows — the "Uptime" label sat ~29px left of the percentage column.

## Root cause (Playwright-measured)

`.uptime-cols` sets an explicit 60/40 width on `td:first-child`/`td:last-child`, but the `th` cells were left unsized. Under `table-layout: fixed` the header split 50/50 while the body split 60/40.

At 375px: header divider at 184px, body divider at 213px → 29px misalignment.

## Fix

Give the `th` cells the same 60/40 as the `td` cells:
```scss
.uptime-cols tr th:first-child, .uptime-cols tr td:first-child { width: 60%; }
.uptime-cols tr th:last-child,  .uptime-cols tr td:last-child  { width: 40%; }
```

## Verification

At 375px the header divider (213px) now matches every body row's divider exactly (misalignment 0). Screenshot confirms the "Service | Uptime" labels sit directly above their columns. Site-wide (`.uptime-cols` is used by every monthly report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)