### PR TITLE
fix(security): suppress single-`detected` OSV timelines in Top Findings (refs #87)

### DIFF
--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -629,6 +629,12 @@ function buildByServiceTable(byService, limit = 5) {
 
 function buildTimelineDetails(timeline) {
   if (!Array.isArray(timeline) || timeline.length === 0) return ''
+  // #291 timelines exist to show PROGRESSION (detected → fix_released → severity_changed → …).
+  // A timeline whose only stage is the initial `detected` carries no progression: it merely
+  // duplicates the `Detected:` bullet above it, or — when the alert's first-ever sighting predates
+  // this month's collection window — contradicts it with an earlier date (aiwatch-reports#87).
+  // Render only when a non-`detected` stage exists.
+  if (!timeline.some(e => e && e.stage && e.stage !== 'detected')) return ''
   const rows = timeline.map(e =>
     `| ${e.stage ?? '—'} | ${fmtIso(e.at)} | ${e.severity ?? '—'} | ${e.fixedVersion ?? '—'} |`,
   )

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -754,13 +754,41 @@ test('returns empty string when timeline is undefined', () => {
   eq(buildTimelineDetails(undefined), '')
 })
 test('renders em dash when severity or fix version is missing', () => {
-  const out = buildTimelineDetails([{ stage: 'detected', at: '2026-04-15' }])
-  assert.ok(out.includes('detected | 2026-04-15 | — | —'), `missing fields: ${out}`)
+  // Needs a non-`detected` stage so the timeline renders at all (#87 progression gate); the
+  // fix_released row omits severity + fixedVersion to exercise the em-dash fallback.
+  const out = buildTimelineDetails([
+    { stage: 'detected', at: '2026-04-15', severity: 'high' },
+    { stage: 'fix_released', at: '2026-04-20' },
+  ])
+  assert.ok(out.includes('fix_released | 2026-04-20 | — | —'), `missing fields: ${out}`)
 })
 test('renders em dash for missing stage so undefined never appears in a table cell', () => {
-  const out = buildTimelineDetails([{ at: '2026-04-15' }])
+  // A real progression stage makes the block render; the malformed stageless entry must still
+  // print em-dash, not "undefined".
+  const out = buildTimelineDetails([
+    { stage: 'fix_released', at: '2026-04-20', severity: 'high', fixedVersion: '1.0.0' },
+    { at: '2026-04-15' },
+  ])
   assert.ok(!out.includes('undefined'), `stage fallback: ${out}`)
   assert.ok(out.includes('— | 2026-04-15 | — | —'), `stage = em dash: ${out}`)
+})
+// aiwatch-reports#87 — suppress single-`detected` timelines (no progression → noise, and a
+// first-sighting `detected` date can contradict the this-month `Detected:` bullet).
+test('suppresses a timeline whose only stage is the initial detected (#87)', () => {
+  eq(buildTimelineDetails([{ stage: 'detected', at: '2026-05-13', severity: 'high' }]), '')
+})
+test('suppresses when no non-detected stage exists, even across multiple entries (#87)', () => {
+  // a malformed stageless entry does not count as progression
+  eq(buildTimelineDetails([{ stage: 'detected', at: '2026-05-13' }, { at: '2026-05-14' }]), '')
+})
+test('still renders once a non-detected stage appears — real progression (#87)', () => {
+  const out = buildTimelineDetails([
+    { stage: 'detected', at: '2026-05-13', severity: 'high' },
+    { stage: 'fix_released', at: '2026-05-20', severity: 'high', fixedVersion: '0.8.0' },
+  ])
+  assert.ok(out.includes('<details'), `renders: ${out}`)
+  assert.ok(out.includes('detected | 2026-05-13'), `keeps detected row: ${out}`)
+  assert.ok(out.includes('fix_released | 2026-05-20 | high | 0.8.0'), `progression row: ${out}`)
 })
 
 console.log('\nbuildTopFindings')
@@ -769,7 +797,11 @@ test('renders OSV finding with timeline expansion', () => {
     title: 'GHSA-1234 langchain SSRF', url: 'https://example.com/x',
     source: 'osv', severity: 'high', service: 'langchain',
     detectedAt: '2026-04-10T12:00:00Z',
-    timeline: [{ stage: 'detected', at: '2026-04-10T12:00:00Z', severity: 'high' }],
+    // needs a non-`detected` stage to render at all (#87 progression gate)
+    timeline: [
+      { stage: 'detected', at: '2026-04-10T12:00:00Z', severity: 'high' },
+      { stage: 'fix_released', at: '2026-04-14T12:00:00Z', severity: 'high', fixedVersion: '0.3.1' },
+    ],
   }])
   assert.ok(out.includes('### Top Findings'), `top heading: ${out}`)
   assert.ok(out.includes('1. [GHSA-1234 langchain SSRF](https://example.com/x)'), `link title: ${out}`)
@@ -781,7 +813,12 @@ test('omits timeline section for HN findings even if timeline field set (defensi
   const out = buildTopFindings([{
     title: 'HN post', url: 'https://news.ycombinator.com/item?id=1',
     source: 'hackernews', severity: 'medium', detectedAt: '2026-04-12',
-    timeline: [{ stage: 'detected', at: '2026-04-12' }], // shouldn't happen but be safe
+    // multi-stage so ONLY the HN source-gate can suppress it (not the #87 progression gate) —
+    // proves the source check, not an incidental single-detected suppression
+    timeline: [
+      { stage: 'detected', at: '2026-04-12' },
+      { stage: 'fix_released', at: '2026-04-15', fixedVersion: '2.0.0' },
+    ], // shouldn't happen but be safe
   }])
   assert.ok(!out.includes('<details'), `HN must never render timeline: ${out}`)
 })


### PR DESCRIPTION
Refs #87.

## Problem
`buildTimelineDetails` (`scripts/generate-report.js`) rendered a `<details>Timeline` block for any OSV finding whose timeline had ≥1 entry. But OSV timelines (aiwatch#291) exist to show **progression** (`detected → fix_released → severity_changed → …`). A timeline whose only stage is the initial `detected` carries no progression — it just **duplicates** the `Detected:` bullet above it, or (when the alert's first-ever sighting predates this month's collection window) **contradicts** it with an earlier date.

Observed in the June 2026 draft — all 4 timelines were single-`detected`:

| Finding | `Detected:` bullet | timeline `detected` row |
|---|---|---|
| #2, #5 | June | same June date (duplicate) |
| #3 | 2026-06-09 | **2026-05-13** ❌ |
| #4 | 2026-06-03 | **2026-05-09** ❌ |

The two dates differ by scope (verified in worker `security-monitor.ts`): the timeline `detected.at` is the alert's **first-ever** sighting (permanent `security:timeline:osv:{id}` record), the bullet is **this month's** `detectedAt`. Same word, two meanings.

## Fix
One guard in `buildTimelineDetails`: render only when a non-`detected` stage exists —
```js
if (!timeline.some(e => e && e.stage && e.stage !== 'detected')) return ''
```
Real multi-stage timelines render unchanged; progression-free ones are dropped. The `Detected:` bullet (the authoritative this-month date) still renders independently.

## Tests
- Existing single-`detected` fixtures given a progression stage so they keep exercising the em-dash fallback / OSV-render / HN-suppression paths. HN case strengthened to multi-stage so it proves the *source* gate, not an incidental single-`detected` suppression.
- New: single-`detected` → suppressed; no non-`detected` stage across multiple entries → suppressed; real progression → rendered.
- **238/238 pass.**

## Verification
- `node scripts/generate-report.test.js` → 238/238.
- Code review (code-reviewer): 0 Critical/Important; predicate confirmed to suppress only progression-free timelines and never a real multi-stage one; caller `buildTopFindings` drops the `''` cleanly.
- June 2026 draft: applied the same suppression to the working tree, rendered in local Jekyll — 0 Timeline `<details>`, all 7 `Detected:` bullets intact, the contradictory May dates gone. **In-browser confirmed.**

## Not closing (`refs`, not `closes`)
The June draft's rendered application lives in the `report/2026-06` draft (still under review, uncommitted) — Acceptance item 4 lands when that draft is committed. Keeping #87 open to track it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)