### PR TITLE
fix(report): include Pinecone in the API Response Time p75 table

### DIFF
--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -62,9 +62,11 @@ const NEVER_PUBLISHES_UPTIME = new Set(['bedrock', 'azureopenai'])
 // (SCORE_WITHHELD / STALE_SOURCE / isStaleSource / isRecentlyAdded moved to generate-charts.js
 // as the mover-exclusion single source of truth — aiwatch-reports#67; imported above.)
 
-// Services without direct probe coverage (excluded from API Response Time ranking).
-// Archive.avgLatencyMs will be null for these — tracked for explicit messaging.
-const NO_PROBE = new Set(['bedrock', 'azureopenai', 'pinecone'])
+// Services with no direct probe (excluded from the API Response Time ranking); archive.avgLatencyMs
+// is null for these. Pinecone is NOT here: the Worker DOES probe it (control-plane RTT) and the live
+// dashboard ranks it, so dropping it from the report's p75 table alone was a stale inconsistency with
+// its non-null archive.avgLatencyMs and the dashboard's latency ranking.
+const NO_PROBE = new Set(['bedrock', 'azureopenai'])
 
 // ── CLI parsing ──────────────────────────────────────────────────────
 function parseCliMonth(argv) {

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -588,6 +588,18 @@ test('excludes NO_PROBE services', () => {
   const table = buildLatencyTable(services, { bedrock: { name: 'Amazon Bedrock' } })
   assert.ok(!table.includes('Amazon Bedrock'), 'bedrock should be excluded')
 })
+test('a probed service with a real p75 (e.g. Pinecone) is included; only bedrock/azure are dropped', () => {
+  // Pinecone was previously (wrongly) in NO_PROBE despite the Worker probing it (control-plane RTT)
+  // and archiving a non-null avgLatencyMs — dropping it from the p75 table disagreed with both the
+  // archive and the live dashboard latency ranking. It must now render.
+  const services = [
+    { id: 'pinecone', data: { avgLatencyMs: 844 } },
+    { id: 'bedrock', data: { avgLatencyMs: 999 } },
+  ]
+  const table = buildLatencyTable(services, { pinecone: { name: 'Pinecone' }, bedrock: { name: 'Amazon Bedrock' } })
+  assert.ok(table.includes('Pinecone'), `pinecone has a probe p75 → must appear: ${table}`)
+  assert.ok(!table.includes('Amazon Bedrock'), 'bedrock (genuinely no probe) still excluded')
+})
 test('uses competition ranking for ties (not sequential)', () => {
   // Two services tied at 230ms must both render with "N=" suffix; third slot skips to 3.
   const services = [


### PR DESCRIPTION
## Problem
The **API Response Time — Monthly p75** table (`buildLatencyTable`) filters on `avgLatencyMs !== null && !NO_PROBE.has(id)`, and `NO_PROBE` listed **`pinecone`**. But Pinecone is genuinely probed:
- Worker `probe.ts`: `{ id: 'pinecone', url: 'https://api.pinecone.io/indexes' }` (control-plane, 401 — the RTT is still a real measurement).
- June monthly archive: `avgLatencyMs: 844` (non-null).
- Live dashboard `src/pages/Latency.jsx`: ranks it (excludes only `category==='app'` = Character.AI; pinecone is `api`).

So the **report was the only surface dropping Pinecone** from the latency ranking — disagreeing with the archive AND the dashboard. The `NO_PROBE` comment even claimed "avgLatencyMs will be null for these", which is false for pinecone. (The front-matter `description` even highlights "Pinecone" as an example service, so its absence was conspicuous.)

## Change
- Remove `pinecone` from `NO_PROBE` → `['bedrock', 'azureopenai']` (which truly carry null latency). Comment corrected.
- New test: a probed service with a real p75 (Pinecone, 844) IS included; bedrock (no probe) still excluded. Fails if pinecone is re-added.
- **242/242 pass.**

## Verification
- Ran the fixed `buildLatencyTable` against the real June archive: 28 rows (was 27), **Pinecone at rank 19 (844ms)** between Stability AI (765) and AssemblyAI (901); Deepgram still last (2030ms, "slowest" claims hold).
- Code review (code-reviewer): 0 Critical/Important; NO_PROBE has a single reader (the p75 filter), no count/caveat/score-note keys off pinecone∈NO_PROBE, fix mirrors the dashboard rather than introducing a semantic difference.
- June draft updated separately (Pinecone row inserted + ranks 19–28 renumbered), in-browser verified.

## Scope
Generator (future reports) + June draft (its `report/2026-06` branch). Generator-level because fixing only the draft would let next month re-drop Pinecone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)