### PR TITLE
docs(reports): curate Resilience Patterns page + auto-fill service count (#97)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: AIWatch Reports
-description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for 43 AI services
+description: Monthly AI service incident reports — uptime, incidents, and reliability rankings for AI services
 baseurl: "/reports"
 url: https://ai-watch.dev
 theme: minima

--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "[MON] [YEAR] AI Reliability Report"
-description: "Monthly reliability report for 43 AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
+description: "Monthly reliability report for [SERVICE_COUNT] AI services including OpenAI, Anthropic Claude, Gemini, Amazon Bedrock, Pinecone, and more. Uptime, incidents, and AIWatch Score rankings."
 date: [YYYY-MM-DD]
 published: true
 ---
@@ -9,7 +9,7 @@ published: true
 > **Source**: [ai-watch.dev](https://ai-watch.dev) — Real-time AI service status monitoring
 > **Period**: [MONTH] 1–[LAST_DAY], [YEAR]
 > **Published**: [PUBLISH_MONTH] [YEAR]
-> **Services monitored**: 43 — 33 API services, 6 coding agents, 4 AI apps
+> **Services monitored**: [SERVICE_COUNT] — 33 API services, 6 coding agents, 4 AI apps
 
 <!-- AUTHORING SELF-CHECK — read before writing prose; these are the recurring misses:
      1. CLAIMS BACKED BY DATA, AT THE RIGHT SCOPE. Every superlative/absolute ("the slowest", "the most",
@@ -215,7 +215,8 @@ These p75 figures are a network-latency reference: direct API-endpoint round-tri
        every month (per-model monitoring, Voice-Agent isolation, Gemini key rotation + dual monitoring,
        retry timeout = the Longest column, coding-agent auto-failover). Stated ONCE there — do NOT re-lecture
        it monthly; that cross-month repetition is exactly what this split fixes. New evergreen pattern? Add it
-       to that page, not here.
+       to that page, not here — following the MAINTENANCE curation rules at the top of ../resilience/
+       (evergreen + high-value only, one pattern per failure-mode, prune stale bullets on edit).
      • Observations (here) = THIS MONTH'S DELTA only — the specific failure mode the month surfaced, tied to
        the relevant Resilience pattern with a link. The only home for the month's actionable advice, so Notable
        Incidents stays descriptive (don't end an incident with "keep a fallback" — put the delta here + link).
@@ -225,7 +226,7 @@ These p75 figures are a network-latency reference: direct API-endpoint round-tri
      CAVEAT (e.g. Character.AI) is a legitimate month-specific bullet too. -->
 
 
-- **[Service]**: <!-- THIS month's date-tied failure fact (e.g. "its worst incident was a 27h streaming-STT degradation; p75 the highest probed"), DEEP-linked to the relevant Resilience pattern ([Resilience → Voice/transcription](../resilience/#voice--transcription-deepgram)). Do NOT re-explain the evergreen pattern — link it. -->
+- **[Service]**: <!-- THIS month's date-tied failure fact (e.g. "its worst incident was a 27h streaming-STT degradation; p75 the highest probed"), DEEP-linked to the relevant Resilience pattern ([Resilience → Deepgram](../resilience/#deepgram)). Do NOT re-explain the evergreen pattern — link it. -->
 - **[Service]**: <!-- 2-4 bullets total; only services whose THIS-MONTH data yields a new lesson. If a service's story is unchanged from a prior report, omit it (the pattern already lives in ../resilience/). -->
 <!-- A partial-month / withheld-Score CAVEAT bullet (e.g. Character.AI: why its Score is absent + how to read
      its half-month counts) belongs here too — it's month-specific and not an evergreen pattern. -->
@@ -239,7 +240,7 @@ These p75 figures are a network-latency reference: direct API-endpoint round-tri
 ## About This Report
 
 * **Data Sources:** Real-time data is aggregated from official status pages via multiple frameworks, including Atlassian Statuspage, incident.io, Google Cloud Status, Better Stack, Instatus, OnlineOrNot, and RSS feeds (Source: [ai-watch.dev](https://ai-watch.dev)).
-* **Monitoring Frequency:** All 43 services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
+* **Monitoring Frequency:** All [SERVICE_COUNT] services are polled every **5 minutes** via Cloudflare Workers. Health check probes measure direct API response times (RTT) at the same interval.
 * **AIWatch Score (0–100):** Calculated from four components — **Uptime** (40%), **Incident affected days** (25%), **Recovery speed** (15%), and **Responsiveness** (20%). A service with no probe endpoint is scored on the remaining components rescaled to 100, with **no penalty**. A service that has a probe but fewer than 7 days of samples gets that same rescale **plus a 5% penalty** until its probe data matures. Full methodology: [ai-watch.dev/methodology#score](https://ai-watch.dev/methodology#score)
 * **Uptime Source:** *Official* = AIWatch computes a 30-day uptime figure from the incident and outage records the provider publishes on its status page — one window and one weighting for every service, so the figures compare. *Platform* = the same computation, but the records come from the status-page platform's own monitors (Better Stack) rather than incidents the provider declared. *No uptime* = the status page publishes no records to compute from. AIWatch **invents none**: the Score simply drops its 40-point Uptime component and is rescaled over the remaining signals (incidents, recovery, responsiveness). A service that still has a probe is scored and ranked on what can be measured; one with **neither** uptime **nor** a probe has too little signal, so its Score is withheld and it is not ranked. The note above the Score table names whichever services that is — the membership is read from the data, not fixed here. A service AIWatch tracked for only part of the month is **excluded from the ranking** rather than labelled — its partial-month Score would rest on insufficient coverage. The label describes the Uptime input, not the Score's rigour.
 * **Incident Counting:** Counts are the incidents each provider published, attributed to the service they affected. Providers differ in granularity, and in *where* that granularity lives: Anthropic maps to a single status-page component but posts one incident **per model**; Together AI tracks each model as its own **resource**, so one event can surface as several incidents. Others post one incident per event at the service level. Compare counts only across providers with comparable granularity.

--- a/index.md
+++ b/index.md
@@ -1,10 +1,10 @@
 ---
 layout: home
 title: AIWatch Monthly Reports
-description: "Monthly AI service incident reports covering 43 AI services — uptime, incidents, and reliability rankings."
+description: "Monthly AI service incident reports covering the AI services AIWatch monitors — uptime, incidents, and reliability rankings."
 ---
 
-Monthly AI service incident reports covering 43 AI services monitored by [AIWatch](https://ai-watch.dev).
+Monthly AI service incident reports covering the AI services monitored by [AIWatch](https://ai-watch.dev).
 
 ## Reports
 

--- a/resilience.md
+++ b/resilience.md
@@ -6,36 +6,68 @@ permalink: /resilience/
 published: true
 ---
 
+<!-- MAINTENANCE — curation rules for this page (read before editing; this page is public and must not
+     grow unbounded as reports accumulate — the point is a curated SET, never an append-only log):
+     1. ADD only a pattern that is BOTH evergreen (would read identically next month — a property of the
+        service's architecture, not a one-off event) AND high-value (a real failure mode worth building
+        against). A month-specific fact belongs in that report's Observations, not here.
+     2. ONE pattern per failure-mode per service — refine the existing bullet, don't append a variant.
+        If a new incident restates a pattern already here, it needs NO edit; just link it from Observations.
+     3. PRUNE on every edit — when you touch a section, drop any bullet whose architecture no longer holds
+        (a service changed its setup / the failure mode is gone). Removal is as important as addition.
+     4. CLASSIFY by service category — the primary axis is the AIWatch service category (the allowed set:
+        LLM APIs, Voice / transcription, Coding agents, Inference & infra, Observability, Video, Image,
+        AI apps; only categories that actually have a pattern appear as headings). A pattern attributed to a
+        NAMED service gets an h3 under its category heading (Anthropic, Gemini, Deepgram) — keep that h3 even
+        when it's the only service in the category, so its anchor stays stable for report deep-links; a
+        category-level pattern not tied to one named service sits directly under the h2 (Coding agents); a
+        service-AGNOSTIC pattern lives under "Cross-cutting patterns" at the bottom, stated ONCE — never
+        duplicated into each service. Keep the category headings + the TOC below in sync; ~<=4 bullets per
+        service subsection — if one outgrows that, the pattern is too granular, consolidate.
+     5. STALENESS — bump "Last reviewed" below when you curate; a section untouched for many months is a
+        prune candidate, not automatically still true.
+     NOT enforced by CI (a discipline like the report AUTHORING SELF-CHECK) — it holds only if you apply it. -->
+
 Structural guidance for building reliably on the services AIWatch monitors. These patterns are properties of each service's architecture, so they hold month to month — the monthly reports' **Observations** point here and add only what's *new* that month. Read a report's Observations for this month's specific failure mode; read this page for how to build against it.
+
+<small>_Last reviewed: 2026-07_</small>
+
+**Jump to:** [LLM APIs](#llm-apis) · [Voice / transcription](#voice--transcription) · [Coding agents](#coding-agents) · [Cross-cutting patterns](#cross-cutting-patterns)
 
 ---
 
-## Anthropic (Claude API, Claude Code, claude.ai)
+## LLM APIs
 
-- **Monitor the per-model components individually** (Opus / Sonnet / Haiku / …), not the aggregated incident count across them. Single-model traffic isn't well represented by the combined total, and retry / failover decisions need per-model granularity.
+### Anthropic (Claude API, Claude Code, claude.ai)
+
+- **Monitor the per-model components individually**, not the aggregated incident count across them. Single-model traffic isn't well represented by the combined total, and retry / failover decisions need per-model granularity.
 - **The three surfaces share Anthropic infrastructure and can fail together** — you can't fail over from one Anthropic surface to another. For real redundancy, pair Anthropic with a **non-Anthropic** provider, not with itself.
 
-## Voice / transcription (Deepgram)
-
-- **The Voice Agent carries an upstream-LLM dependency.** The longest Deepgram incidents trace back to that surface, so a single-LLM Voice Agent setup takes the full upstream blast radius — **configure multiple LLM providers for failover**.
-- **Isolate the Voice Agent from your core STT/TTS** so an upstream-LLM incident can't take down basic transcription.
-- **Real-time transcription is a hot path**, and Deepgram is consistently the slowest probed service — route it behind a **degradation-aware fallback** to a second provider. A latency degradation alone (not only a hard outage) stalls real-time audio.
-
-## Gemini
+### Gemini
 
 - **Prefer long-lived keys with a rotation cadence ≥ monthly** — newly-created keys have been the affected scope in past incidents.
 - **Monitor BOTH gcloud Vertex and AI Studio** — they don't always agree, and direct-API outages often surface on AI Studio first.
 - **Gemini incidents are rare but long** — design for graceful degradation (retries + a non-streaming fallback path), not fast recovery.
 
+## Voice / transcription
+
+### Deepgram
+
+- **The Voice Agent carries an upstream-LLM dependency.** The longest Deepgram incidents trace back to that surface, so a single-LLM Voice Agent setup takes the full upstream blast radius — **configure multiple LLM providers for failover**.
+- **Isolate the Voice Agent from your core STT/TTS** so an upstream-LLM incident can't take down basic transcription.
+- **Real-time transcription is a hot path** — route it behind a **degradation-aware fallback** to a second provider. A latency degradation alone (not only a hard outage) stalls real-time audio.
+
 ## Coding agents
 
 - **Failure modes vary by agent** — some flap (frequent short incidents), others take a rare long one. Plan for the **long** case on any agent on a critical path: a manually-swapped backup is too slow across a multi-day outage. **Drive failover from a health check** so an extended outage degrades to a fallback automatically, rather than relying on someone noticing and switching.
 
-## Retry / timeout tuning (general)
+---
+
+## Cross-cutting patterns
+
+Patterns that apply across services, not tied to one provider.
+
+### Retry / timeout tuning (general)
 
 - **Set client-side timeouts to cover the *Longest* incident column, not the average**, so the retry budget survives the worst case rather than the mean.
 - **Standard exponential backoff with a sub-minute initial retry** absorbs the flap pattern some status pages show (e.g. Together AI, Mistral).
-
-## Services with no official uptime
-
-Some services (Amazon Bedrock, Azure OpenAI, Character.AI, …) publish no official uptime; AIWatch **withholds** their Score rather than invent one. Read their reliability from incidents + recovery, and treat a **withheld** Score as "insufficient signal", not "unreliable". See [How AIWatch Works → Score](https://ai-watch.dev/methodology#score).

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -1114,6 +1114,11 @@ function fillTemplate(template, month, archive, meta) {
   out = out.replace(/\[LAST_DAY\]/g, String(lastDay))
   out = out.replace(/\[PUBLISH_MONTH\]/g, publishMonth)
   out = out.replace(/\[NEXT_MONTH\]/g, nxt.name)
+  // aiwatch-reports#97 — the monitored-service count is derived from the archive's service set, not
+  // hardcoded in the template, so it never drifts as services are added. For a current-month run this
+  // is the live roster (verified 2026-04/-05 match exactly); a back-generated old month reflects that
+  // month's archived set. The category breakdown beside it is still a manual literal — see #98.
+  out = out.replace(/\[SERVICE_COUNT\]/g, String(services.length))
 
   // aiwatch-reports#74 — resolve `[SCORE_ANCHOR]` from the heading that actually shipped, rather
   // than hand-slugging it in the template. The old template asked a human to substitute a lowercase

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -694,6 +694,25 @@ test('NEXT_MONTH resolves year rollover correctly', () => {
   const out = fillTemplate(tmpl, '2026-12', archive, {})
   assert.ok(out.includes('January'), `expected "January" after December: ${out}`)
 })
+test('SERVICE_COUNT resolves to the archive service count, not a hardcoded literal or meta size (aiwatch-reports#97)', () => {
+  // The monitored-service count is derived from archive.services so it never drifts as services
+  // are added; every [SERVICE_COUNT] occurrence (frontmatter description, "Services monitored",
+  // "All N services are polled") is filled from the same source. meta deliberately carries a
+  // DIFFERENT cardinality (4) than archive.services (3), so the count can only be right if it
+  // derives from archive.services — this pins the source, not just the absence of a literal.
+  const tmpl = `Services monitored: [SERVICE_COUNT]\nAll [SERVICE_COUNT] services are polled`
+  const svc = { score: 44, grade: 'Degrading', monthlyScore: 61, monthlyGrade: 'Fair', uptime: 90, incidents: 6, avgResolutionMin: 456, officialUptime: 99 }
+  const archive = { services: { a: { ...svc }, b: { ...svc }, c: { ...svc } }, daysCollected: 0 }
+  const meta = { a: { name: 'A' }, b: { name: 'B' }, c: { name: 'C' }, d: { name: 'D' } }
+  const out = fillTemplate(tmpl, '2026-04', archive, meta)
+  assert.ok(out.includes('Services monitored: 3'), `expected archive count 3 (not meta size 4): ${out}`)
+  assert.ok(!out.includes('[SERVICE_COUNT]'), `every SERVICE_COUNT placeholder must be substituted: ${out}`)
+})
+test('SERVICE_COUNT substitutes even an empty archive (0), leaving no placeholder (aiwatch-reports#97)', () => {
+  const out = fillTemplate('monitored: [SERVICE_COUNT]', '2026-04', { services: {}, daysCollected: 0 }, {})
+  assert.ok(out.includes('monitored: 0'), `expected 0 for an empty archive: ${out}`)
+  assert.ok(!out.includes('[SERVICE_COUNT]'), `placeholder must be substituted even at 0: ${out}`)
+})
 
 // ── Security section (refs aiwatch#290 / aiwatch#291) ───────────────
 console.log('\nbuildBySourceTable')


### PR DESCRIPTION
## Summary

Curates the public `/resilience/` Resilience Patterns page so it stays a bounded, well-organised reference as monthly reports accumulate, and cuts hardcoded service-count maintenance surface across the reports site.

## Changes

- **resilience.md** — MAINTENANCE curation rules (evergreen + high-value only, one pattern per failure-mode, prune on edit, classify by AIWatch service category, staleness + `Last reviewed`); category-level TOC; two-tier taxonomy (service-category h2 → named-service h3: LLM APIs→Anthropic/Gemini, Voice / transcription→Deepgram; category-level pattern flat under h2: Coding agents; service-agnostic → Cross-cutting patterns); dropped staleness-prone model-name examples; removed the scoring-methodology "no official uptime" section (already covered by `/methodology#score`).
- **_templates/monthly-report.md** — Observations ROLE BOUNDARY comment now points at the curation rules; example deep-link → `#deepgram`; `[SERVICE_COUNT]` placeholder.
- **_config.yml, index.md** — dropped the hardcoded "43" from the evergreen site description surfaces (renders in the footer, incl. on `/resilience/`).
- **scripts/generate-report.js** + template — `[SERVICE_COUNT]` filled from `archive.services.length`, so the monitored-service count never drifts; unit-tested (+ empty-archive guard, + meta-vs-archive source pin).

## Verification

- Jekyll render verified locally (resilience page structure/TOC/anchors + reports home).
- `node --test scripts/*.test.js` — all pass (generate-report: 249).
- Two review rounds (code-review + comment-analysis + test-analysis); all findings resolved.

Refs #97. Category breakdown auto-fill deferred to #98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)