### PR TITLE
fix(css): scope the uptime-table header 60/40 to mobile (keep desktop 50/50)

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -147,13 +147,16 @@ tr:nth-child(odd) { background: transparent !important; }
   width: 100%;
   table-layout: fixed;
 }
-/* Give the HEADER cells the same 60/40 as the body. Without th widths the thead split 50/50
-   while the body split 60/40, so the "Service | Uptime" divider misaligned the value column
-   by ~29px on mobile (single-column). */
-.uptime-cols tr th:first-child, .uptime-cols tr td:first-child { width: 60%; }
-.uptime-cols tr th:last-child, .uptime-cols tr td:last-child { width: 40%; }
+.uptime-cols tr td:first-child { width: 60%; }
+.uptime-cols tr td:last-child { width: 40%; }
 @media (max-width: 768px) {
   .uptime-cols tbody { columns: 1; }
+  /* Single-column on mobile: match the HEADER cells to the body's 60/40 so the "Service | Uptime"
+     divider lines up (without th widths the thead splits 50/50 vs the body's 60/40 — a ~29px
+     misalign). Scoped to mobile: on desktop the body flows into 2 columns while the header is one
+     full-width row, so a 60/40 header divider aligns with neither — keep it the balanced 50/50. */
+  .uptime-cols tr th:first-child { width: 60%; }
+  .uptime-cols tr th:last-child { width: 40%; }
 }
 
 /* ── Header ── */


### PR DESCRIPTION
## Problem

#84 fixed the mobile Official-Uptime header alignment by giving `.uptime-cols th` a 60/40 width — but at top level, so it also applied on desktop. On desktop the body flows into **two** columns (`columns: 2`) while the header is one full-width row; a 60/40 header divider aligns with neither flow column, and "Service" visibly took more than half. Regression from #84.

## Fix

Move the `th` 60/40 rule **into** the `@media (max-width: 768px)` block, next to the `columns: 1` body flip — so the header scheme and the body-column scheme turn over at **one shared breakpoint** and can never disagree (this is what prevents the regression recurring).

- Desktop: `th` unsized → balanced 50/50 header (each label spans one of the two flow columns — the intended "half-half over 2 columns" look).
- Mobile: `th` 60/40 keeps #84's single-column header/body alignment.

## Verification

Playwright at 1100px: header 429/429 (50/50). At 375px: header divider 213px == every body row. **Reviewed to 0 Critical/Important** — the reviewer confirmed both breakpoints flip together, no cascade leak, no bleed to `.recommendations`/ranking tables.

Note: this PR follows up #84 (both should ship; #84 alone leaves desktop broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)