### PR TITLE
style(summary): drop "/100" suffix from auto-draft Score displays

### DIFF
--- a/scripts/generate-summary.js
+++ b/scripts/generate-summary.js
@@ -94,7 +94,7 @@ function analyze(scores, incidents) {
 // ── Text generators ───────────────────────────────────────
 function generateOpening(monthYear, a) {
   if (a.isStable) {
-    return `${monthYear} was a relatively stable month across all monitored services. ${a.top[0]?.Service} led the rankings with a score of ${a.top[0]?.Score}/100, while ${a.zeroIncidents.length} services recorded zero incidents.`
+    return `${monthYear} was a relatively stable month across all monitored services. ${a.top[0]?.Service} led the rankings with a score of ${a.top[0]?.Score}, while ${a.zeroIncidents.length} services recorded zero incidents.`
   }
   const topNames = a.top.map(r => r.Service)
   const topStable = topNames.length > 2
@@ -104,7 +104,7 @@ function generateOpening(monthYear, a) {
   if (worstSvc && a.top.some(t => t.Service === worstSvc.Service)) {
     return `${monthYear}: ${a.withIncidents.length} out of ${a.totalServices} services recorded at least one incident, with a combined downtime of ${fmtDuration(a.totalDowntimeMins)}. ${topStable} led the reliability rankings.`
   }
-  return `${monthYear} showed a clear divide: ${topStable} remained highly stable, while ${worstSvc?.Service} (${worstSvc?.Score}/100) experienced the most challenges. ${a.withIncidents.length} out of ${a.totalServices} services recorded at least one incident, with a combined downtime of ${fmtDuration(a.totalDowntimeMins)}.`
+  return `${monthYear} showed a clear divide: ${topStable} remained highly stable, while ${worstSvc?.Service} (${worstSvc?.Score}) experienced the most challenges. ${a.withIncidents.length} out of ${a.totalServices} services recorded at least one incident, with a combined downtime of ${fmtDuration(a.totalDowntimeMins)}.`
 }
 
 // `momByService` (aiwatch-reports#54 bonus) maps a service display name → { curr, prev }
@@ -116,22 +116,22 @@ function generateTldr(a, incidents, momByService = {}) {
 
   // Most reliable
   if (a.perfectServices.length > 0) {
-    lines.push(`- **Most reliable**: ${a.perfectServices.map(r => r.Service).join(', ')} (${a.perfectServices[0].Score}/100 — zero incidents, perfect uptime)`)
+    lines.push(`- **Most reliable**: ${a.perfectServices.map(r => r.Service).join(', ')} (${a.perfectServices[0].Score} — zero incidents, perfect uptime)`)
   } else {
-    lines.push(`- **Most reliable**: ${a.top[0]?.Service} (${a.top[0]?.Score}/100)`)
+    lines.push(`- **Most reliable**: ${a.top[0]?.Service} (${a.top[0]?.Score})`)
   }
 
   // Best balance
   if (a.balanceSvc) {
     const incRow = incidents.find(r => r.Service === a.balanceSvc.Service)
     const downtime = incRow ? incRow['Total Downtime'] : '—'
-    lines.push(`- **Best balance (stability + ecosystem)**: ${a.balanceSvc.Service} (${a.balanceSvc.Score}/100, only ${downtime} downtime)`)
+    lines.push(`- **Best balance (stability + ecosystem)**: ${a.balanceSvc.Service} (${a.balanceSvc.Score}, only ${downtime} downtime)`)
   }
 
   // Riskiest
   if (a.bottom[0]) {
     const riskRow = incidents.find(r => r.Service === a.bottom[0].Service)
-    lines.push(`- **Riskiest this month**: ${a.bottom[0].Service} (${a.bottom[0].Score}/100${riskRow ? `, ${riskRow['Total Downtime']} total downtime` : ''})`)
+    lines.push(`- **Riskiest this month**: ${a.bottom[0].Service} (${a.bottom[0].Score}${riskRow ? `, ${riskRow['Total Downtime']} total downtime` : ''})`)
   }
 
   // Most incidents (MoM-framed when a prior-month count is available — #54 bonus)

--- a/scripts/generate-summary.test.js
+++ b/scripts/generate-summary.test.js
@@ -207,7 +207,7 @@ test('generates volatile opening', () => {
   assert(text.includes('March 2026'), 'should include month')
   assert(text.includes('ServiceA'), 'should include top service')
   assert(text.includes('ServiceD'), 'should include worst service')
-  assert(text.includes('52/100'), 'should include worst score')
+  assert(text.includes('ServiceD (52)'), 'should include worst score')
   assert(text.includes('29h 20m') || text.includes('combined downtime'), 'should include combined downtime')
 })
 
@@ -241,7 +241,7 @@ test('includes all required sections', () => {
 test('most reliable shows perfect services', () => {
   const a = analyze(MOCK_SCORES, MOCK_INCIDENTS)
   const text = generateTldr(a, MOCK_INCIDENTS)
-  assert(text.includes('ServiceA (100/100'), 'should show perfect score service')
+  assert(text.includes('ServiceA (100'), 'should show perfect score service')
 })
 
 test('MoM-frames the Most-incidents bullet when a prior count is provided (aiwatch-reports#54)', () => {


### PR DESCRIPTION
## What

The monthly-report **Summary auto-draft** (`scripts/generate-summary.js`) rendered scores as `${Score}/100` in 6 places (opening line + Most-reliable / Best-balance / Riskiest TL;DR bullets), while every other section — the **ranking table**, **Notable Movers**, and the **Insights** prose — shows bare numbers. Only the Summary carried the `/100` suffix.

The report already establishes the scale once, via the Summary's **"AIWatch Score (0–100)"** definition line, so the per-number suffix is redundant. Adding `/100` everywhere instead would read poorly (`62 → 64/100`, `scored 91/100, 79/100 and 74/100`), so the consistent direction is bare numbers everywhere.

## Change
- `generate-summary.js`: drop `/100` from all 6 score-display sites (opening ×2, Most-reliable ×2, Best-balance, Riskiest).
- `generate-summary.test.js`: update the 2 assertions that pinned `52/100` / `100/100` → `ServiceD (52)` / `ServiceA (100`. **34/34 pass.**

Presentation-only — no scoring, ranking, or data change. The template's Recommendations rows never carried `/100`; the June draft's Recommendations `/100` was a hand-authored value and is fixed separately in that draft.

## Verification
- `node scripts/generate-summary.test.js` → 34/34.
- Code review (code-reviewer): 0 Critical / Important / Suggestion.
- Rendered June draft: 0 `/100` in Summary/Recommendations HTML; scores show as `Windsurf 100`, `Modal 94`, `Deepgram (45)`.

No tracking issue (free-form presentation-consistency fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)