### PR TITLE
docs(reports): describe the computed 30-day uptime model, not the copied % (refs #1006)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Each monthly report includes:
 - **AIWatch Score Rankings** — Composite reliability score (uptime + incidents + recovery time)
 - **3-Month Trend** — Score direction over the trailing 3 months (slope chart), plus **Notable Movers**: the services whose Score, recovery time (MTTR), or total downtime changed most, so a flat Score can't hide a recovery-time regression. Auto-rendered once ≥2 months of archive exist; omitted otherwise. (Uptime is intentionally not trended — see *Methodology*.)
 - **Incident Summary** — Total downtime and incident counts per service
-- **Official Uptime** — Provider-reported uptime figures
+- **30-Day Uptime** — computed by AIWatch from each provider's published incident/outage records, over one window and one formula for every service
 - **Notable Incidents** — Top 5 incidents with root cause and impact
 - **Observations** — Developer recommendations based on the data
 

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -97,16 +97,14 @@ Combines four components — Uptime (40%), Incident affected days (25%), Recover
 <!-- Generate with: node scripts/generate-charts.js [YYYY-MM]/index.md -->
 ![AIWatch Score Rankings](../assets/[YYYY-MM]/score-chart.svg)
 
-> **Uptime Source column**: **Official** (read directly from the service's status page) · **No official uptime** (the provider publishes none; the Score is computed from the remaining signals). A service tracked for less than the full month is excluded from the ranking, not labelled — see the note above the table. Full definitions: [About This Report → Uptime Source](#about-this-report).
+> **Uptime Source column**: **Official** (AIWatch computes the 30-day figure from the incident/outage records the provider publishes) · **Platform** (same computation, but the records come from the status page platform's own monitors — Better Stack — rather than incidents the provider declared) · **No uptime** (the status page publishes no records to compute from; the Score is built from the remaining signals). A service tracked for less than the full month is excluded from the ranking, not labelled — see the note above the table. Full definitions: [About This Report → Uptime Source](#about-this-report).
 > <!-- Keep this caption short — full definitions live in the About This Report methodology section to avoid duplicating them here. -->
 
 ---
 
-## Official Uptime (Primary Component)
+## 30-Day Uptime
 
-> **Reference table.** The uptime percentage each service publishes on its own status page, where it publishes one (the window varies by page — 30 or 90 days). The narrative-driven sections below (Incident Summary / Notable Incidents / Observations) cover what these numbers mean for vendor selection.
-
-<!-- UPTIME_EXCLUSION_NOTE -->
+Uptime computed by AIWatch over a 30-day window from the incident and outage records each provider publishes on its status page — the same window and the same weighting for every service, so the figures compare. It is not a copy of the percentage a provider displays on its own page: those use different periods (30, 60 or 90 days) and different definitions of downtime, and cannot be compared across services. Full definitions: [ai-watch.dev/methodology](https://ai-watch.dev/methodology#uptime). The narrative-driven sections below (Incident Summary / Notable Incidents / Observations) cover what these numbers mean for vendor selection.
 
 <table class="uptime-cols">
 <thead><tr><th>Service</th><th>Uptime</th></tr></thead>
@@ -114,6 +112,8 @@ Combines four components — Uptime (40%), Incident affected days (25%), Recover
 <tr><td></td><td></td></tr>
 </tbody>
 </table>
+
+<!-- UPTIME_EXCLUSION_NOTE -->
 
 ---
 
@@ -168,7 +168,7 @@ These p75 figures are a network-latency reference: direct API-endpoint round-tri
 
 <!-- Top 5-6 notable incidents — the report's main narrative content. Place this
      section in the narrative cluster (Incident Summary → Notable Incidents →
-     Observations) that follows the metrics cluster (Score → Official Uptime →
+     Observations) that follows the metrics cluster (Score → 30-Day Uptime →
      API Response Time → Detection & RTT Degradation). Each entry: title with key duration,
      affected component(s), and a short prose paragraph that explains scope +
      remediation/mitigation. -->
@@ -209,9 +209,9 @@ Actionable takeaways per service. Descriptive context for each event lives in ea
 * **Data Sources:** Real-time data is aggregated from official status pages via multiple frameworks, including Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, OnlineOrNot, and RSS feeds (Source: [ai-watch.dev](https://ai-watch.dev)).
 * **Monitoring Frequency:** All 43 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
 * **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). A service with no probe endpoint is scored on the remaining components rescaled to 100, with **no penalty**. A service that has a probe but fewer than 7 days of samples gets that same rescale **plus a 5% penalty** until its probe data matures. Full methodology: [ai-watch.dev/methodology#score](https://ai-watch.dev/methodology#score)
-* **Uptime Source:** *Official* = the service publishes a rolling uptime % that AIWatch reads directly from its status page (the window varies by page — 30 or 90 days). *No official uptime* = the provider publishes no comparable figure. AIWatch **invents none**: the Score simply drops its 40-point Uptime component and is rescaled over the remaining signals (incidents, recovery, responsiveness), A service that still has a probe is scored and ranked on what can be measured; one with **neither** uptime **nor** a probe has too little signal, so its Score is withheld and it is not ranked. The note above the Score table names whichever services that is — the membership is read from the data, not fixed here. A service AIWatch tracked for only part of the month is **excluded from the ranking** rather than labelled — its partial-month Score would rest on insufficient coverage. The label describes the Uptime input, not the Score's rigour.
+* **Uptime Source:** *Official* = AIWatch computes a 30-day uptime figure from the incident and outage records the provider publishes on its status page — one window and one weighting for every service, so the figures compare. *Platform* = the same computation, but the records come from the status-page platform's own monitors (Better Stack) rather than incidents the provider declared. *No uptime* = the status page publishes no records to compute from. AIWatch **invents none**: the Score simply drops its 40-point Uptime component and is rescaled over the remaining signals (incidents, recovery, responsiveness). A service that still has a probe is scored and ranked on what can be measured; one with **neither** uptime **nor** a probe has too little signal, so its Score is withheld and it is not ranked. The note above the Score table names whichever services that is — the membership is read from the data, not fixed here. A service AIWatch tracked for only part of the month is **excluded from the ranking** rather than labelled — its partial-month Score would rest on insufficient coverage. The label describes the Uptime input, not the Score's rigour.
 * **Incident Counting:** Counts are the incidents each provider published, attributed to the service they affected. Providers differ in granularity, and in *where* that granularity lives: Anthropic maps to a single status-page component but posts one incident **per model**; Together AI tracks each model as its own **resource**, so one event can surface as several incidents. Others post one incident per event at the service level. Compare counts only across providers with comparable granularity.
-* **Uptime Metrics:** Uptime percentages are the official figure each status page exposes — read from the page directly, or aggregated by AIWatch from the per-component availabilities it publishes — for some services a single component, for others a worst-of across a component set, for others still an upstream platform average, depending on what the page exposes. Services marked with "—" publish no accessible uptime metric.
+* **Uptime Metrics:** Every percentage in the 30-Day Uptime table is computed by AIWatch over a trailing 30-day window from the outage records the status page publishes — never copied from the figure a provider displays on its own page (see *Uptime Source* above for how those records are sourced and weighted). Its **scope** depends on what the page exposes: a single component for some services, a worst-of across a component set for others, an upstream platform monitor for others still. Services marked with "—" publish no records to compute from.
 * **Component Reliability:** A **different measurement** from every other uptime figure in this report — do not compare them. AIWatch polls each service's status page every 5 minutes and, per component, counts a poll as good **only** when that component reads `operational`; `degraded` and `partial outage` both count against it, with no weighting by incident severity (severity is recorded per *service*, not per component). The percentage is that ratio of good polls, over the days AIWatch could read the page. Only components AIWatch surfaces for that service are counted — billing, docs and compliance surfaces are excluded — and a service needs at least two of them to appear at all. The table lists only each service's **weakest** component, and only when it fell below 99.9%: it is a list of where to look, not a ranking of everything.
 * **Timezone Standard:** All timestamps are recorded in **UTC**.
 

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -43,9 +43,12 @@ const OUT_DIR_ROOT = path.join(__dirname, '..')
 // it leaked a stray "100.00%" row.)
 //
 // It is NOT the uptime-source taxonomy any more (aiwatch#951). A hand-maintained list drifted in
-// both directions: Mistral and Perplexity publish real official uptime yet were labelled "Estimate"
-// and dropped from the Official Uptime table, while OpenRouter and Stability AI publish none yet
-// were labelled "Official · 100.00%" beside a Score that had been rescaled without any uptime.
+// both directions: Mistral and Perplexity publish records AIWatch can read, yet were labelled
+// "Estimate" and dropped from the table, while services that genuinely had no readable records were
+// labelled "Official · 100.00%" beside a Score rescaled without any uptime. (aiwatch#1006 later made
+// AIWatch compute uptime from the raw records of six status-page platforms — Atlassian, incident.io,
+// Instatus, Better Stack, Flashduty, OnlineOrNot — so Stability AI and OpenRouter, once "no uptime",
+// now carry a real computed figure.)
 // Modern archives answer the question directly — `officialUptime` is non-null exactly when the Score
 // consumed one — so the label and the table now read the data. "Estimate" is gone as a concept:
 // aiwatch#713 removed the invented uptime it named.
@@ -264,9 +267,21 @@ function confidence(svc) {
 // mid-month addition, but reports#45 EXCLUDES such a service from the ranking outright, so the
 // label named a row that can no longer exist — and its one real use read "Partial (9-day)",
 // not the "(Nd)" the legend taught. Removed from the template with the rest of the drifted prose.
+// aiwatch#1006 — three states, read from the DATA:
+//   'Official' — AIWatch computed the 30-day figure from the incident/outage records the provider
+//                publishes on its own status page.
+//   'Platform' — the same computation, but the records come from the status-page platform's own
+//                monitors (Better Stack). A measurement, not the provider declaring an incident —
+//                which is why it keeps a separate label even though the window and weights are identical.
+//   'No uptime' — the status page publishes no records to compute from; the Score omits the uptime
+//                component and rescales (aiwatch#713).
+// `uptimeSource` is archived from aiwatch#1006 onward. An older archive has the figure but not the
+// provenance, so it falls back to 'Official' — which is what those archives meant, since 'platform_avg'
+// figures were the BetterStack averages the pre-#1006 code also labelled official.
 function uptimeSourceLabel(svc, id = svc?.id) {
   const official = officialUptimeFor(svc, id)
-  return official === null || official === undefined ? 'No official uptime' : 'Official'
+  if (official === null || official === undefined) return 'No uptime'
+  return svc?.data?.uptimeSource === 'platform_avg' ? 'Platform' : 'Official'
 }
 
 // Ranking-exclusion note (#29). SCORE_WITHHELD services publish no official uptime and have no
@@ -514,9 +529,9 @@ function emitUptimeWarnings(messages, env = process.env) {
   return messages.length
 }
 
-// #586 — resolve the value the "Official Uptime" table should display for a service: the
-// STATUS-PAGE figure (`officialUptime`; the window varies by page), NOT the daily-counter `uptime` that feeds the
-// Score. Returns null when the service has no comparable published metric (→ omitted from the table).
+// #586 — resolve the value the 30-Day Uptime table should display for a service: the computed
+// `officialUptime` figure (#1006 — AIWatch's own trailing-30-day computation), NOT the daily-counter
+// `uptime` that feeds the Score. Returns null when the service has no comparable published metric (→ omitted).
 // Also the single source of truth for `uptimeSourceLabel` and `buildWhy`'s zero-incident wording,
 // so those three can never disagree about whether a service publishes an official uptime.
 //   • Modern archives (≥2026-06, post-aiwatch#951) carry `officialUptime` explicitly and correctly:
@@ -859,7 +874,7 @@ function buildComponentReliabilitySection(archive, meta, month) {
     // The window is NOT the month: per-component counting is younger than the report, and a service
     // whose status page goes dark simply stops contributing days (aiwatch-reports#73). Say "the days
     // AIWatch could read its status page", which is what the ratio actually measures.
-    "> AIWatch surfaces a **per-component uptime breakdown** — each multi-surface service's weakest component over the days AIWatch could read its status page, the surface most likely to be your bottleneck that a single service-level uptime number hides. It is a different measurement from the Official Uptime table and **is not a Score input**; see [About This Report → Component Reliability](#about-this-report).",
+    "> AIWatch surfaces a **per-component uptime breakdown** — each multi-surface service's weakest component over the days AIWatch could read its status page, the surface most likely to be your bottleneck that a single service-level uptime number hides. It is a different measurement from the 30-Day Uptime table and **is not a Score input**; see [About This Report → Component Reliability](#about-this-report).",
     '',
     '| Service | Weakest Component | Uptime | Components |',
     '|---|---|---|---|',
@@ -1123,9 +1138,9 @@ function fillTemplate(template, month, archive, meta) {
     out = out.replace(/\n*<!-- SCORE_RANKING_NOTE -->\n*/, '\n\n')
   }
   out = replaceTableBody(out, 'API Response Time', latencyTable)
-  // Incident Summary + Official Uptime use HTML <tbody>
+  // Incident Summary + 30-Day Uptime use HTML <tbody>
   out = replaceTableBody(out, 'Incident Summary', incidentRows)
-  out = replaceTableBody(out, 'Official Uptime', uptimeRows)
+  out = replaceTableBody(out, '30-Day Uptime', uptimeRows)
   // aiwatch#951 — the caption naming who is missing from that table, rendered from the same gate.
   const uptimeExclusionNote = buildUptimeExclusionNote(services, meta)
   if (uptimeExclusionNote) {

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -152,13 +152,24 @@ test('Medium when uptime null', () => {
   eq(confidence({ data: { uptime: null, incidents: 3 } }), 'Medium')
 })
 
-console.log('\nuptimeSourceLabel (#29, rewritten for aiwatch#951)')
+console.log('\nuptimeSourceLabel (#29 → aiwatch#951 → aiwatch#1006: three states, read from the data)')
 test('Official when the archive carries a status-page figure', () => {
   eq(uptimeSourceLabel({ id: 'cohere', data: { officialUptime: 100 } }), 'Official')
 })
-test('No official uptime when the archive says the provider publishes none', () => {
-  eq(uptimeSourceLabel({ id: 'openrouter', data: { officialUptime: null, uptime: 100 } }), 'No official uptime')
-  eq(uptimeSourceLabel({ id: 'stability', data: { officialUptime: null, uptime: 100 } }), 'No official uptime')
+test('No uptime when the archive carries no figure to show', () => {
+  eq(uptimeSourceLabel({ id: 'openrouter', data: { officialUptime: null, uptime: 100 } }), 'No uptime')
+  eq(uptimeSourceLabel({ id: 'gemini', data: { officialUptime: null, uptime: 100 } }), 'No uptime')
+})
+// aiwatch#1006 — Better Stack pages are computed on the SAME 30-day window with the SAME weights, but
+// their records are the platform's own monitoring, not incidents the provider declared. Same number
+// shape, different evidence — so the label stays distinct and now comes from the archived provenance
+// rather than a hand-maintained id list (which is exactly what drifted in aiwatch#951).
+test('aiwatch#1006: Platform when the records come from the status-page platform monitors', () => {
+  eq(uptimeSourceLabel({ id: 'together', data: { officialUptime: 99.81, uptimeSource: 'platform_avg' } }), 'Platform')
+  eq(uptimeSourceLabel({ id: 'luma', data: { officialUptime: 99.3, uptimeSource: 'platform_avg' } }), 'Platform')
+})
+test('aiwatch#1006: an archive written before the provenance field falls back to Official', () => {
+  eq(uptimeSourceLabel({ id: 'together', data: { officialUptime: 99.73 } }), 'Official')
 })
 // The label used to come from a hand-maintained set, which had drifted in BOTH directions.
 test('aiwatch#951: Mistral and Perplexity publish real uptime — no longer mislabelled', () => {
@@ -166,11 +177,11 @@ test('aiwatch#951: Mistral and Perplexity publish real uptime — no longer misl
   eq(uptimeSourceLabel({ id: 'perplexity', data: { officialUptime: 100 } }), 'Official')
 })
 test('aiwatch#951: bedrock/azureopenai stay excluded even if a stale archive carries a value', () => {
-  eq(uptimeSourceLabel({ id: 'bedrock', data: { officialUptime: 100 } }), 'No official uptime')
-  eq(uptimeSourceLabel({ id: 'azureopenai', data: { officialUptime: 100 } }), 'No official uptime')
+  eq(uptimeSourceLabel({ id: 'bedrock', data: { officialUptime: 100 } }), 'No uptime')
+  eq(uptimeSourceLabel({ id: 'azureopenai', data: { officialUptime: 100 } }), 'No uptime')
 })
 test('legacy archive (no officialUptime field) falls back to the maintained set', () => {
-  eq(uptimeSourceLabel({ id: 'perplexity', data: { uptime: 99.5 } }), 'No official uptime')
+  eq(uptimeSourceLabel({ id: 'perplexity', data: { uptime: 99.5 } }), 'No uptime')
   eq(uptimeSourceLabel({ id: 'cohere', data: { uptime: 100 } }), 'Official')
 })
 
@@ -360,7 +371,7 @@ test('header is "Uptime Source" (not "Confidence"); the column reads the archive
   assert.ok(!table.includes('Confidence'), 'Confidence column must be gone')
   assert.ok(!table.includes('Estimate'), 'the "Estimate" label went with the estimate itself (aiwatch#713)')
   const openrouterRow = table.split('\n').find(r => r.includes('OpenRouter'))
-  assert.ok(/\| No official uptime \|/.test(openrouterRow), `must not claim Official: ${openrouterRow}`)
+  assert.ok(/\| No uptime \|/.test(openrouterRow), `must not claim Official: ${openrouterRow}`)
   assert.ok(!/100\.00% uptime/.test(openrouterRow), `must not quote the measured uptime: ${openrouterRow}`)
   const perplexityRow = table.split('\n').find(r => r.includes('Perplexity'))
   assert.ok(/\| Official \|/.test(perplexityRow), `publishes real uptime → Official: ${perplexityRow}`)
@@ -2075,7 +2086,7 @@ test('officialUptimeFor withholds the value', () => {
   eq(officialUptimeFor(CONTRADICTORY), null)
 })
 test('uptimeSourceLabel does not claim "Official"', () => {
-  eq(uptimeSourceLabel(CONTRADICTORY), 'No official uptime')
+  eq(uptimeSourceLabel(CONTRADICTORY), 'No uptime')
 })
 test('buildWhy does not quote the withheld figure, and claims nothing about the provider', () => {
   // The archive DID carry a figure; we withheld it because it contradicted the Score. Saying
@@ -2260,7 +2271,7 @@ const RETIRED_CLAIMS = [
   [/still has a probe \(Gemini, xAI, OpenRouter\)/, 'the medium-confidence set was 7 services in June 2026, not 3'],
   [/neither uptime nor a probe \(Amazon Bedrock, Azure OpenAI\)/, 'characterai joined that set in June 2026'],
   [/without probe coverage \([^)]*\) are excluded from rankings/, 'no probe alone never unranks a service — Modal ranked #2 in June 2026 without one'],
-  [/Partial \(Nd\)/,                     'uptimeSourceLabel emits only Official / No official uptime; #45 excludes short-window services instead'],
+  [/Partial \(Nd\)/,                     'uptimeSourceLabel emits Official / Platform / No uptime; #45 excludes short-window services instead'],
 ]
 
 /**
@@ -2282,6 +2293,25 @@ function archiveExercisingEverySection(base) {
 test('no retired false claim survives a full report render', () => {
   const out = fillTemplate(REAL_TEMPLATE, '2026-05', REAL_ARCHIVE, {})
   for (const [re, why] of RETIRED_CLAIMS) assert.ok(!re.test(out), `retired claim resurfaced (${why}): ${re}`)
+})
+
+// #1006 — guards the replaceTableBody('30-Day Uptime') anchor against heading drift. The section was
+// renamed from "Official Uptime" to "30-Day Uptime"; when the anchor lagged, replaceTableBody found no
+// heading and silently left the template's empty placeholder — a permanently blank uptime table, green.
+// REAL_ARCHIVE carries no officialUptime, so give every service one and assert a real % row lands
+// INSIDE the section (and the placeholder is gone).
+test('the 30-Day Uptime table renders real rows into its section (anchor guard)', () => {
+  const archive = JSON.parse(JSON.stringify(REAL_ARCHIVE))
+  for (const id of Object.keys(archive.services)) {
+    archive.services[id] = { ...archive.services[id], officialUptime: 99.42, score: 90, scoreConfidence: 'high' }
+  }
+  const out = fillTemplate(REAL_TEMPLATE, '2026-05', archive, {})
+  const start = out.indexOf('## 30-Day Uptime')
+  assert.ok(start !== -1, 'the 30-Day Uptime heading must exist')
+  const rest = out.indexOf('\n## ', start + 1)
+  const section = out.slice(start, rest === -1 ? undefined : rest)
+  assert.match(section, /<tr><td>[^<]+<\/td><td>99\.42%<\/td><\/tr>/, 'a real uptime row must be injected, not the empty placeholder')
+  assert.ok(!section.includes('<tr><td></td><td></td></tr>'), 'the empty placeholder row must be replaced')
 })
 
 test('the ratchet actually exercises every conditional section', () => {
@@ -2385,16 +2415,18 @@ test('every service lands in exactly one group — ranked, withheld, stale, or r
 })
 
 
-test('uptimeSourceLabel emits exactly two labels — there is no Partial', () => {
-  // The template taught a third label the generator cannot produce. Its one historical use was
-  // hand-typed as "Partial (9-day)" (not the "(Nd)" the legend showed), and reports#45 now excludes
-  // a short-window service from the ranking entirely rather than labelling its row.
+test('uptimeSourceLabel emits only Official / Platform / No uptime — never Partial', () => {
+  // #1006 added a third label (Platform, for a BetterStack-sourced figure). The label the generator
+  // still cannot produce is "Partial": its one historical use was hand-typed as "Partial (9-day)"
+  // (not the "(Nd)" the legend showed), and reports#45 now excludes a short-window service from the
+  // ranking entirely rather than labelling its row.
   const labels = new Set([
     uptimeSourceLabel({ id: 'groq', data: { officialUptime: 100, scoreConfidence: 'high' } }, 'groq'),
+    uptimeSourceLabel({ id: 'together', data: { officialUptime: 99.7, uptimeSource: 'platform_avg' } }, 'together'),
     uptimeSourceLabel({ id: 'openrouter', data: { officialUptime: null } }, 'openrouter'),
     uptimeSourceLabel({ id: 'bedrock', data: {} }, 'bedrock'),
   ])
-  assert.deepStrictEqual([...labels].sort(), ['No official uptime', 'Official'])
+  assert.deepStrictEqual([...labels].sort(), ['No uptime', 'Official', 'Platform'])
   for (const l of labels) assert.ok(!/Partial/.test(l), `unexpected label: ${l}`)
 })
 


### PR DESCRIPTION
Mirrors the aiwatch **#1006** change (aiwatch#1014) in the monthly report copy.

## Changes
- **"Official Uptime" table → "30-Day Uptime"**; the 30-day-computation explanation is now the section's **main paragraph above the table** (was a blockquote footnote), and the excluded-services list stays as a note **below** the table.
- **`uptimeSourceLabel` is 3-state** — `Official` (provider records) / `Platform` (Better Stack monitors) / `No uptime`. The ranking caption AND the *About This Report* bullets (*Uptime Source*, *Uptime Metrics*) now describe AIWatch **computing** a 30-day figure, never copying the % a provider displays.
- **Fix the `replaceTableBody` anchor** to the renamed `## 30-Day Uptime` heading — a stale anchor silently left the uptime table **empty** — and add a render test that would have caught it.

## Tests
`node scripts/generate-report.test.js` → **247 passed, 0 failed** (adds the anchor-guard render test; updates the label test to assert the real 3-state set).

## Note
The **Platform** label only appears once a monthly archive is (re)written by the deployed #1006 worker — an already-frozen month's archive won't show it retroactively. The June draft (`2026-06/`) is intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)