### PR TITLE
docs(report): two-tier Observations — Resilience Patterns page + monthly deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each monthly report includes:
 - **Incident Summary** — Total downtime and incident counts per service
 - **Official Uptime** — Provider-reported uptime figures
 - **Notable Incidents** — Top 5 incidents with root cause and impact
-- **Observations** — Developer recommendations based on the data
+- **Observations** — This month's per-service resilience *deltas* (the specific failure mode the month surfaced), each tied to an evergreen pattern in [Resilience Patterns](resilience.md) with a link — the single home for the month's actionable advice. **Not** picks (Recommendations), event description (Notable Incidents), the count caveat (Incident Summary), or the evergreen how-to (Resilience Patterns)
 
 ---
 

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -183,20 +183,30 @@ These p75 figures are a network-latency reference: direct API-endpoint round-tri
 
 ## Observations
 
-Actionable takeaways per service. Descriptive context for each event lives in earlier sections — [Summary](#summary), [Incident Summary](#incident-summary), and [Notable Incidents](#notable-incidents). This section is what to *do* with that data — keep each bullet prescriptive, not a recap.
+**This month's** per-service resilience deltas — what each service's data *newly* argues for. The evergreen, month-to-month-stable patterns (per-model monitoring, Voice-Agent isolation, key rotation, retry-timeout tuning, failover mechanics) live once in **[Resilience Patterns](../resilience/)** — link there, don't re-explain them. Each bullet ties THIS month's failure mode to the relevant pattern and adds only what's new.
 
-- **If you build on [Service]**: <!-- one-sentence operational guidance -->
-- **Quietly reliable picks within their own role**: <!-- 2-3 services with low-but-nonzero incident counts + fast recovery, each labelled with its actual category (e.g. "OSS model hosting", "serverless GPU compute", "LLM tier fallback"). Make the role explicit so readers don't misread the list as a single-tier fallback set. -->
-<!-- Two cautions when picking these:
-     (1) Avoid restating zero-incident services — those already live in
-         Incident Summary's "Zero incidents recorded" note and the Official
-         Uptime caveat (both above). Pick services with low-but-nonzero
-         counts whose Score + recovery profile demonstrates resilience under
-         real traffic, not just absence of incidents.
-     (2) Don't lump cross-category services as a single "fallback set" —
-         services in EXCLUDE_FALLBACK (Hugging Face, Modal, Replicate,
-         Pinecone, etc.) are not drop-in LLM-API replacements. Always
-         attach the use-case label so readers don't infer interchangeability. -->
+<!-- ROLE BOUNDARY — this section vs its neighbours (they blur; keep each to its ONE job):
+     • Recommendations   = the PICKS TABLE — WHO to use per use case. Only place for picks.
+     • Notable Incidents = the EVENT — what happened + why it mattered. DESCRIBE; do not prescribe.
+     • Incident Summary note = how to READ the counts (granularity; count ≠ reliability). Only home for that.
+     • ../resilience/ (Resilience Patterns) = the EVERGREEN, structural how-to-build guidance that holds
+       every month (per-model monitoring, Voice-Agent isolation, Gemini key rotation + dual monitoring,
+       retry timeout = the Longest column, coding-agent auto-failover). Stated ONCE there — do NOT re-lecture
+       it monthly; that cross-month repetition is exactly what this split fixes. New evergreen pattern? Add it
+       to that page, not here.
+     • Observations (here) = THIS MONTH'S DELTA only — the specific failure mode the month surfaced, tied to
+       the relevant Resilience pattern with a link. The only home for the month's actionable advice, so Notable
+       Incidents stays descriptive (don't end an incident with "keep a fallback" — put the delta here + link).
+     THE TEST for a bullet: would it read identically next month? If yes, it's evergreen — move it to
+     ../resilience/ and link. Every bullet must carry a DATE-TIED fact (this month X's worst was a 27h Y; a
+     single 72h Z) and point at the pattern, not restate the architecture. A partial-month / withheld-Score
+     CAVEAT (e.g. Character.AI) is a legitimate month-specific bullet too. -->
+
+
+- **[Service]**: <!-- THIS month's date-tied failure fact (e.g. "its worst incident was a 27h streaming-STT degradation; p75 the highest probed"), DEEP-linked to the relevant Resilience pattern ([Resilience → Voice/transcription](../resilience/#voice--transcription-deepgram)). Do NOT re-explain the evergreen pattern — link it. -->
+- **[Service]**: <!-- 2-4 bullets total; only services whose THIS-MONTH data yields a new lesson. If a service's story is unchanged from a prior report, omit it (the pattern already lives in ../resilience/). -->
+<!-- A partial-month / withheld-Score CAVEAT bullet (e.g. Character.AI: why its Score is absent + how to read
+     its half-month counts) belongs here too — it's month-specific and not an evergreen pattern. -->
 
 ---
 

--- a/resilience.md
+++ b/resilience.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: "Resilience Patterns — Building on AIWatch-Monitored Services"
+description: "Structural, month-to-month-stable guidance for building reliably on the AI services AIWatch monitors: per-model monitoring, voice-agent isolation, key rotation, retry-timeout tuning, and failover mechanics."
+permalink: /resilience/
+published: true
+---
+
+Structural guidance for building reliably on the services AIWatch monitors. These patterns are properties of each service's architecture, so they hold month to month — the monthly reports' **Observations** point here and add only what's *new* that month. Read a report's Observations for this month's specific failure mode; read this page for how to build against it.
+
+---
+
+## Anthropic (Claude API, Claude Code, claude.ai)
+
+- **Monitor the per-model components individually** (Opus / Sonnet / Haiku / …), not the aggregated incident count across them. Single-model traffic isn't well represented by the combined total, and retry / failover decisions need per-model granularity.
+- **The three surfaces share Anthropic infrastructure and can fail together** — you can't fail over from one Anthropic surface to another. For real redundancy, pair Anthropic with a **non-Anthropic** provider, not with itself.
+
+## Voice / transcription (Deepgram)
+
+- **The Voice Agent carries an upstream-LLM dependency.** The longest Deepgram incidents trace back to that surface, so a single-LLM Voice Agent setup takes the full upstream blast radius — **configure multiple LLM providers for failover**.
+- **Isolate the Voice Agent from your core STT/TTS** so an upstream-LLM incident can't take down basic transcription.
+- **Real-time transcription is a hot path**, and Deepgram is consistently the slowest probed service — route it behind a **degradation-aware fallback** to a second provider. A latency degradation alone (not only a hard outage) stalls real-time audio.
+
+## Gemini
+
+- **Prefer long-lived keys with a rotation cadence ≥ monthly** — newly-created keys have been the affected scope in past incidents.
+- **Monitor BOTH gcloud Vertex and AI Studio** — they don't always agree, and direct-API outages often surface on AI Studio first.
+- **Gemini incidents are rare but long** — design for graceful degradation (retries + a non-streaming fallback path), not fast recovery.
+
+## Coding agents
+
+- **Failure modes vary by agent** — some flap (frequent short incidents), others take a rare long one. Plan for the **long** case on any agent on a critical path: a manually-swapped backup is too slow across a multi-day outage. **Drive failover from a health check** so an extended outage degrades to a fallback automatically, rather than relying on someone noticing and switching.
+
+## Retry / timeout tuning (general)
+
+- **Set client-side timeouts to cover the *Longest* incident column, not the average**, so the retry budget survives the worst case rather than the mean.
+- **Standard exponential backoff with a sub-minute initial retry** absorbs the flap pattern some status pages show (e.g. Together AI, Mistral).
+
+## Services with no official uptime
+
+Some services (Amazon Bedrock, Azure OpenAI, Character.AI, …) publish no official uptime; AIWatch **withholds** their Score rather than invent one. Read their reliability from incidents + recovery, and treat a **withheld** Score as "insufficient signal", not "unreliable". See [How AIWatch Works → Score](https://ai-watch.dev/methodology#score).


### PR DESCRIPTION
## Problem
Recommendations and Observations blurred, and the redundancy kept regenerating no matter how bullets were reworded. **Investigating the section's history** (past 2026-04/05 reports) revealed why: Observations has a real, unique value that recent bullets had drifted away from.

- **Its real job** (from 2026-04/05): deep service-specific *"if you build on X, do Y"* engineering guidance — key rotation cadence, which status pages to monitor, retry/backoff vs the Longest column, surface isolation (Voice Agent from core STT), the failover *mechanism*, per-model monitoring, infra-coupling warnings.
- **The drift**: recent bullets became shallow pick/fallback one-liners ("AssemblyAI primary, Deepgram fallback"; "keep a second agent") that duplicate Recommendations, Notable Incidents, and the Incident Summary count caveat. The template even instructed a "Quietly reliable **picks**" list *inside* Observations, and the README called it "Developer recommendations".

## Change (docs only)
Pin each neighbour to ONE job, and set the depth bar for Observations:
- **Template intro + ROLE BOUNDARY**: Recommendations = picks; **Notable Incidents = the EVENT** (describe, don't prescribe); Incident Summary note = the count caveat; **Observations = the ENGINEERING RESPONSE** and the *only* home for actionable advice. Includes past-report depth examples and "if the only advice is 'keep a fallback', go deeper — HOW (auto vs manual? which surface? which second provider?)".
- **Reframe the placeholder** from a "quietly reliable picks" list → "if you build on [Service]" deep-guidance bullets; keep the partial-month/withheld-Score caveat as the one allowed exception.
- **README**: Observations = per-service resilience engineering, not picks / events / count caveat.

## June 2026 draft (separate, working tree)
Rewritten to this standard, in-browser verified:
- Shallow bullets deepened — Deepgram → *isolate the streaming-STT surface behind a degradation-aware fallback* (its worst incident was a 27h streaming-STT degradation, p75 the highest probed); Codex → *health-check auto-failover, since the risk is one 72h outage not frequent blips*; Anthropic → *monitor per-model components individually*.
- The "keep a fallback" one-liners **removed from Notable Incidents** so advice lives once (here); the count-caveat bullet dropped (it's Incident Summary's job).

HTML comment tags balanced. No code / tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)