### PR TITLE
fix(recurrence): track the Summary "Watch out" bullet as its own slot (refs #61)

### DIFF
--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -1532,7 +1532,7 @@ async function main() {
 //
 // The hand-authored narrative slots (Summary "High incident count" bullet, Key
 // Insight patterns, Notable Incidents) have no memory of prior months, so the same
-// framing recurs (Together AI led the "High incident count" bullet Apr/May/Jun) and
+// framing recurs (Together AI filled the "High incident count" bullet in both Apr and May) and
 // is only caught by a human at edit time. This injects a generate-time RECURRENCE
 // CHECK block — the same class of mechanical gate #415 was on the aiwatch side:
 // a passive "compare against last month" rule gets only probabilistic compliance.
@@ -1544,9 +1544,36 @@ async function main() {
 // delete-before-merge fence as AUTO-DRAFT, and degrade gracefully (a missing/corrupt
 // prior month is skipped, never thrown — same contract as the charts prior-month read).
 
-// Slots we track. Keyed the same on the current-subject side (computeCurrentSubjects)
-// and the prior-month side (extractNarrativeSubjects) so detectRecurrence can pair them.
-const RECURRENCE_SLOTS = ['summary', 'keyInsight', 'notable']
+// Slots we track. Most are keyed the same on the current-subject side (computeCurrentSubjects) and
+// the prior-month side (extractNarrativeSubjects) so detectRecurrence can pair them.
+//
+// #61 — `summaryWatchOut` is the exception: it is evaluated by the **#55 pre-publish lint only**, and
+// deliberately has NO current side at generate time. The two gates read different things. The lint
+// compares two AUTHORED reports, so it can see a Watch out bullet. The #54 block runs while the report
+// is still being drafted — the bullet does not exist yet — so computeCurrentSubjects predicts the
+// current subjects from archive DATA (incident counts → the "High incident count" bullet, slowest
+// recovery + movers → Key Insight). "Watch out" is editorial judgement with no data proxy: guessing it
+// would warn about a bullet the author has not written. So the slot stays empty on that side, and
+// detectRecurrence's `|| []` yields no generate-time flag by design, not by omission.
+// That still closes #61: the lint runs BEFORE publish, which is the gate the Anthropic 3-peat needed.
+// Wire a current side here only if a defensible data proxy appears — and update this note if so.
+//
+// It is a SEPARATE slot rather than folded into `summary` so a flag can name which bullet repeated
+// (the two carry different narrative weight: a recurring high-incident count is often a true
+// structural fact about a chatty status page, while a recurring "Watch out" is the editorial lede
+// going stale).
+//
+// Which Summary bullets are tracked, and why the rest are not. Census over all four published
+// reports (2026-03/04/05/06 — 03 is `published: true` and is a prior for the June window):
+//   • Watch out (4/4)                    → TRACKED. Editorial concern bullet; its repeat is staleness.
+//   • High incident count/noise (3/4)    → TRACKED already (#54, the proven Together AI repeat).
+//   • Most reliable (4/4)                → excluded: the ranking's top, so repeats are structural.
+//   • Riskiest this month (4/4)          → excluded: the ranking's bottom, same reason.
+//   • Biggest improvement (1/4, June)    → excluded FOR NOW. Not structural like the two above, so a
+//   • Best balance (1/4, March)            defensible future slot — but each has appeared once in four
+//     months, so tracking it would be designing for a case we have never seen, against #54's founding
+//     rule of targeting proven repeats and avoiding noise. Revisit if either becomes a fixture.
+const RECURRENCE_SLOTS = ['summary', 'summaryWatchOut', 'keyInsight', 'notable']
 const RECURRENCE_WINDOW = 3 // look back this many published months
 const RECURRENCE_MIN = 2    // flag a subject repeated in ≥ this many of the window
 
@@ -1556,6 +1583,7 @@ const RECURRENCE_CLOSE_MARKER = '<!-- END RECURRENCE CHECK -->'
 // Human label per slot for the injected block.
 const RECURRENCE_SLOT_LABEL = {
   summary: "the Summary 'High incident count' bullet",
+  summaryWatchOut: "the Summary 'Watch out' bullet",
   keyInsight: 'a Key Insight pattern',
   notable: 'Notable Incidents',
 }
@@ -1636,6 +1664,74 @@ function highIncidentBulletSubjects(summaryTxt, lexicon) {
   return out
 }
 
+// Subjects of the Summary "Watch out" bullet (#61). Sibling to highIncidentBulletSubjects: the other
+// EDITORIAL concern bullet, and the one whose repeats went unflagged — the Anthropic trio was named
+// in it three months running (2026-04, -05, -06; leading it in -06) and neither gate saw it. A human
+// reviewer caught it.
+//
+// Deliberately NOT the `Name (` stat-group scan highIncidentBulletSubjects uses. That bullet is
+// formulaic ("Mistral API (155 incidents…)"); "Watch out" is free prose, so the same scan pulls
+// any capitalized word before a paren — "…all landed Fair (63–65)" would yield a service called
+// "Fair", since canonicalizeToLexicon returns unknown names unchanged. Filtering to the report's
+// own lexicon (as keyInsightSubjects does) is precise regardless of sentence shape.
+//
+// Scoped to the ONE bullet, not the whole Summary (see RECURRENCE_SLOTS for which bullets and why).
+//
+// The Score-table lexicon ALONE is not enough here, and the miss is the exact case this exists for.
+// The bullet names its subject editorially, and a group noun need not spell its members out:
+//   2026-05: "…and the Anthropic stack — Claude API / claude.ai / Claude Code all landed Fair"
+//   2026-06: "the Anthropic stack stayed Fair (66–69)."          ← no member is named at all
+// A lexicon-only scan yields the trio for May and NOTHING for June, so the very recurrence that
+// motivated this issue still would not flag. Hence the group aliases below.
+//
+// A group EXPANDS to its members rather than standing as a subject of its own, because the spellings
+// are one narrative subject — the same reason #54 folds "Mistral" into "Mistral API". 2026-04 names
+// the trio outright while 2026-06 names only the group; as distinct subjects those two months never
+// match each other, so a repeat phrased differently month to month stays invisible however it is read.
+//
+// Expansion only has to fire when the group arrives WITHOUT its members, since a bullet that names
+// them is already covered by the lexicon filter. What THIS bullet actually shows across four months:
+//   2026-06  "the Anthropic stack stayed Fair (66–69)."                group only    → must expand
+//   2026-05  "the Anthropic stack — Claude API / claude.ai / …"        group+members → lexicon has them
+//   2026-04  "Anthropic per-model counts (Claude API 40 + claude.ai…"  members named → lexicon has them
+//            (its group noun is not alias-matched, and does not need to be — the members are right there)
+//   2026-03  Watch out names GitHub Copilot alone                      no group noun → nothing to expand
+//
+// So `stack` is the only member-less wording this slot has ever seen. `services` is a deliberate
+// HEDGE, and — stated plainly, because the distinction matters to anyone pruning this pattern — it is
+// NOT attested in this bullet: it appears in 2026-03's sibling High-incident bullet ("Anthropic
+// services — counts inflated…"). It is kept because the vocabulary for this one group demonstrably
+// drifts between bullets and months, and a wording the slot has not seen yet is exactly how the #61
+// false negative returns. That is a bet on observed drift, not evidence from the slot itself.
+//
+// It stays NARROW for the same reason it exists: bare "Anthropic" is ordinary prose in these reports
+// ("Anthropic posts a separate incident per model", 2026-06), so matching it would expand the trio
+// into bullets that merely mention the vendor — a permanent false positive.
+const SUBJECT_GROUP_ALIASES = [
+  { re: /\bAnthropic\s+(?:stack|services)\b/i, members: ['Claude API', 'claude.ai', 'Claude Code'] },
+]
+
+function watchOutBulletSubjects(summaryTxt, lexicon) {
+  const bulletRe = /^[-*]\s*\*\*watch out[^*]*\*\*:?\s*(.+)$/im
+  const m = summaryTxt.match(bulletRe)
+  if (!m) return []
+  const text = m[1]
+  const out = subjectsInText(text, lexicon)
+  const seen = new Set(out.map(normSubject))
+  for (const { re, members } of SUBJECT_GROUP_ALIASES) {
+    if (!re.test(text)) continue // no group noun → expand nothing (2026-03's bullet names Copilot alone)
+    for (const member of members) {
+      // Exact match against the document's OWN Score table — a member off that month's roster is
+      // dropped, never invented from the alias.
+      const canon = lexicon.find(l => normSubject(l) === normSubject(member))
+      if (!canon || seen.has(normSubject(canon))) continue
+      seen.add(normSubject(canon))
+      out.push(canon)
+    }
+  }
+  return out
+}
+
 // Key Insight subjects = services named in the section's BOLD-LEAD bullets (`- **…**: …`)
 // ONLY, not its prose — the bold-lead bullets ARE the recurring framings. Scanning the full
 // ~200-line section pulls every incidentally-mentioned service (noisy flags); requiring the
@@ -1674,6 +1770,7 @@ function extractNarrativeSubjects(indexMd) {
   const lexicon = serviceNameLexicon(md)
   return {
     summary: highIncidentBulletSubjects(sectionText(md, 'Summary'), lexicon),
+    summaryWatchOut: watchOutBulletSubjects(sectionText(md, 'Summary'), lexicon),
     keyInsight: keyInsightSubjects(sectionText(md, 'Key Insight'), lexicon),
     notable: affectedSubjects(sectionText(md, 'Notable Incidents'), lexicon),
   }
@@ -1890,4 +1987,6 @@ module.exports = {
   RECURRENCE_OPEN_MARKER,
   RECURRENCE_CLOSE_MARKER,
   RECURRENCE_SLOTS,
+  RECURRENCE_SLOT_LABEL,
+  watchOutBulletSubjects,
 }

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -1784,14 +1784,16 @@ const { computeCurrentSubjects } = require('./generate-report')
 
 // A minimal published-report fixture: a Score table (the self-contained lexicon) plus
 // the three narrative slots, mirroring the real report structure.
-function sampleReport({ highIncident, keyInsight, affected }) {
+function sampleReport({ highIncident, keyInsight, affected, watchOut, riskiest }) {
   return [
     '# Report',
     '',
     '## Summary',
     '',
     '- **Most reliable**: Modal (97/100)',
+    `- **Riskiest this month**: ${riskiest || 'Replicate (61/100)'}`,
     `- **High incident count, fast recovery**: ${highIncident}`,
+    ...(watchOut ? [`- **Watch out**: ${watchOut}`] : []),
     '',
     '## Key Insight',
     '',
@@ -1805,7 +1807,11 @@ function sampleReport({ highIncident, keyInsight, affected }) {
     '| 2 | Together AI | 84 | Good |',
     '| 3 | Mistral API | 78 | Good |',
     '| 4 | ChatGPT | 70 | Good |',
-    '| 5 | Gemini API | 64 | Fair |',
+    '| 5 | Claude API | 65 | Fair |',
+    '| 6 | Gemini API | 64 | Fair |',
+    '| 7 | claude.ai | 64 | Fair |',
+    '| 8 | Claude Code | 63 | Fair |',
+    '| 9 | Replicate | 61 | Fair |',
     '',
     '## Notable Incidents',
     '',
@@ -1876,6 +1882,146 @@ test('missing sections and garbage input degrade to [] without throwing', () => 
   eq(`${empty.summary.length}${empty.keyInsight.length}${empty.notable.length}`, '000')
   const junk = extractNarrativeSubjects(null)
   eq(`${junk.summary.length}${junk.keyInsight.length}${junk.notable.length}`, '000')
+})
+
+// ── Summary "Watch out" slot (aiwatch-reports#61) ────────────────────
+// The bullet's wording in these fixtures is lifted from the real 2026-04/05/06 reports, because the
+// gap was a wording gap: prose shape, not structure, is what the extractor has to survive.
+console.log('\nwatchOutBulletSubjects (aiwatch-reports#61)')
+
+test('pulls Watch out subjects and does not leak non-lexicon capitalized words', () => {
+  const md = sampleReport({
+    highIncident: 'Together AI (85 incidents)',
+    keyInsight: '- x',
+    affected: 'Gemini API',
+    // Real 2026-05 shape. "Fair (63–65)" is the trap: the High-incident bullet's `Name (` stat-group
+    // scan would read "Fair" as a service — canonicalizeToLexicon returns unknown names unchanged —
+    // which is why this slot filters to the lexicon instead.
+    watchOut: 'Gemini API (only 2 incidents but a 22h 32m average recovery) and the Anthropic stack — Claude API / claude.ai / Claude Code all landed Fair (63–65).',
+  })
+  const s = extractNarrativeSubjects(md)
+  assert.ok(s.summaryWatchOut.includes('Gemini API'), 'named service found')
+  assert.ok(s.summaryWatchOut.includes('Claude API'), 'member named outright found')
+  assert.ok(!s.summaryWatchOut.includes('Fair'), '"Fair (63–65)" must not read as a service')
+  // This bullet names the group noun AND its members — the one shape where expansion can double them.
+  // detectRecurrence dedups downstream, so a duplicate is invisible in the flags; pin it at this
+  // exported surface instead, where the contract (order-preserving, de-duplicated) actually lives.
+  eq(s.summaryWatchOut.length, new Set(s.summaryWatchOut).size, `no duplicate subjects: ${s.summaryWatchOut}`)
+})
+
+test('expands the "Anthropic stack" group noun when no member is named (the 2026-06 shape)', () => {
+  // The miss this issue exists for: June names ONLY the group, so a lexicon-only scan returns
+  // nothing for it and the Apr/May→Jun repeat stays invisible.
+  const md = sampleReport({
+    highIncident: 'Together AI (85 incidents)',
+    keyInsight: '- x',
+    affected: 'Gemini API',
+    watchOut: 'the Anthropic stack stayed Fair (66–69). Codex reads 86 → 76, but that dip is an advisory.',
+  })
+  const s = extractNarrativeSubjects(md)
+  eq([...s.summaryWatchOut].sort().join('|'), 'Claude API|Claude Code|claude.ai')
+})
+
+test('a group member absent from the report\'s own Score table is dropped, not invented', () => {
+  const md = sampleReport({
+    highIncident: 'Together AI (85 incidents)',
+    keyInsight: '- x',
+    affected: 'Gemini API',
+    watchOut: 'the Anthropic stack stayed Fair.',
+  }).replace('| 7 | claude.ai | 64 | Fair |\n', '') // roster without claude.ai
+  const s = extractNarrativeSubjects(md)
+  assert.ok(s.summaryWatchOut.includes('Claude API'), 'rostered member kept')
+  assert.ok(!s.summaryWatchOut.includes('claude.ai'), 'unrostered member not invented from the alias')
+  // Without the `!canon` guard the unrostered member is pushed as `undefined` rather than skipped —
+  // which `!includes('claude.ai')` above still satisfies. detectRecurrence's `!key` check swallows it
+  // downstream, so pin the contract here, at the exported surface that promises it.
+  assert.ok(s.summaryWatchOut.every(Boolean), `no holes in the subject list: ${JSON.stringify(s.summaryWatchOut)}`)
+})
+
+test('the group alias does NOT expand when the bullet names no group noun', () => {
+  // The negative half. Without it, `if (!re.test(text)) continue` can be deleted outright and the
+  // suite stays green — the trio would then be injected into EVERY Watch out bullet, sit in ≥2 of any
+  // 3 priors forever, and flag Anthropic every month: a permanent false positive, worse than the
+  // blindness #61 fixes. Not hypothetical — 2026-03's real bullet is "GitHub Copilot infrastructure
+  // instability (18 affected days)", no Anthropic surface anywhere in it.
+  // 2026-03's real shape, and it is the month that pins the guard's SCOPE too: its group noun sits in
+  // the SIBLING High-incident bullet while its Watch out names only Copilot. Testing the group noun
+  // against the whole Summary section instead of the one bullet passes every other test, yet drags
+  // the trio into this month's Watch out subjects — the same false positive through another door.
+  const md = sampleReport({
+    highIncident: 'Anthropic services — counts inflated due to per-model component reporting',
+    keyInsight: '- x',
+    affected: 'Gemini API',
+    watchOut: 'GitHub Copilot infrastructure instability (18 affected days)',
+  })
+  const s = extractNarrativeSubjects(md)
+  eq(s.summaryWatchOut.join('|'), '')
+})
+
+test('a bare "Anthropic" mention does NOT expand the trio — the alias must stay narrow', () => {
+  // The other half of the guard. Widening the pattern to /Anthropic/i passes every other test, yet
+  // any bullet merely MENTIONING the vendor would inject all three services — parking them in the
+  // slot every month. Bare "Anthropic" is ordinary prose here ("Anthropic posts a separate incident
+  // per model"), so this is the likelier false positive of the two, not a contrived one.
+  const md = sampleReport({
+    highIncident: 'Together AI (85 incidents)',
+    keyInsight: '- x',
+    affected: 'Gemini API',
+    watchOut: 'Anthropic shipped a fix for the per-model split; Gemini API had a slow month.',
+  })
+  const s = extractNarrativeSubjects(md)
+  eq(s.summaryWatchOut.join('|'), 'Gemini API') // the named service, and nothing the alias invented
+})
+
+test('the group alias matches the hedged "Anthropic services" wording (unattested in this bullet)', () => {
+  // NOT evidence from this slot — no Watch out bullet has used this wording (2026-03's, where the
+  // phrase does appear, is its sibling High-incident bullet; its Watch out names GitHub Copilot
+  // alone). The alias is a pattern as a bet on observed drift: the vocabulary for this one group
+  // moves between bullets and months, and a wording the slot has not seen yet is how the #61 false
+  // negative returns. See SUBJECT_GROUP_ALIASES — this test pins the hedge, it does not justify it.
+  const md = sampleReport({
+    highIncident: 'Together AI (85 incidents)',
+    keyInsight: '- x',
+    affected: 'Gemini API',
+    watchOut: 'Anthropic services — counts inflated due to per-model component reporting.',
+  })
+  const s = extractNarrativeSubjects(md)
+  eq([...s.summaryWatchOut].sort().join('|'), 'Claude API|Claude Code|claude.ai')
+})
+
+test('Most reliable / Riskiest are NOT tracked — their repeats are structural, not narrative', () => {
+  // Both bullets are the ranking's top and bottom, so the same services fill them by construction;
+  // tracking them would warn every month regardless of how fresh the writing is.
+  const md = sampleReport({
+    highIncident: 'Together AI (85 incidents)',
+    keyInsight: '- x',
+    affected: 'Gemini API',
+    riskiest: 'Replicate (61/100, Fair) — the lowest score',
+    watchOut: 'Gemini API had a slow month.',
+  })
+  const s = extractNarrativeSubjects(md)
+  assert.ok(!s.summaryWatchOut.includes('Modal'), 'Most reliable subject not pulled into the slot')
+  assert.ok(!s.summaryWatchOut.includes('Replicate'), 'Riskiest subject not pulled into the slot')
+  assert.ok(!s.summary.includes('Modal') && !s.summary.includes('Replicate'), 'nor into the high-incident slot')
+})
+
+test('the Apr/May→Jun Anthropic "Watch out" run is flagged (the reports#61 regression)', () => {
+  // The concrete miss: the trio was named in Watch out in 2026-04, -05 AND -06 (leading it only in
+  // -06) and neither gate saw it — each month phrased it differently, which is exactly what defeated
+  // a lexicon-only scan.
+  const mk = watchOut => extractNarrativeSubjects(sampleReport({
+    highIncident: 'Together AI (85 incidents)', keyInsight: '- x', affected: 'Gemini API', watchOut,
+  }))
+  const apr = mk('Anthropic per-model counts (Claude API 40 + claude.ai 37 + Claude Code 31) often track the same root event')
+  const may = mk('Gemini API (2 incidents) and the Anthropic stack — Claude API / claude.ai / Claude Code all landed Fair (63–65).')
+  const jun = mk('the Anthropic stack stayed Fair (66–69).')
+
+  const flags = detectRecurrence(jun, [{ month: '2026-05', subjects: may }, { month: '2026-04', subjects: apr }])
+  const watch = flags.filter(f => f.slot === 'summaryWatchOut')
+  eq(watch.map(f => f.service).sort().join('|'), 'Claude API|Claude Code|claude.ai')
+  for (const f of watch) eq(f.monthsSeen.sort().join(','), '2026-04,2026-05')
+  // Gemini led Watch out in May only — one prior month is not a run, so it must not flag.
+  assert.ok(!watch.some(f => f.service === 'Gemini API'), 'a single prior month does not make a recurrence')
 })
 
 console.log('\ndetectRecurrence (aiwatch-reports#54)')

--- a/scripts/lint-recurrence.js
+++ b/scripts/lint-recurrence.js
@@ -21,6 +21,7 @@ const path = require('path')
 const {
   extractNarrativeSubjects,
   detectRecurrence,
+  RECURRENCE_SLOT_LABEL: SLOT_LABEL,
   SUMMARY_OPEN_MARKER,
   NOTABLE_OPEN_MARKER,
   OBSERVATIONS_OPEN_MARKER,
@@ -28,12 +29,10 @@ const {
 } = require('./generate-report')
 const { monthsBefore } = require('./generate-charts')
 
-// Human labels per slot for the warn annotation (mirrors #54's block wording).
-const SLOT_LABEL = {
-  summary: "the Summary 'High incident count' bullet",
-  keyInsight: 'a Key Insight pattern',
-  notable: 'Notable Incidents',
-}
+// Human labels per slot for the warn annotation — IMPORTED from generate-report (#61), not copied.
+// This was a hand-maintained mirror of #54's block wording; adding the 'Watch out' slot is exactly
+// the edit that would have let the two drift (the lint would print a bare slot key for any slot the
+// copy missed), so it now shares the one definition that the RECURRENCE block already renders from.
 
 // The exact fence markers we ship (kept for reference/coupling); the detector below is a
 // keyword check so a hand-edited/close marker or a future fence variant is still caught.

--- a/scripts/lint-recurrence.test.js
+++ b/scripts/lint-recurrence.test.js
@@ -22,7 +22,7 @@ function eq(actual, expected, msg) {
 
 // A minimal report fixture: frontmatter + Score table (the self-contained lexicon that
 // #54's extractor reads) + the three narrative slots.
-function report({ published = true, highIncident = 'Together AI (85 incidents)', keyInsight = '- x', affected = 'Gemini API', extra = '' } = {}) {
+function report({ published = true, highIncident = 'Together AI (85 incidents)', keyInsight = '- x', affected = 'Gemini API', watchOut = '', extra = '' } = {}) {
   return [
     '---',
     'layout: page',
@@ -33,6 +33,7 @@ function report({ published = true, highIncident = 'Together AI (85 incidents)',
     '## Summary',
     '',
     `- **High incident count, fast recovery**: ${highIncident}`,
+    ...(watchOut ? [`- **Watch out**: ${watchOut}`] : []),
     extra,
     '',
     '## Key Insight',
@@ -46,6 +47,9 @@ function report({ published = true, highIncident = 'Together AI (85 incidents)',
     '| 1 | Together AI | 84 | Good |',
     '| 2 | Mistral API | 78 | Good |',
     '| 3 | Gemini API | 64 | Fair |',
+    '| 4 | Claude API | 65 | Fair |',
+    '| 5 | claude.ai | 64 | Fair |',
+    '| 6 | Claude Code | 63 | Fair |',
     '',
     '## Notable Incidents',
     '',
@@ -162,6 +166,21 @@ test('WARNS on a same-slot recurrence vs the prior month (reuses #54 extraction)
   eq(r.warnings.length, 1)
   assert.ok(r.warnings[0].message.includes('Together AI'), 'names the repeated service')
   assert.ok(r.warnings[0].message.includes('2026-05'), 'names the prior month')
+})
+
+test('WARNS on a recurring "Watch out" subject, naming the bullet — and never FAILS (#61)', () => {
+  // The gate was blind here: the Anthropic trio was named in Watch out in 2026-04/05/06 (leading it
+  // only in -06) and only a human caught it. June names ONLY the group noun, May spells the members
+  // out — the two must still match.
+  // Overlap ONLY the Watch out slot — differ the others so the count isolates this slot.
+  const md = report({ highIncident: 'Together AI (85 incidents)', affected: 'Gemini API', watchOut: 'the Anthropic stack stayed Fair (66-69).' })
+  const priorMd = report({ highIncident: 'Mistral API (140 incidents)', affected: 'Mistral API', watchOut: 'the Anthropic stack - Claude API / claude.ai / Claude Code all landed Fair (63-65).' })
+  const r = lintReport({ md, priorMd, month: '2026-06', priorMonth: '2026-05' })
+  eq(r.errors.length, 0) // warn-only: a recurring concern is sometimes legitimately the story
+  eq(r.warnings.length, 3) // one per member of the expanded group
+  assert.ok(r.warnings.every(w => w.message.includes("Summary 'Watch out' bullet")),
+    `warn names the bullet via the imported RECURRENCE_SLOT_LABEL: ${r.warnings.map(w => w.message).join(' | ')}`)
+  assert.ok(r.warnings.some(w => w.message.includes('Claude API')), 'names the repeated service')
 })
 
 test('does NOT warn when every slot names a different service than the prior month', () => {


### PR DESCRIPTION
Refs #61. Must land before the 2026-07 report is generated (~Aug 1) — this is a gate that runs at report time, so fixing it afterwards leaves that month with the blind spot.

## The miss

The recurrence gate tracked the Summary "High incident count" bullet, Key Insight and Notable Incidents — never **"Watch out"**. The Anthropic trio was named in that bullet **three months running** (2026-04, -05, -06; leading it in -06) and neither gate flagged it. A human reviewer caught it.

The issue said two months; it was three — 2026-04's bullet names the trio too ("Anthropic per-model counts (Claude API 40 + claude.ai 37 + Claude Code 31)").

## The issue's proposed fix does not close its own case

The proposal was to reuse the lexicon filter. Verified against the real reports, that fails:

```
2026-04  "Anthropic per-model counts (Claude API 40 + claude.ai 37 + Claude Code 31)…"
2026-06  "the Anthropic stack stayed Fair (66–69)."      ← names no member at all
```

Lexicon-only yields the trio for April and `[]` for June — so the repeat that motivated the issue still would not flag, and 04 vs 06 would never match each other at all.

Hence `SUBJECT_GROUP_ALIASES`: a group noun **expands to its members**, so both spellings resolve to one narrative subject — the same reason #54 folds "Mistral" into "Mistral API". It stays narrow (`/\bAnthropic\s+(?:stack|services)\b/i`) because bare "Anthropic" is ordinary prose in these reports ("Anthropic posts a separate incident per model"); matching it would expand the trio into any bullet mentioning the vendor — a permanent false positive, worse than the blindness being fixed. `services` is a deliberate hedge, **not** attested in this bullet (it appears in 2026-03's sibling High-incident bullet) — the comment says so plainly, since the vocabulary for this group demonstrably drifts.

Also deliberately **not** the `Name (` stat-group scan the high-incident slot uses: that bullet is formulaic, "Watch out" is free prose, and the scan reads "…all landed Fair (63–65)" as a service called "Fair" (`canonicalizeToLexicon` returns unknown names unchanged).

## Scope: this is a lint-only slot — narrower than the issue assumed

The issue says the gap spans **both** the generate-time RECURRENCE CHECK (#54) and the pre-publish lint (#55). Only #55 is closable, and I've updated the issue body to say so.

At generate time the Watch out bullet **does not exist yet** — `_templates/monthly-report.md:39` ships `- **Watch out**:` empty. `computeCurrentSubjects` predicts the current subjects from archive *data* (incident counts → the high-incident bullet; slowest recovery + movers → Key Insight). "Watch out" is editorial judgement with no data proxy; the plausible candidates are already Key Insight's inputs, so wiring them would duplicate every keyInsight flag under a second label — noise, not coverage — and would warn the author about a subject they have not chosen.

That still closes the miss: **#55 runs before publish**, which is the gate the Anthropic 3-peat actually needed. Documented at `RECURRENCE_SLOTS` so the asymmetry reads as design, not omission.

## Decisions (census over all four published reports)

2026-03 is `published: true` and is a prior for the June window, so it counts.

| Bullet | Occurrences | |
|---|---|---|
| Watch out | 4/4 | **tracked** — editorial concern bullet; its repeat is staleness |
| High incident count/noise | 3/4 | already tracked (#54) |
| Most reliable | 4/4 | excluded — the ranking's top, repeats by construction |
| Riskiest this month | 4/4 | excluded — the ranking's bottom, same |
| Biggest improvement | 1/4 (June) | excluded for now — designing for a case never seen |
| Best balance | 1/4 (March) | same |

## Drift cleanup

`lint-recurrence.js` had **hand-copied** `SLOT_LABEL` from `generate-report.js` ("mirrors #54's block wording"). Adding a fourth slot is exactly the edit that would have let the copy drift — the lint would print a bare slot key. It now imports the one definition; a mutation removing the slot from the map fails the lint test, so the import is load-bearing, not decorative.

**Drive-by (outside #61's scope):** a pre-existing comment claimed Together AI led the "High incident count" bullet `Apr/May/Jun`. June has no such bullet at all, and the claim contradicted the census this PR adds, in the same file. Reworded to "filled … in both Apr and May" — position-agnostic, since May's bullet leads with Mistral API.

## Tests — 254 → 259 (+ lint 25 → 26), every guard mutation-verified

Each mutation asserts it actually applied, so a failed match can't read as "not caught":

- **wiring** — dropping the slot from `RECURRENCE_SLOTS` fails **both** files (the extractor stays perfect while the gate never reads it — the axis that has survived here before)
- **the group-noun guard, both directions** — removing it (expand always) fails; widening its scope to the whole Summary fails. 2026-03 is the witness: its group noun sits in the sibling High-incident bullet while its Watch out names Copilot alone
- **the alias pinned from both sides** — too wide (bare `/Anthropic/i`) fails, too narrow (literal `"stack"`) fails
- **roster guard** (`!canon`) and **dedup guard**, pinned at the exported surface where the contract lives

Real-corpus behaviour after the change:

```
2026-03 ["GitHub Copilot"]                                        ← no group noun → nothing expanded
2026-04 ["Claude Code","Claude API","claude.ai"]
2026-05 ["ChatGPT","Claude Code","Gemini API","Claude API","claude.ai"]
2026-06 ["Codex","Claude API","claude.ai","Claude Code"]           ← expanded from the group noun
```

`node scripts/lint-recurrence.js 2026-06/index.md` now emits the three Watch-out warnings the human reviewer had to catch by hand — as **warnings**, exit 0 (a recurring concern is sometimes legitimately the story; it just can't pass silently).

No browser surface: the RECURRENCE block is a draft-time artifact deleted before publish, so it was verified by rendering the real artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)