### PR TITLE
feat(report): surface the Score's Responsiveness inputs in their own section (refs #76)

### DIFF
--- a/_templates/monthly-report.md
+++ b/_templates/monthly-report.md
@@ -102,7 +102,7 @@ published: true
 
 > *"Which AI service is safest to rely on in production?"*
 
-Combines four components — Uptime (40%), Incident affected days (25%), Recovery speed (15%), Responsiveness (20%, derived from each service's median (p50) probe RTT and its RTT stability). The [API Response Time — Monthly p75](#api-response-time--monthly-p75) table below is a separate network-latency reference, not the Responsiveness input; full breakdown of weights, fallbacks, and penalties is in [About This Report → AIWatch Score](#about-this-report). [How it's calculated →](https://ai-watch.dev/methodology#score)
+Combines four components — Uptime (40%), Incident affected days (25%), Recovery speed (15%), Responsiveness (20%, the p50 RTT + stability figures shown under [Responsiveness Inputs](#responsiveness-inputs-score-component)). The separate [API Response Time — Monthly p75](#api-response-time--monthly-p75) table is a network-latency reference that does *not* feed the Score; full breakdown of weights, fallbacks, and penalties is in [About This Report → AIWatch Score](#about-this-report). [How it's calculated →](https://ai-watch.dev/methodology#score)
 
 <!-- SCORE_RANKING_NOTE -->
 
@@ -137,9 +137,11 @@ Uptime computed by AIWatch over a 30-day window from the incident and outage rec
 
 <!-- COMPONENT_RELIABILITY_SECTION -->
 
+<!-- RESPONSIVENESS_SECTION -->
+
 ## API Response Time — Monthly p75
 
-These p75 figures are a network-latency reference: direct API-endpoint round-trip time, probed from the Cloudflare Workers edge every 5 minutes — not inference latency. Lower is better. They are **not** the Score's Responsiveness input, which reads each service's median (p50) probe RTT and its stability. So this table ranks *which service is fastest on the network*, while [AIWatch Score](#[SCORE_ANCHOR]) ranks *which is safest to rely on*. A service AIWatch does not probe has no row here; that alone does not drop it from the Score ranking.
+These p75 figures are a network-latency reference: direct API-endpoint round-trip time, probed from the Cloudflare Workers edge every 5 minutes — not inference latency. Lower is better. **This table does not feed the Score** — the Score's Responsiveness component reads the *median* (p50) RTT and its stability instead, shown above under [Responsiveness Inputs](#responsiveness-inputs-score-component). So this table ranks *which service is fastest on the network*, while [AIWatch Score](#[SCORE_ANCHOR]) ranks *which is safest to rely on*. A service AIWatch does not probe has no row here; that alone does not drop it from the Score ranking.
 
 <!-- Data source: curl https://api.ai-watch.dev/api/probe/history?days=30 -->
 <!-- 32 probe targets: 30 API services (incl. twelvelabs) + cursor (coding agent) + characterai (app, detail-card only, aiwatch#921). A service AIWatch does not probe simply has no row here (13 of 41 in June 2026, ten of them ranked); that alone does not affect its Score. -->

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -994,10 +994,11 @@ function buildLatencyTable(services, meta) {
   // descending comparator yields "faster = higher rank" and ties get "N=" suffix.
   const ranked = competitionRank(withLatency, s => -s.data.avgLatencyMs)
 
-  // Only p75 (avgLatencyMs) exists in the archive today. The p95 / Spikes / vs-Last-Month
-  // columns were dropped (#17) — they rendered as a literal "—" in every cell, every month.
-  // To re-enable a column: add its field to MonthlyServiceData in the aiwatch worker
-  // (worker/src/monthly-archive.ts), surface it via /api/report, then append it here:
+  // The p95 / Spikes / vs-Last-Month columns were dropped (#17) — they rendered a literal "—" in
+  // every cell, every month. `p95LatencyMs` / `latencySpikes` ARE in the archive now, so re-enabling
+  // either is just appending a column here (the old note claiming "only p75 exists in the archive"
+  // was stale). `p50LatencyMs` is deliberately NOT one of them — see buildResponsivenessSection:
+  // this table is the network-latency reference, not the Score's input:
   //   p95 (ms)      ← s.data.p95LatencyMs
   //   Spikes        ← s.data.latencySpikes
   //   vs Last Month ← delta from s.data.prevMonthLatencyMs (or read the prior archive)
@@ -1009,6 +1010,60 @@ function buildLatencyTable(services, meta) {
     `| ${r.rankLabel} | ${serviceName(r.item.id, meta)} | ${Math.round(r.item.data.avgLatencyMs)} |`,
   )
   return [...header, ...rows].join('\n')
+}
+
+// #76 / aiwatch#1002 — the Responsiveness component's two inputs, in their OWN section rather than as
+// columns on the p75 table above. Deliberate, and the report's own structure already argues for it:
+// the Uptime component (40%) has its own section, and the p75 table's caption explicitly promises it is
+// a network-latency reference and NOT the Score's input. Adding p50 there would falsify that caption
+// and the /methodology cards that mirror it, and would rebuild the score-vs-latency mixing the p75
+// framing exists to prevent.
+//
+// Shows the raw persisted p50 + cvCombined only, never the derived sub-scores. Those come from tuned
+// constants in the worker's score.ts (REFERENCE_MS / REFERENCE_CV / P50_FLOOR_MS, retuned per aiwatch#132)
+// which this repo cannot import — restating the formula here, in prose in another repo with nothing
+// pinning it, is a parallel copy that goes silently false the next time those constants move (the drift
+// aiwatch#1002 item 7 warns about). The caption links /methodology for the formula rather than repeating
+// its numbers, and the caption test asserts no `exp(` leaks back in.
+function buildResponsivenessSection(archive, meta, month) {
+  const services = archive && archive.services
+  if (!services || typeof services !== 'object') return ''
+  // Same exclusions as the ranking and the component breakdown: a service the report says it cannot
+  // rank has no business in a Score-component table (buildComponentReliabilitySection's reasoning).
+  const exclude = charts.buildMoverExclude(services, month)
+  const rows = []
+  for (const [id, s] of Object.entries(services)) {
+    if (exclude.has(id)) continue
+    // `== null`, NOT `!== null`: the key is ABSENT on archives written before aiwatch#1054, and
+    // `undefined !== null` is true — the p75 table's idiom would pass absence straight into Math.round
+    // as NaN. Also NOT filtered on avgLatencyMs: an inheriting service (claudecode→claude,
+    // codex→openai — aiwatch#883) is scored on its parent's probe, so it HAS a p50 while its own
+    // avgLatencyMs is null. Filtering on that would drop exactly the rows inheritance exists to serve.
+    if (!s || s.p50LatencyMs == null) continue
+    rows.push({ name: serviceName(id, meta), p50: s.p50LatencyMs, cv: s.cvCombined })
+  }
+  if (rows.length === 0) return '' // pre-aiwatch#1054 month → the whole section collapses, no empty table
+  rows.sort((a, b) => a.p50 - b.p50 || a.name.localeCompare(b.name))
+  return [
+    '## Responsiveness Inputs (Score Component)',
+    '',
+    "> **This table feeds the Score.** These are the two figures the **Responsiveness** component (20% of",
+    "> the AIWatch Score) was computed from this month: each service's median (p50) probe RTT, and the",
+    '> combined coefficient of variation (CV) of that RTT — day-to-day movement plus the p95/p50 spread.',
+    '> **Lower is better for both**: a fast service still scores poorly here if it is erratic.',
+    '>',
+    '> Do not confuse it with [API Response Time — Monthly p75](#api-response-time--monthly-p75) further',
+    '> down. That table probes the **same endpoints** but its p75 figure is **not part of the Score** —',
+    '> it is a network-speed reference only. This one is scored; that one is not.',
+    '> [How each figure becomes a sub-score →](https://ai-watch.dev/methodology#score)',
+    '',
+    '| Service | p50 RTT | RTT variation (CV) |',
+    '|---|---|---|',
+    ...rows.map(r => `| ${r.name} | ${Math.round(r.p50)} ms | ${r.cv == null ? '—' : r.cv.toFixed(2)} |`),
+    '',
+    '---',
+    '',
+  ].join('\n')
 }
 
 // ── Template filling ─────────────────────────────────────────────────
@@ -1204,6 +1259,12 @@ function fillTemplate(template, month, archive, meta) {
   // Component Reliability section (aiwatch#605 Phase 3b) — same marker pattern. The section
   // emits its own trailing `---`; when omitted, strip the marker so the preceding Official
   // Uptime `---` stays the single rule before API Response Time.
+  const responsivenessSection = buildResponsivenessSection(archive, meta, month)
+  if (responsivenessSection) {
+    out = out.replace(/<!-- RESPONSIVENESS_SECTION -->/, responsivenessSection)
+  } else {
+    out = out.replace(/\n*<!-- RESPONSIVENESS_SECTION -->\n*/, '\n\n')
+  }
   const componentSection = buildComponentReliabilitySection(archive, meta, month)
   if (componentSection) {
     out = out.replace(/<!-- COMPONENT_RELIABILITY_SECTION -->/, componentSection)
@@ -1955,6 +2016,7 @@ module.exports = {
   buildSecuritySection,
   buildDetectionSection,
   buildComponentReliabilitySection,
+  buildResponsivenessSection,
   buildTrendSection,
   crossesScoreMethodCutover,
   fmtLeadMin,

--- a/scripts/generate-report.test.js
+++ b/scripts/generate-report.test.js
@@ -29,6 +29,7 @@ const {
   buildSecuritySection,
   buildDetectionSection,
   buildComponentReliabilitySection,
+  buildResponsivenessSection,
   buildTrendSection,
   crossesScoreMethodCutover,
   fmtLeadMin,
@@ -707,6 +708,25 @@ test('SERVICE_COUNT resolves to the archive service count, not a hardcoded liter
   const out = fillTemplate(tmpl, '2026-04', archive, meta)
   assert.ok(out.includes('Services monitored: 3'), `expected archive count 3 (not meta size 4): ${out}`)
   assert.ok(!out.includes('[SERVICE_COUNT]'), `every SERVICE_COUNT placeholder must be substituted: ${out}`)
+})
+test('fillTemplate injects the Responsiveness section AND never leaves the marker behind (#76 wiring)', () => {
+  // The builder being correct proves nothing about fillTemplate injecting it — the axis that survives
+  // unit tests. Drives the REAL template marker both ways.
+  const fsW = require('fs'); const pathW = require('path')
+  const tmpl = fsW.readFileSync(pathW.join(__dirname, '..', '_templates', 'monthly-report.md'), 'utf-8')
+  assert.ok(tmpl.includes('<!-- RESPONSIVENESS_SECTION -->'), 'template carries the marker to fill')
+
+  const withP50 = { services: { groq: { p50LatencyMs: 174, cvCombined: 0.21, score: 91, monthlyScore: 91, uptime: 99, officialUptime: 100 } }, daysCollected: 30 }
+  const filled = fillTemplate(tmpl, '2026-07', withP50, { groq: { name: 'Groq Cloud' } })
+  assert.ok(filled.includes('## Responsiveness Inputs (Score Component)'), 'section injected when data present')
+  assert.ok(filled.includes('| Groq Cloud | 174 ms | 0.21 |'), 'the row reached the rendered report')
+  assert.ok(!filled.includes('RESPONSIVENESS_SECTION'), 'marker consumed, not left in output')
+
+  // Legacy month → section collapses, and crucially the marker does not survive as a literal comment.
+  const legacy = { services: { groq: { score: 91, monthlyScore: 91, avgLatencyMs: 207, uptime: 99, officialUptime: 100 } }, daysCollected: 30 }
+  const collapsed = fillTemplate(tmpl, '2026-06', legacy, { groq: { name: 'Groq Cloud' } })
+  assert.ok(!collapsed.includes('Responsiveness Inputs (Score Component)'), 'no empty section on a pre-#1054 month')
+  assert.ok(!collapsed.includes('RESPONSIVENESS_SECTION'), 'marker stripped even when the section is empty')
 })
 test('SERVICE_COUNT substitutes even an empty archive (0), leaving no placeholder (aiwatch-reports#97)', () => {
   const out = fillTemplate('monitored: [SERVICE_COUNT]', '2026-04', { services: {}, daysCollected: 0 }, {})
@@ -2169,6 +2189,75 @@ test('loadPriorNarrative skips months with no index.md (never throws)', () => {
   }
 })
 
+// ── buildResponsivenessSection (#76 / aiwatch#1002) ─────────────────
+console.log('\nbuildResponsivenessSection (#76 / aiwatch#1002)')
+const rMeta = { groq: { name: 'Groq Cloud' }, openai: { name: 'OpenAI API' }, claudecode: { name: 'Claude Code' } }
+
+test('omits the section entirely on a month with no p50 (every archive before aiwatch#1054)', () => {
+  // The key is ABSENT on those archives, not null — verified live against the real 2026-06 archive.
+  // An empty table with a caption promising "the values the Score used" would be worse than no section.
+  eq(buildResponsivenessSection({ services: { groq: { score: 91, avgLatencyMs: 207 } } }, rMeta, '2026-07'), '')
+  eq(buildResponsivenessSection({ services: {} }, rMeta, '2026-07'), '')
+  eq(buildResponsivenessSection(null, rMeta, '2026-07'), '')
+})
+
+test('renders p50 + CV per service, fastest first', () => {
+  const out = buildResponsivenessSection({ services: {
+    openai: { p50LatencyMs: 223, cvCombined: 0.31 },
+    groq: { p50LatencyMs: 174, cvCombined: 0.21 },
+  } }, rMeta, '2026-07')
+  assert.ok(out.includes('## Responsiveness Inputs (Score Component)'), 'has heading')
+  assert.ok(out.trimEnd().endsWith('---'), 'ends with a rule')
+  assert.ok(out.includes('| Groq Cloud | 174 ms | 0.21 |'), `groq row: ${out}`)
+  assert.ok(out.includes('| OpenAI API | 223 ms | 0.31 |'), `openai row: ${out}`)
+  const order = [...out.matchAll(/\| (Groq Cloud|OpenAI API) \|/g)].map(m => m[1])
+  assert.deepStrictEqual(order, ['Groq Cloud', 'OpenAI API'], 'fastest first')
+})
+
+test('a service is included on p50 alone — never filtered on avgLatencyMs (the aiwatch#883 trap)', () => {
+  // claudecode has no probe of its own, so its avgLatencyMs is null while the parent probe's p50 is
+  // what scored it. The p75 table's `avgLatencyMs !== null` idiom would drop exactly this row.
+  const out = buildResponsivenessSection({ services: {
+    claudecode: { avgLatencyMs: null, p50LatencyMs: 192, cvCombined: 0.44 },
+  } }, rMeta, '2026-07')
+  assert.ok(out.includes('| Claude Code | 192 ms | 0.44 |'), `inherited row present: ${out}`)
+})
+
+test('skips a service the Score scored no Responsiveness for, and tolerates a null CV', () => {
+  const out = buildResponsivenessSection({ services: {
+    groq: { p50LatencyMs: 174, cvCombined: 0.21 },
+    openai: { p50LatencyMs: null, cvCombined: null }, // probed but unscorable this month
+    claudecode: { p50LatencyMs: 192, cvCombined: null }, // defensive: p50 without a CV
+  } }, rMeta, '2026-07')
+  assert.ok(!out.includes('OpenAI API'), `no p50 → no row: ${out}`)
+  assert.ok(out.includes('| Claude Code | 192 ms | — |'), `null CV renders as a dash: ${out}`)
+})
+
+test('excludes a service the ranking itself drops, even when it carries a p50 (stale source)', () => {
+  // buildMoverExclude drops SCORE_WITHHELD / stale-source / mid-month-added, mirroring the ranking and
+  // the component breakdown. Without it, a service whose status page froze mid-month (incidentSourceStale)
+  // would still show a p50 here — a Score-component figure for a service the report says it cannot rank.
+  // bedrock/azureopenai can't test this (no probe → p50 already null), so use a stale-flagged probed one.
+  const out = buildResponsivenessSection({ services: {
+    groq: { p50LatencyMs: 174, cvCombined: 0.21 },
+    deepseek: { p50LatencyMs: 569, cvCombined: 0.33, incidentSourceStale: true },
+  } }, { groq: { name: 'Groq Cloud' }, deepseek: { name: 'DeepSeek API' } }, '2026-07')
+  assert.ok(out.includes('Groq Cloud'), 'the rankable service stays')
+  assert.ok(!out.includes('DeepSeek'), `a stale-source service is excluded despite its p50: ${out}`)
+})
+
+test('the caption keeps the p50 table distinct from the p75 network-latency reference', () => {
+  // The whole reason this is its own section (aiwatch#1002 item 6). If the caption ever stops saying
+  // so, the two tables have silently merged in the reader's mind.
+  const out = buildResponsivenessSection({ services: { groq: { p50LatencyMs: 174, cvCombined: 0.21 } } }, rMeta, '2026-07')
+  assert.ok(/This table feeds the Score/.test(out), 'states plainly that THIS one is scored')
+  assert.ok(/not part of the Score/.test(out), 'states plainly that the p75 table is NOT scored')
+  assert.ok(/same endpoints/.test(out), 'explains why they look alike — same probe, different statistic')
+  assert.ok(/Lower is better for/.test(out), 'says which direction is good — CV has no intuitive scale')
+  assert.ok(/methodology#score/.test(out), 'links the formula rather than restating its constants here')
+  assert.ok(!/exp\(/.test(out), 'the drift-prone score.ts formula is NOT inlined (aiwatch#1002 item 7)')
+})
+
 // ── buildComponentReliabilitySection (aiwatch#605 Phase 3b) ─────────
 console.log('\nbuildComponentReliabilitySection (#605 Phase 3b)')
 const crMeta = { services: {} }
@@ -2716,7 +2805,9 @@ test('the API Response Time section carries ONE prose block, and it is true', ()
   // Everything the footnote used to carry now lives here, once.
   assert.match(intro, /Cloudflare Workers edge every 5 minutes/, 'measurement method')
   assert.match(intro, /not inference latency/, 'the disclaimer readers need')
-  assert.match(intro, /median \(p50\) probe RTT/, 'and the p75-is-not-the-Score-input correction')
+  assert.match(intro, /does not feed the Score/, 'the p75-is-not-a-Score-input correction, stated plainly')
+  assert.match(intro, /\(p50\) RTT/, 'and it points at the statistic that IS scored')
+  assert.match(intro, /Responsiveness Inputs/, 'linking to where that scored figure lives')
   assert.match(intro, /no row here/, 'a probe-less service is absent from THIS table')
   assert.match(intro, /does not drop it from the Score ranking/, 'and that is all this needs to say')
   assert.ok(!/are excluded from rankings/.test(intro), 'the false causal claim must stay dead')


### PR DESCRIPTION
Refs #76 (design "B", chosen with the maintainer). Consumes the archive fields shipped in aiwatch#1054.

## Problem

The AIWatch Score's **Responsiveness** component is 20% of the score, computed from each service's median (p50) probe RTT and the combined CV of that RTT. **Neither figure appeared anywhere in the report** — the prose had to cite p50 values a reader could not look up ("correct, and unverifiable"). aiwatch#1054 started persisting `p50LatencyMs` + `cvCombined` into the archive; this renders them.

## A new section — not columns on the p75 table

The "API Response Time — Monthly p75" table is a network-latency reference that does **not** feed the Score (`score.ts` reads p50 + cvCombined, never p75/avgLatencyMs). Bolting p50 onto it would falsify its caption and the `/methodology` cards that mirror it, and rebuild the score-vs-latency mixing the p75 framing was cleaned up to prevent (aiwatch#1002 item 6).

## Placement + framing (from maintainer review)

The section sits in the **score-component cluster** — after Component Reliability, before p75 and Detection — not below the non-score reference tables:

```
## 30-Day Uptime             ┐ score components
## Component Reliability      │  ("what drives the Score")
## Responsiveness Inputs      ┘
## API Response Time — p75    ┐ references (NOT scored)
## Detection & RTT Degradation┘
```

And three captions were sharpened **in parallel** — this table feeds the Score; the p75 table probes the *same endpoints* but its p75 figure does not — because even a reader who knows the project had read both as feeding the Score. The distinction is now stated plainly on both, and the Score-rankings intro links to where the scored figure lives.

## Correctness

`buildResponsivenessSection` mirrors `buildComponentReliabilitySection`: same `buildMoverExclude` (a service the report cannot rank has no place in a Score-component table — pinned with a stale-source service that still carries a p50), collapses to `''` on a pre-#1054 month so no empty table ships, marker stripped either way. Two subtleties the sibling p75 table gets wrong and this must not:

- **`== null`, not `!== null`** — the key is ABSENT on older archives, and `undefined !== null` would pass absence into `Math.round` as `NaN`.
- **never filtered on `avgLatencyMs`** — an inheriting service (claudecode→claude, codex→openai, aiwatch#883) is scored on its parent's probe, so it has a real p50 while its own `avgLatencyMs` is null; the p75 table's filter drops exactly those rows.

Shows the raw p50 + cvCombined only, never the derived sub-scores — those come from tuned `score.ts` constants this repo cannot import, so restating the formula in a caption is a parallel copy that goes false when they retune (aiwatch#1002 item 7). The caption links `/methodology`, and a test asserts no `exp(` leaks back in.

Also corrects a stale comment on `buildLatencyTable` claiming "only p75 exists in the archive" — `p95LatencyMs` / `latencySpikes` have been there since aiwatch#17.

## Tests — 259 → 266, mutation-verified on both axes

Each mutation asserts it actually applied:

- **wiring** — never injecting the section **fails** (the builder can be perfect while `fillTemplate` never fills the marker); the wiring test drives the real template both ways and checks the marker is consumed, not left as a literal comment.
- **behavior** — filtering on `avgLatencyMs` **fails**; `!== null` **fails**; disabling the exclude filter **fails**; re-inlining a `score.ts` formula **fails**.

`for f in scripts/*.test.js` → 129/266/34/26/18, 0 failed. Recurrence lint clean.

## Verification

Verified in-browser against a **crafted July archive** (a fixture API server standing in for `/api/report`, since no real archive carries p50 until the ~Aug 1 build) — section renders in the right cluster, fastest-first, tie handled, null-CV as "—", and collapses entirely on the real June archive that has no p50. The crafted data + fixture were reverted before commit; the 2026-06 report was not touched.

## Timing / scope

The section renders with real values only once the ~Aug 1 archive build carries p50 (the worker is already deployed, so that is automatic; aiwatch#1002's `verify-after 2026-08-02` checks the archive fields). Until then every existing month collapses the section cleanly. `refs`, not `closes` — the first real render is the Aug gate, and aiwatch#1002 Part C is broader (it also wants stability surfaced, which this delivers, but Parts A-item-1 / B remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)