### PR TITLE
docs(report): link Score methodology to canonical /methodology#score

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Each monthly report includes:
 - **API probe**: Direct RTT measurement every 5 minutes to 31 probe targets with public endpoints (supplementary monitoring data)
 - **3-Month Trend (Notable Movers)**: ranked by the largest single change across **Score / MTTR / total downtime** over the window — incident-feed *measured* metrics. Uptime is deliberately excluded: the archive's `uptime` field mixes per-service sources (status-page group aggregates, estimate/poll-derived figures) so a cross-service uptime delta is misleading (a 3-month official-uptime trend awaits aiwatch#586 + ≥3 months of the clean `officialUptime` field). Direction (🔺/🔻) follows the bold *headline* metric, not Score. Services the Score ranking excludes (no-incident-feed / stale source) are excluded from movers too. The first point is flagged when its month is partial (mid-month onboarding); MTTR/downtime are measured over the months that have incident data.
 
-Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
+Full methodology: [ai-watch.dev/methodology#score](https://ai-watch.dev/methodology#score)
 
 ---
 

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -84,7 +84,7 @@ published: true
 
 > *"Which AI service is safest to rely on in production?"*
 
-Combines four components — Uptime (40%), Incident affected days (25%), Recovery speed (15%), Responsiveness (20%, derived from each service's median (p50) probe RTT and its RTT stability). The [API Response Time — Monthly p75](#api-response-time--monthly-p75) table below is a separate network-latency reference, not the Responsiveness input; full breakdown of weights, fallbacks, and penalties is in [About This Report → AIWatch Score](#about-this-report). [How it's calculated →](https://ai-watch.dev/#about-score)
+Combines four components — Uptime (40%), Incident affected days (25%), Recovery speed (15%), Responsiveness (20%, derived from each service's median (p50) probe RTT and its RTT stability). The [API Response Time — Monthly p75](#api-response-time--monthly-p75) table below is a separate network-latency reference, not the Responsiveness input; full breakdown of weights, fallbacks, and penalties is in [About This Report → AIWatch Score](#about-this-report). [How it's calculated →](https://ai-watch.dev/methodology#score)
 
 <!-- SCORE_RANKING_NOTE -->
 
@@ -208,7 +208,7 @@ Actionable takeaways per service. Descriptive context for each event lives in ea
 
 * **Data Sources:** Real-time data is aggregated from official status pages via multiple frameworks, including Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, OnlineOrNot, and RSS feeds (Source: [ai-watch.dev](https://ai-watch.dev)).
 * **Monitoring Frequency:** All 43 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
-* **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). A service with no probe endpoint is scored on the remaining components rescaled to 100, with **no penalty**. A service that has a probe but fewer than 7 days of samples gets that same rescale **plus a 5% penalty** until its probe data matures. Full methodology: [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
+* **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). A service with no probe endpoint is scored on the remaining components rescaled to 100, with **no penalty**. A service that has a probe but fewer than 7 days of samples gets that same rescale **plus a 5% penalty** until its probe data matures. Full methodology: [ai-watch.dev/methodology#score](https://ai-watch.dev/methodology#score)
 * **Uptime Source:** *Official* = the service publishes a rolling uptime % that AIWatch reads directly from its status page (the window varies by page — 30 or 90 days). *No official uptime* = the provider publishes no comparable figure. AIWatch **invents none**: the Score simply drops its 40-point Uptime component and is rescaled over the remaining signals (incidents, recovery, responsiveness), A service that still has a probe is scored and ranked on what can be measured; one with **neither** uptime **nor** a probe has too little signal, so its Score is withheld and it is not ranked. The note above the Score table names whichever services that is — the membership is read from the data, not fixed here. A service AIWatch tracked for only part of the month is **excluded from the ranking** rather than labelled (aiwatch-reports#45) — its partial-month Score would rest on insufficient coverage. The label describes the Uptime input, not the Score's rigour.
 * **Incident Counting:** Counts are the incidents each provider published, attributed to the service they affected. Providers differ in granularity, and in *where* that granularity lives: Anthropic maps to a single status-page component but posts one incident **per model**; Together AI tracks each model as its own **resource**, so one event can surface as several incidents. Others post one incident per event at the service level. Compare counts only across providers with comparable granularity.
 * **Uptime Metrics:** Uptime percentages are the official figure each status page exposes — read from the page directly, or aggregated by AIWatch from the per-component availabilities it publishes — for some services a single component, for others a worst-of across a component set, for others still an upstream platform average, depending on what the page exposes. Services marked with "—" publish no accessible uptime metric.
@@ -221,7 +221,7 @@ Actionable takeaways per service. Descriptive context for each event lives in ea
 
 - **Live status** — [ai-watch.dev](https://ai-watch.dev)
 - **Slack/Discord alerts** — [ai-watch.dev/#settings](https://ai-watch.dev/#settings)
-- **Score methodology** — [ai-watch.dev/#about-score](https://ai-watch.dev/#about-score)
+- **Score methodology** — [ai-watch.dev/methodology#score](https://ai-watch.dev/methodology#score)
 - **All reports** — [ai-watch.dev/reports](https://ai-watch.dev/reports/)
 
 ---


### PR DESCRIPTION
## Problem
The report template + README linked "Score methodology" to **`ai-watch.dev/#about-score`**, a legacy hash. Since aiwatch#673 the in-dashboard `#about-score` page was unified into the public `/methodology` page — the legacy hash now only resolves via a **client-side redirect shim** in the SPA (`hashRoute.js` → `window.location.replace('/methodology#score')`).

Relying on the shim is a double-hop (dashboard load → JS redirect → methodology), hurts SEO, and breaks for non-JS consumers (crawlers, link previews, RSS readers). The real address differs from what the link shows.

## Change
Point future reports at the canonical **`https://ai-watch.dev/methodology#score`** (real `id="score"` anchor on the page):
- `_templates/monthly-report.md` — 3 links (How it's calculated / Full methodology / Score methodology)
- `README.md` — 1 link

`ai-watch.dev/#settings` left unchanged — it is still a valid current SPA route, not a legacy redirect. The SPA redirect shim stays as a backstop for already-published reports + external bookmarks.

## Scope
Template (all future reports) + README. **Already-published past reports (2026-03/04/05) intentionally left unchanged** — the shim keeps them working; the operator opted to preserve them as historical artifacts. The June 2026 draft is fixed separately in its `report/2026-06` branch (in-browser verified: 3 links now resolve to `/methodology#score`, 0 legacy).

## Verification
- Canonical target confirmed: `/methodology` renders `<section id="score">` (aiwatch `api/_methodology/html-template.ts`).
- June draft rendered in local Jekyll — all 3 methodology links now `href="https://ai-watch.dev/methodology#score"`, 0 `#about-score`. In-browser confirmed.
- Diff verified minimal — only `about-score` links changed; `#settings` and all other links untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)