### PR TITLE
fix(report): gate Component Reliability to ranked services + fix intro claim

### DIFF
--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -816,11 +816,19 @@ function buildDetectionSection(archive, meta) {
 // AIWatch differentiator: no competitor publishes a monthly per-component uptime ranking. EN-only,
 // like the other data tables. Returns '' (section omitted) when nothing qualifies. Pure + tested.
 const COMPONENT_WEAK_THRESHOLD = 99.9
-function buildComponentReliabilitySection(archive, meta) {
+function buildComponentReliabilitySection(archive, meta, month) {
   const services = archive && archive.services
   if (!services || typeof services !== 'object') return ''
+  // Exclude the services the Score ranking itself excludes — withheld (no uptime + no probe),
+  // stale-source (frozen/dead status page), and mid-month adds — mirroring buildTrendSection. A
+  // service the report says it cannot rank should not appear in a reliability breakdown either;
+  // in particular a service whose status page went dark contributes only a frozen partial window
+  // (e.g. Character.AI, deactivated mid-June — a 6-day window, not comparable to the full-window
+  // rows), which is exactly the mis-read the caption used to warn against (aiwatch-reports#91).
+  const exclude = charts.buildMoverExclude(services, month)
   const rows = []
   for (const [id, s] of Object.entries(services)) {
+    if (exclude.has(id)) continue
     const comps = s && Array.isArray(s.components) ? s.components : null
     if (!comps || comps.length < 2) continue // curation already ≥2; defensive
     const weakest = comps[0] // least-reliable-first
@@ -838,7 +846,7 @@ function buildComponentReliabilitySection(archive, meta) {
     // The window is NOT the month: per-component counting is younger than the report, and a service
     // whose status page goes dark simply stops contributing days (aiwatch-reports#73). Say "the days
     // AIWatch could read its status page", which is what the ratio actually measures.
-    "> AIWatch is the only monitor publishing a **per-component uptime ranking**. This surfaces each multi-surface service's weakest component over the days AIWatch could read its status page — the surface most likely to be your bottleneck, which a single service-level uptime number hides. It is a different measurement from the Official Uptime table; see [About This Report → Component Reliability](#about-this-report).",
+    "> AIWatch surfaces a **per-component uptime breakdown** — each multi-surface service's weakest component over the days AIWatch could read its status page, the surface most likely to be your bottleneck that a single service-level uptime number hides. It is a different measurement from the Official Uptime table and **is not a Score input**; see [About This Report → Component Reliability](#about-this-report).",
     '',
     '| Service | Weakest Component | Uptime | Components |',
     '|---|---|---|---|',
@@ -1152,7 +1160,7 @@ function fillTemplate(template, month, archive, meta) {
   // Component Reliability section (aiwatch#605 Phase 3b) — same marker pattern. The section
   // emits its own trailing `---`; when omitted, strip the marker so the preceding Official
   // Uptime `---` stays the single rule before API Response Time.
-  const componentSection = buildComponentReliabilitySection(archive, meta)
+  const componentSection = buildComponentReliabilitySection(archive, meta, month)
   if (componentSection) {
     out = out.replace(/<!-- COMPONENT_RELIABILITY_SECTION -->/, componentSection)
   } else {

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -1941,6 +1941,33 @@ test('renders one weakest-component row per qualifying service, weakest-first', 
   assert.ok(out.includes('| ChatGPT | Conversations | 99.20% | 2 |'), 'weakest component + uptime + count')
   assert.ok(!out.includes('Groq'), 'all-healthy service skipped')
 })
+// aiwatch-reports#91 — a service the Score ranking excludes (withheld / stale-source / mid-month
+// add) must not appear in Component Reliability either: its per-component window is partial/frozen
+// and not comparable to the full-window rows (Character.AI, status page deactivated mid-June).
+test('excludes a stale-source service even if its weakest component would qualify (#91)', () => {
+  const out = buildComponentReliabilitySection({ services: {
+    openai: { components: [{ id: 'l', name: 'Login', uptime: 99.66 }, { id: 'c', name: 'Chat', uptime: 99.98 }] },
+    characterai: { incidentSourceStale: true, components: [{ id: 'x', name: 'Character.AI', uptime: 98.46 }, { id: 'y', name: 'Y', uptime: 100 }] },
+  } }, { openai: { name: 'OpenAI API' }, characterai: { name: 'Character.AI' } }, '2026-06')
+  assert.ok(out.includes('OpenAI API'), `keeps ranked service: ${out}`)
+  assert.ok(!out.includes('Character.AI'), `drops stale-source service: ${out}`)
+})
+test('excludes a Score-withheld service (bedrock/azure id-set) from the table (#91)', () => {
+  const out = buildComponentReliabilitySection({ services: {
+    openai: { components: [{ id: 'l', name: 'Login', uptime: 99.66 }, { id: 'c', name: 'Chat', uptime: 99.98 }] },
+    bedrock: { components: [{ id: 'x', name: 'US-East', uptime: 97.0 }, { id: 'y', name: 'EU', uptime: 100 }] },
+  } }, { openai: { name: 'OpenAI API' }, bedrock: { name: 'Amazon Bedrock' } }, '2026-06')
+  assert.ok(out.includes('OpenAI API'), `keeps ranked service: ${out}`)
+  assert.ok(!out.includes('Bedrock'), `drops withheld service: ${out}`)
+})
+test('the intro calls the table a breakdown, not a ranking, and disclaims Score membership (#91)', () => {
+  const out = buildComponentReliabilitySection({ services: {
+    deepgram: { components: [{ id: 'a', name: 'A', uptime: 65.81 }, { id: 'b', name: 'B', uptime: 100 }] },
+  } }, { deepgram: { name: 'Deepgram' } }, '2026-06')
+  assert.ok(!/only monitor/.test(out), `no unverifiable "only monitor" claim: ${out}`)
+  assert.ok(!/uptime ranking/.test(out), `not called a ranking: ${out}`)
+  assert.ok(/is not a Score input/.test(out), `discloses it is not scored: ${out}`)
+})
 test('skips a single-component service (needs >=2)', () => {
   eq(buildComponentReliabilitySection({ services: {
     solo: { components: [{ id: 'a', name: 'API', uptime: 98 }] },


### PR DESCRIPTION
## Problem
The **Component Reliability** table (`buildComponentReliabilitySection`) listed every service with ≥2 components whose weakest is <99.9%, with **no coverage gate**. Two issues surfaced reviewing the June 2026 report:

1. **Character.AI wrongly included.** Its status page was deactivated mid-June, so its per-component uptime rests on a **frozen 6-day window** (12–17 June) vs ~19 days for the other rows — yet the Score ranking AND the p75 latency table both exclude it. The report even carried a hand-written caption warning "should not be read against the rows around it": a signal the row didn't belong.
2. **Intro overclaim + self-contradiction.** "AIWatch is **the only monitor** publishing a per-component uptime **ranking**" is an unverifiable absolute, and it contradicts About This Report, which calls the same table "a list of where to look, **not a ranking** of everything."

## Change
1. **Coverage gate** — exclude the same set the ranking excludes (withheld / stale-source / mid-month adds) via the existing `buildMoverExclude`, mirroring `buildTrendSection`. `buildComponentReliabilitySection` gains a `month` param; the call site passes it. Drops **only Character.AI** this month; the other 8 rows are unchanged.
2. **Intro** → "AIWatch **surfaces** a per-component uptime **breakdown** … **is not a Score input**" — removes the absolute + the ranking contradiction, and discloses it isn't scored.

## Tests
- 3 new: stale-source excluded, withheld (bedrock/azure id-set) excluded, intro wording (no "only monitor"/"ranking", has "is not a Score input"). All fail on revert.
- Existing tests unchanged. **241/241 report, 129/129 charts pass.**

## Verification
- Ran the fixed builder against the real June archive: Character.AI gone, 8 rows remain (Deepgram, Codex, ChatGPT, Cursor, Cerebras, AssemblyAI, OpenAI, Copilot), intro fixed.
- Code review (code-reviewer): 0 Critical/Important; gate shape/`buildMoverExclude` reuse confirmed correct, `month=undefined` legacy calls safe.
- June 2026 draft updated separately (row + orphaned caption removed, intro aligned), in-browser verified.

## Scope
Generator (future reports) + June draft (its `report/2026-06` branch). Why this belongs in the generator: fixing only the draft would let next month re-emit the ungated table + the old intro (the twin the earlier June-only intro edit missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)